### PR TITLE
Fix ResponseTextCode parsing

### DIFF
--- a/Sources/NIOIMAP/Grammar/Response/ResponseTextCode.swift
+++ b/Sources/NIOIMAP/Grammar/Response/ResponseTextCode.swift
@@ -29,8 +29,7 @@ extension NIOIMAP {
         case uidNext(NZNumber)
         case uidValidity(NZNumber)
         case unseen(NZNumber)
-        case unknownCTE
-        case undefinedFilter(FilterName)
+        case namespace(NamespaceResponse)
         case other(Atom, String?)
     }
 
@@ -67,12 +66,8 @@ extension ByteBuffer {
             return self.writeString("UNSEEN \(number)")
         case .other(let atom, let string):
             return self.writeResponseTextCode_other(atom: atom, string: string)
-        case .unknownCTE:
-            return self.writeString("UNKNOWN-CTE")
-        case .undefinedFilter(let filterName):
-            return
-                self.writeString("UNDEFINED-FILTER ") +
-                self.writeFilterName(filterName)
+        case .namespace(let namesapce):
+            return self.writeNamespaceResponse(namesapce)
         }
     }
 

--- a/Sources/NIOIMAP/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAP/Parser/GrammarParser.swift
@@ -2582,7 +2582,7 @@ extension NIOIMAP.GrammarParser {
     //                       SP Namespace SP Namespace
     static func parseNamespaceResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.NamespaceResponse {
         return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NIOIMAP.NamespaceResponse in
-            try ParserLibrary.parseFixedString("* NAMESPACE ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.parseFixedString("NAMESPACE ", buffer: &buffer, tracker: tracker)
             let n1 = try self.parseNamespace(buffer: &buffer, tracker: tracker)
             try ParserLibrary.parseSpace(buffer: &buffer, tracker: tracker)
             let n2 = try self.parseNamespace(buffer: &buffer, tracker: tracker)
@@ -3098,6 +3098,10 @@ extension NIOIMAP.GrammarParser {
             try ParserLibrary.parseFixedString("UNSEEN ", buffer: &buffer, tracker: tracker)
             return .unseen(try self.parseNZNumber(buffer: &buffer, tracker: tracker))
         }
+        
+        func parseResponseTextCode_namespace(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.ResponseTextCode {
+            return .namespace(try self.parseNamespaceResponse(buffer: &buffer, tracker: tracker))
+        }
 
         func parseResponseTextCode_atom(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.ResponseTextCode {
             let atom = try self.parseAtom(buffer: &buffer, tracker: tracker)
@@ -3122,6 +3126,7 @@ extension NIOIMAP.GrammarParser {
             parseResponseTextCode_uidNext,
             parseResponseTextCode_uidValidity,
             parseResponseTextCode_unseen,
+            parseResponseTextCode_namespace,
             parseResponseTextCode_atom
         ], buffer: &buffer, tracker: tracker)
     }

--- a/Tests/NIOIMAPTests/Grammar/Response/ResponseTextCodeTests.swift
+++ b/Tests/NIOIMAPTests/Grammar/Response/ResponseTextCodeTests.swift
@@ -27,7 +27,6 @@ extension ResponseTextCodeTests {
         let inputs: [(NIOIMAP.ResponseTextCode, String, UInt)] = [
             (.alert, "ALERT", #line),
             (.parse, "PARSE", #line),
-            (.unknownCTE, "UNKNOWN-CTE", #line),
             (.readOnly, "READ-ONLY", #line),
             (.readWrite, "READ-WRITE", #line),
             (.tryCreate, "TRYCREATE", #line),
@@ -43,7 +42,7 @@ extension ResponseTextCodeTests {
             (.capability([]), "CAPABILITY IMAP4 IMAP4rev1", #line),
             (.capability([.other("some"), .auth("SSL")]), "CAPABILITY IMAP4 IMAP4rev1 some AUTH=SSL", #line),
             (.capability([.other("some1"), .auth("SSL1"), .other("some2"), .auth("SSL2")]), "CAPABILITY IMAP4 IMAP4rev1 some1 AUTH=SSL1 some2 AUTH=SSL2", #line),
-            (.undefinedFilter("some"), "UNDEFINED-FILTER some", #line)
+            (.namespace(.userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil)), "NAMESPACE NIL NIL NIL", #line)
         ]
 
         for (code, expectedString, line) in inputs {

--- a/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
@@ -2510,7 +2510,7 @@ extension ParserUnitTests {
     
     func testParseNamespaceResponse() {
         let inputs: [(String, String, NIOIMAP.NamespaceResponse, UInt)] = [
-            ("* NAMESPACE nil nil nil", " ", .userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil), #line),
+            ("NAMESPACE nil nil nil", " ", .userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil), #line),
         ]
 
         for (input, terminator, expected, line) in inputs {
@@ -2836,6 +2836,7 @@ extension ParserUnitTests {
             ("UIDNEXT 12", "\r", .uidNext(12), #line),
             ("UIDVALIDITY 34", "\r", .uidValidity(34), #line),
             ("UNSEEN 56", "\r", .unseen(56), #line),
+            ("NAMESPACE NIL NIL NIL", "\r", .namespace(.userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil)), #line),
             ("some", "\r", .other("some", nil), #line),
             ("some thing", "\r", .other("some", "thing"), #line),
         ]


### PR DESCRIPTION
`ResponseTextCode` now parses correctly, and tests have been added to reflect this.

### Motivation:
There were a couple of instances inside `ResponseTextCode` where options weren't spec-compliant.

### Modifications:
Added a new test case to test a variety of combinations. Also fixed the parser itself.

### Result:
Everything now works as expected.