### PR TITLE
Make UserId a string

### DIFF
--- a/Sources/NIOIMAP/Grammar/Command/CommandType.swift
+++ b/Sources/NIOIMAP/Grammar/Command/CommandType.swift
@@ -33,7 +33,7 @@ extension NIOIMAP {
         case subscribe(Mailbox)
         case unsubscribe(Mailbox)
         case authenticate(AuthType, InitialResponse?, [NIOIMAP.Base64])
-        case login(UserID, Password)
+        case login(UserId, Password)
         case starttls
         case check
         case close
@@ -92,7 +92,7 @@ extension ByteBuffer {
         case let .authenticate(type, initial, data):
             return self.writeCommandType_authenticate(type: type, initial: initial, data: data)
         case let .login(userid, password):
-            return self.writeCommandType_login(userid: userid, password: password)
+            return self.writeCommandType_login(userId: userid, password: password)
         case .starttls:
             return self.writeCommandType_startTLS()
         case .check:
@@ -244,9 +244,9 @@ extension ByteBuffer {
         }
     }
     
-    private mutating func writeCommandType_login(userid: NIOIMAP.Literal, password: NIOIMAP.Literal) -> Int {
+    private mutating func writeCommandType_login(userId: NIOIMAP.UserId, password: NIOIMAP.Literal) -> Int {
         self.writeString("LOGIN ") +
-        self.writeLiteral(userid) +
+        self.writeUserId(userId) +
         self.writeSpace() +
         self.writeLiteral(password)
     }

--- a/Sources/NIOIMAP/Grammar/CoreTypealiases.swift
+++ b/Sources/NIOIMAP/Grammar/CoreTypealiases.swift
@@ -63,9 +63,7 @@ public extension NIOIMAP {
     
     /// IMAPv4 `password`
     typealias Password = AString
-    
-    /// IMAPv4 `userid`
-    typealias UserID = AString
+
 }
 
 // MARK: - Atom

--- a/Sources/NIOIMAP/Grammar/UserId.swift
+++ b/Sources/NIOIMAP/Grammar/UserId.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+extension NIOIMAP {
+    
+    /// IMAPv4 `userid`
+    public typealias UserId = String
+    
+}
+
+// MARK: - Encoding
+extension ByteBuffer {
+    
+    @discardableResult mutating func writeUserId(_ id: NIOIMAP.UserId) -> Int {
+        self.writeString(id)
+    }
+    
+}

--- a/Sources/NIOIMAP/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAP/Parser/GrammarParser.swift
@@ -1939,7 +1939,7 @@ extension NIOIMAP.GrammarParser {
     static func parseLogin(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.CommandType {
         return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NIOIMAP.CommandType in
             try ParserLibrary.parseFixedString("LOGIN ", buffer: &buffer, tracker: tracker)
-            let userid = try Self.parseUserid(buffer: &buffer, tracker: tracker)
+            let userid = try Self.parseUserId(buffer: &buffer, tracker: tracker)
             try ParserLibrary.parseFixedString(" ", buffer: &buffer, tracker: tracker)
             let password = try Self.parsePassword(buffer: &buffer, tracker: tracker)
             return .login(userid, password)
@@ -4326,8 +4326,9 @@ extension NIOIMAP.GrammarParser {
     }
 
     // userid          = astring
-    static func parseUserid(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.UserID {
-        return try Self.parseAString(buffer: &buffer, tracker: tracker)
+    static func parseUserId(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.UserId {
+        var astring = try Self.parseAString(buffer: &buffer, tracker: tracker)
+        return astring.readString(length: astring.readableBytes)! // if this fails, something has gone very, very wrong
     }
 
     // vendor-token     = atom (maybe?!?!?!)

--- a/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
@@ -4056,6 +4056,26 @@ extension ParserUnitTests {
 
 }
 
+// MARK: - parseUserId
+extension ParserUnitTests {
+    
+    func testParseUserId() {
+        let inputs: [(String, String, NIOIMAP.UserId, UInt)] = [
+            ("test", "\r\n", "test", #line),
+            ("{4}\r\ntest", "\r\n", "test", #line),
+            ("\"test\"", "\r\n", "test", #line),
+        ]
+
+        for (input, terminator, expected, line) in inputs {
+            TestUtilities.withBuffer(input, terminator: terminator) { (buffer) in
+                let testValue = try NIOIMAP.GrammarParser.parseUserId(buffer: &buffer, tracker: .testTracker)
+                XCTAssertEqual(testValue, expected, line: line)
+            }
+        }
+    }
+    
+}
+
 // MARK: - vendor-token
 extension ParserUnitTests {
 


### PR DESCRIPTION
UserID is now a string instead of a ByteBuffer.

### Motivation:
ByteBuffer is a little tricky to work with when signing in. String is simpler.

### Modifications:
Change the type alias to a string, add tests to ensure it's valid.
