### PR TITLE
Fix UserID spelling

### DIFF
--- a/Sources/NIOIMAP/Grammar/Command/CommandType.swift
+++ b/Sources/NIOIMAP/Grammar/Command/CommandType.swift
@@ -33,7 +33,7 @@ extension NIOIMAP {
         case subscribe(Mailbox)
         case unsubscribe(Mailbox)
         case authenticate(AuthType, InitialResponse?, [NIOIMAP.Base64])
-        case login(UserId, Password)
+        case login(UserID, Password)
         case starttls
         case check
         case close
@@ -92,7 +92,7 @@ extension ByteBuffer {
         case let .authenticate(type, initial, data):
             return self.writeCommandType_authenticate(type: type, initial: initial, data: data)
         case let .login(userid, password):
-            return self.writeCommandType_login(userId: userid, password: password)
+            return self.writeCommandType_login(userID: userid, password: password)
         case .starttls:
             return self.writeCommandType_startTLS()
         case .check:
@@ -244,9 +244,9 @@ extension ByteBuffer {
         }
     }
     
-    private mutating func writeCommandType_login(userId: NIOIMAP.UserId, password: NIOIMAP.Literal) -> Int {
+    private mutating func writeCommandType_login(userID: NIOIMAP.UserID, password: NIOIMAP.Literal) -> Int {
         self.writeString("LOGIN ") +
-        self.writeUserId(userId) +
+        self.writeUserID(userID) +
         self.writeSpace() +
         self.writeLiteral(password)
     }

--- a/Sources/NIOIMAP/Grammar/UserID.swift
+++ b/Sources/NIOIMAP/Grammar/UserID.swift
@@ -17,14 +17,14 @@ import NIO
 extension NIOIMAP {
     
     /// IMAPv4 `userid`
-    public typealias UserId = String
+    public typealias UserID = String
     
 }
 
 // MARK: - Encoding
 extension ByteBuffer {
     
-    @discardableResult mutating func writeUserId(_ id: NIOIMAP.UserId) -> Int {
+    @discardableResult mutating func writeUserID(_ id: NIOIMAP.UserID) -> Int {
         self.writeString(id)
     }
     

--- a/Sources/NIOIMAP/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAP/Parser/GrammarParser.swift
@@ -4326,7 +4326,7 @@ extension NIOIMAP.GrammarParser {
     }
 
     // userid          = astring
-    static func parseUserId(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.UserId {
+    static func parseUserId(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.UserID {
         var astring = try Self.parseAString(buffer: &buffer, tracker: tracker)
         return astring.readString(length: astring.readableBytes)! // if this fails, something has gone very, very wrong
     }

--- a/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
@@ -4060,7 +4060,7 @@ extension ParserUnitTests {
 extension ParserUnitTests {
     
     func testParseUserId() {
-        let inputs: [(String, String, NIOIMAP.UserId, UInt)] = [
+        let inputs: [(String, String, NIOIMAP.UserID, UInt)] = [
             ("test", "\r\n", "test", #line),
             ("{4}\r\ntest", "\r\n", "test", #line),
             ("\"test\"", "\r\n", "test", #line),


### PR DESCRIPTION
I accidentally merged before pushing Johannes' spelling comments. 