### PR TITLE
Fix package swift version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,6 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -11,9 +14,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-
-// swift-tools-version:5.1
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 


### PR DESCRIPTION
Xcode suddenly decided it didn't like having the swift version anywhere except the top line of the package, so it's now been moved to the top of the package.