### PR TITLE
Fix parsing message body

### DIFF
--- a/Sources/NIOIMAP/Grammar/Body/Body.swift
+++ b/Sources/NIOIMAP/Grammar/Body/Body.swift
@@ -19,8 +19,8 @@ extension NIOIMAP {
     /// IMAOv4 body
     public enum Body: Equatable {
         
-        case singlepart(TypeSinglepart)
-        case multipart(TypeMultipart)
+        case singlepart(Singlepart)
+        case multipart(Multipart)
         
         /// IMAPv4 `body-fld-lines`
         public typealias FieldLines = Number
@@ -51,9 +51,9 @@ extension ByteBuffer {
         size += self.writeString("(")
         switch body {
         case .singlepart(let part):
-            size += self.writeBodyTypeSinglepart(part)
+            size += self.writeBodySinglepart(part)
         case .multipart(let part):
-            size += self.writeBodyTypeMultipart(part)
+            size += self.writeBodyMultipart(part)
         }
         size += self.writeString(")")
         return size

--- a/Sources/NIOIMAP/Grammar/Body/Multipart.swift
+++ b/Sources/NIOIMAP/Grammar/Body/Multipart.swift
@@ -17,7 +17,7 @@ import NIO
 extension NIOIMAP.Body {
 
     /// IMAPv4 `body-type-mpart`
-    public struct TypeMultipart: Equatable {
+    public struct Multipart: Equatable {
         public var bodies: [NIOIMAP.Body]
         public var mediaSubtype: NIOIMAP.Media.Subtype
         public var multipartExtension: ExtensionMultipart?
@@ -33,7 +33,7 @@ extension NIOIMAP.Body {
 // MARK: - Encoding
 extension ByteBuffer {
 
-    @discardableResult mutating func writeBodyTypeMultipart(_ part: NIOIMAP.Body.TypeMultipart) -> Int {
+    @discardableResult mutating func writeBodyMultipart(_ part: NIOIMAP.Body.Multipart) -> Int {
         part.bodies.reduce(into: 0) { (result, body) in
             result += self.writeBody(body)
         } +

--- a/Sources/NIOIMAP/Grammar/Body/Singlepart.swift
+++ b/Sources/NIOIMAP/Grammar/Body/Singlepart.swift
@@ -16,19 +16,19 @@ import NIO
 
 extension NIOIMAP.Body {
 
-    public indirect enum TypeSinglepartType: Equatable {
+    public indirect enum SinglepartType: Equatable {
         case basic(TypeBasic)
         case message(TypeMessage)
         case text(TypeText)
     }
 
     /// IMAPv4 `body-type-1part`
-    public struct TypeSinglepart: Equatable {
-        public var type: TypeSinglepartType
+    public struct Singlepart: Equatable {
+        public var type: SinglepartType
         public var `extension`: ExtensionSinglepart?
 
         /// Convenience function for a better experience when chaining multiple types.
-        public static func type(_ type: TypeSinglepartType, extension: ExtensionSinglepart?) -> Self {
+        public static func type(_ type: SinglepartType, extension: ExtensionSinglepart?) -> Self {
             return Self(type: type, extension: `extension`)
         }
     }
@@ -38,7 +38,7 @@ extension NIOIMAP.Body {
 // MARK: - Encoding
 extension ByteBuffer {
 
-    @discardableResult mutating func writeBodyTypeSinglepart(_ part: NIOIMAP.Body.TypeSinglepart) -> Int {
+    @discardableResult mutating func writeBodySinglepart(_ part: NIOIMAP.Body.Singlepart) -> Int {
         var size = 0
         switch part.type {
         case .basic(let basic):

--- a/Sources/NIOIMAP/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAP/Parser/GrammarParser.swift
@@ -231,14 +231,14 @@ extension NIOIMAP.GrammarParser {
 
         func parseBody_singlePart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body {
             try ParserLibrary.parseFixedString("(", buffer: &buffer, tracker: tracker)
-            let part = try self.parseBodyTypeSinglePart(buffer: &buffer, tracker: tracker)
+            let part = try self.parseBodySinglePart(buffer: &buffer, tracker: tracker)
             try ParserLibrary.parseFixedString(")", buffer: &buffer, tracker: tracker)
             return .singlepart(part)
         }
 
         func parseBody_multiPart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body {
             try ParserLibrary.parseFixedString("(", buffer: &buffer, tracker: tracker)
-            let part = try self.parseBodyTypeMultipart(buffer: &buffer, tracker: tracker)
+            let part = try self.parseBodyMultipart(buffer: &buffer, tracker: tracker)
             try ParserLibrary.parseFixedString(")", buffer: &buffer, tracker: tracker)
             return .multipart(part)
         }
@@ -480,31 +480,31 @@ extension NIOIMAP.GrammarParser {
 
     // body-type-1part = (body-type-basic / body-type-msg / body-type-text)
     //                   [SP body-ext-1part]
-    static func parseBodyTypeSinglePart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.TypeSinglepart {
+    static func parseBodySinglePart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.Singlepart {
 
-        func parseBodyTypeSinglePart_basic(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.TypeSinglepartType {
+        func parseBodySinglePart_basic(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.SinglepartType {
             return .basic(try self.parseBodyTypeBasic(buffer: &buffer, tracker: tracker))
         }
 
-        func parseBodyTypeSinglePart_message(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.TypeSinglepartType {
+        func parseBodySinglePart_message(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.SinglepartType {
             return .message(try self.parseBodyTypeMessage(buffer: &buffer, tracker: tracker))
         }
 
-        func parseBodyTypeSinglePart_text(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.TypeSinglepartType {
+        func parseBodySinglePart_text(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.SinglepartType {
             return .text(try self.parseBodyTypeText(buffer: &buffer, tracker: tracker))
         }
 
-        return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> NIOIMAP.Body.TypeSinglepart in
+        return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> NIOIMAP.Body.Singlepart in
             let type = try ParserLibrary.parseOneOf([
-                parseBodyTypeSinglePart_text,
-                parseBodyTypeSinglePart_basic,
-                parseBodyTypeSinglePart_message,
+                parseBodySinglePart_text,
+                parseBodySinglePart_basic,
+                parseBodySinglePart_message,
             ], buffer: &buffer, tracker: tracker)
             let ext = try ParserLibrary.parseOptional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> NIOIMAP.Body.ExtensionSinglepart in
                 try ParserLibrary.parseSpace(buffer: &buffer, tracker: tracker)
                 return try self.parseBodyExtSinglePart(buffer: &buffer, tracker: tracker)
             }
-            return NIOIMAP.Body.TypeSinglepart(type: type, extension: ext)
+            return NIOIMAP.Body.Singlepart(type: type, extension: ext)
         }
     }
 
@@ -520,8 +520,8 @@ extension NIOIMAP.GrammarParser {
 
     // body-type-mpart = 1*body SP media-subtype
     //                   [SP body-ext-mpart]
-    static func parseBodyTypeMultipart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.TypeMultipart {
-        return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NIOIMAP.Body.TypeMultipart in
+    static func parseBodyMultipart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.Body.Multipart {
+        return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NIOIMAP.Body.Multipart in
             let bodies = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
                 try self.parseBody(buffer: &buffer, tracker: tracker)
             }
@@ -531,7 +531,7 @@ extension NIOIMAP.GrammarParser {
                 try ParserLibrary.parseSpace(buffer: &buffer, tracker: tracker)
                 return try self.parseBodyExtMpart(buffer: &buffer, tracker: tracker)
             }
-            return NIOIMAP.Body.TypeMultipart(bodies: bodies, mediaSubtype: media, multipartExtension: ext)
+            return NIOIMAP.Body.Multipart(bodies: bodies, mediaSubtype: media, multipartExtension: ext)
         }
     }
 

--- a/Tests/NIOIMAPTests/Grammar/Body/Type/BodyTypeMultipartTests.swift
+++ b/Tests/NIOIMAPTests/Grammar/Body/Type/BodyTypeMultipartTests.swift
@@ -16,33 +16,33 @@ import XCTest
 import NIO
 @testable import NIOIMAP
 
-class BodyTypeMultipartTests: EncodeTestClass {
+class BodyMultipartTests: EncodeTestClass {
 
 }
 
 // MARK: - Encoding
-extension BodyTypeMultipartTests {
+extension BodyMultipartTests {
 
     func testEncode() {
-        let inputs: [(NIOIMAP.Body.TypeMultipart, String, UInt)] = [
+        let inputs: [(NIOIMAP.Body.Multipart, String, UInt)] = [
             (
                 .bodies([
-                    .singlepart(NIOIMAP.Body.TypeSinglepart(type: .text(.mediaText("subtype", fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 6), lines: 5)), extension: nil)),
+                    .singlepart(NIOIMAP.Body.Singlepart(type: .text(.mediaText("subtype", fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 6), lines: 5)), extension: nil)),
                 ], mediaSubtype: "subtype", multipartExtension: nil),
                 "(\"TEXT\" \"subtype\" () NIL NIL \"BASE64\" 6 5) \"subtype\"",
                 #line
             ),
             (
                 .bodies([
-                    .singlepart(NIOIMAP.Body.TypeSinglepart(type: .text(.mediaText("subtype", fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 6), lines: 5)), extension: nil)),
+                    .singlepart(NIOIMAP.Body.Singlepart(type: .text(.mediaText("subtype", fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 6), lines: 5)), extension: nil)),
                 ], mediaSubtype: "subtype", multipartExtension: .parameter([], dspLanguage: nil)),
                 "(\"TEXT\" \"subtype\" () NIL NIL \"BASE64\" 6 5) \"subtype\" ()",
                 #line
             ),
             (
                 .bodies([
-                    .singlepart(NIOIMAP.Body.TypeSinglepart(type: .text(.mediaText("subtype", fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 6), lines: 5)), extension: nil)),
-                    .singlepart(NIOIMAP.Body.TypeSinglepart(type: .text(.mediaText("subtype", fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 7), lines: 6)), extension: nil)),
+                    .singlepart(NIOIMAP.Body.Singlepart(type: .text(.mediaText("subtype", fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 6), lines: 5)), extension: nil)),
+                    .singlepart(NIOIMAP.Body.Singlepart(type: .text(.mediaText("subtype", fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 7), lines: 6)), extension: nil)),
                 ], mediaSubtype: "subtype", multipartExtension: nil),
                 "(\"TEXT\" \"subtype\" () NIL NIL \"BASE64\" 6 5)(\"TEXT\" \"subtype\" () NIL NIL \"BASE64\" 7 6) \"subtype\"",
                 #line
@@ -51,7 +51,7 @@ extension BodyTypeMultipartTests {
 
         for (test, expectedString, line) in inputs {
             self.testBuffer.clear()
-            let size = self.testBuffer.writeBodyTypeMultipart(test)
+            let size = self.testBuffer.writeBodyMultipart(test)
             XCTAssertEqual(size, expectedString.utf8.count, line: line)
             XCTAssertEqual(self.testBufferString, expectedString, line: line)
         }

--- a/Tests/NIOIMAPTests/Grammar/Body/Type/BodyTypeSinglepartTests.swift
+++ b/Tests/NIOIMAPTests/Grammar/Body/Type/BodyTypeSinglepartTests.swift
@@ -16,15 +16,15 @@ import XCTest
 import NIO
 @testable import NIOIMAP
 
-class BodyTypeSinglepartTests: EncodeTestClass {
+class BodySinglepartTests: EncodeTestClass {
 
 }
 
 // MARK: - Encoding
-extension BodyTypeSinglepartTests {
+extension BodySinglepartTests {
 
     func testEncode() {
-        let inputs: [(NIOIMAP.Body.TypeSinglepart, String, UInt)] = [
+        let inputs: [(NIOIMAP.Body.Singlepart, String, UInt)] = [
             (
                 .type(.basic(.media(.type(.application, subtype: "subtype"), fields: .parameter([], id: nil, description: nil, encoding: .base64, octets: 6))), extension: nil),
                 "\"APPLICATION\" \"subtype\" () NIL NIL \"BASE64\" 6",
@@ -59,7 +59,7 @@ extension BodyTypeSinglepartTests {
 
         for (test, expectedString, line) in inputs {
             self.testBuffer.clear()
-            let size = self.testBuffer.writeBodyTypeSinglepart(test)
+            let size = self.testBuffer.writeBodySinglepart(test)
             XCTAssertEqual(size, expectedString.utf8.count, line: line)
             XCTAssertEqual(self.testBufferString, expectedString, line: line)
         }

--- a/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
@@ -594,11 +594,11 @@ extension ParserUnitTests {
     
 }
 
-// MARK: - parseBodyTypeSinglepart
+// MARK: - parseBodySinglepart
 extension ParserUnitTests {
     
-    func testParseBodyTypeSinglepart() {
-        let inputs: [(String, String, NIOIMAP.Body.TypeSinglepart, UInt)] = [
+    func testParseBodySinglepart() {
+        let inputs: [(String, String, NIOIMAP.Body.Singlepart, UInt)] = [
             (
                 #""text" "plain" ("charset" "utf8") NIL NIL "quoted-printable" 7676"#,
                 "\r",
@@ -615,7 +615,7 @@ extension ParserUnitTests {
 
         for (input, terminator, expected, line) in inputs {
             TestUtilities.withBuffer(input, terminator: terminator, line: line) { (buffer) in
-                let testValue = try NIOIMAP.GrammarParser.parseBodyTypeSinglePart(buffer: &buffer, tracker: .testTracker)
+                let testValue = try NIOIMAP.GrammarParser.parseBodySinglePart(buffer: &buffer, tracker: .testTracker)
                 XCTAssertEqual(testValue, expected, line: line)
             }
         }


### PR DESCRIPTION
Fix parsing single-part message types.

### Motivation:
Single-part `basic` and `text` types differ by only one number, which is present at the end of `text`, but not `basic`. An unfortunate result of this is that the attempted parsing order matters. Any `text` is a valid a `basic`, and so we need to first see if we successfully parse `text` first.

Note: In reality this isn't *too* bad as the a sihglepart is always wrapped inside `()`, meaning we avoid *true* ambiguity.

### Modifications:
Change the parsing order so we attempt to parse `text` before `basic`, and add tests.

### Result:
Tests pass and we correctly parse `sihglepart.text`
