### PR TITLE
Make raw optional string type

### DIFF
--- a/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
@@ -1526,13 +1526,13 @@ extension ParserUnitTests {
  
     func testParseEnvelopeDate() {
         let inputs: [(String, String, NIOIMAP.Envelope.Date, UInt)] = [
-            (#""2020-03-26 12:13:14""#, " ", #""2020-03-26 12:13:14""#, #line),
+            (#""2020-03-26 12:13:14""#, " ", #"2020-03-26 12:13:14"#, #line),
             (#"NIL"#, " ", nil, #line),
         ]
 
         for (input, terminator, expected, line) in inputs {
-            TestUtilities.withBuffer(input, terminator: terminator) { (buffer) in
-                 let testValue = try NIOIMAP.GrammarParser.parseEnvelopeDate(buffer: &buffer, tracker: .testTracker)
+            TestUtilities.withBuffer(input, terminator: terminator, line: line) { (buffer) in
+                let testValue = try NIOIMAP.GrammarParser.parseEnvelopeDate(buffer: &buffer, tracker: .testTracker)
                 XCTAssertEqual(testValue, expected, line: line)
             }
         }


### PR DESCRIPTION
Envelope types used `ByteBuffer`, which was difficult to work with in this instance. The types have been simplified where possible.

### Motivation:
There's no need for a `Envelope.Date` to be a `ByteBuffer`, as we know how long it's going to be. The same applies for an email address, which is typically small enough to not have to be streamed.

### Modifications:
Envelope types have been converted to be a normal `String?`. Some additional writing methods have been added to support writing `NIL` when the optional is `.none`.
