### PR TITLE
IMAP framing parser

### DIFF
--- a/Sources/CLILib/Handlers/Inbound/ResponseRoundtripHandler.swift
+++ b/Sources/CLILib/Handlers/Inbound/ResponseRoundtripHandler.swift
@@ -35,8 +35,8 @@ public class ResponseRoundtripHandler: ChannelInboundHandler {
         do {
             var originalBufferCopy = originalBuffer
             var responses = [NIOIMAP.ResponseStream]()
-            while originalBufferCopy.readableBytes > 0 {
-                responses.append(try parser.parseResponseStream(buffer: &originalBufferCopy))
+            while originalBufferCopy.readableBytes > 0, let response = try parser.parseResponseStream(buffer: &originalBufferCopy) {
+                responses.append(response)
             }
             
             var roundtripBuffer = context.channel.allocator.buffer(capacity: originalBuffer.readableBytes)

--- a/Sources/CLILib/Handlers/Outbound/CommandRoundtripHandler.swift
+++ b/Sources/CLILib/Handlers/Outbound/CommandRoundtripHandler.swift
@@ -37,7 +37,9 @@ public class CommandRoundtripHandler: ChannelOutboundHandler {
             let commandStream = try parser.parseCommandStream(buffer: &originalBufferCopy)
             
             var roundtripBuffer = context.channel.allocator.buffer(capacity: originalBuffer.readableBytes)
-            roundtripBuffer.writeCommandStream(commandStream)
+            if let commandStream = commandStream {
+                roundtripBuffer.writeCommandStream(commandStream)
+            }
             
             if originalBuffer != roundtripBuffer {
                 logger.warning("Input command vs roundtrip output is different")

--- a/Sources/NIOIMAP/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAP/Grammar/Command/Command.swift
@@ -29,6 +29,17 @@ extension NIOIMAP {
 
 }
 
+extension NIOIMAP.Command {
+    internal var isStreamingCommand: Bool {
+        switch self.type {
+        case .append:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 extension ByteBuffer {
 
     @discardableResult public mutating func writeCommand(_ command: NIOIMAP.Command) -> Int {

--- a/Sources/NIOIMAP/Grammar/Command/CommandStream.swift
+++ b/Sources/NIOIMAP/Grammar/Command/CommandStream.swift
@@ -24,6 +24,17 @@ extension NIOIMAP {
 
 }
 
+extension NIOIMAP.CommandStream {
+    internal var isStreamingCommand: Bool {
+        switch self {
+        case .bytes, .idleDone:
+            return false
+        case .command(let command):
+            return command.isStreamingCommand
+        }
+    }
+}
+
 extension ByteBuffer {
 
     @discardableResult public mutating func writeCommandStream(_ stream: NIOIMAP.CommandStream) -> Int {

--- a/Sources/NIOIMAP/Grammar/Response/ResponseStream.swift
+++ b/Sources/NIOIMAP/Grammar/Response/ResponseStream.swift
@@ -33,6 +33,24 @@ extension NIOIMAP {
     
 }
 
+extension NIOIMAP.ResponseStream {
+    // This needs to list all (but not too many!) `ResponseStream` cases where streamed bytes may follow.
+    internal var isStreamingResponse: Bool {
+        switch self {
+        case .responseBegin:
+            return true
+        case .attributeBegin:
+            return true
+        case .simpleAttribute(.dynamic(_)):
+            return true
+        case .attributeBytes(_):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 // MARK: - Encoding
 extension ByteBuffer {
     

--- a/Sources/NIOIMAP/Parser/Coders/CommandDecoder.swift
+++ b/Sources/NIOIMAP/Parser/Coders/CommandDecoder.swift
@@ -34,11 +34,12 @@ extension NIOIMAP {
         public mutating func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
             let save = buffer
             do {
-                let result = try self.parser.parseCommandStream(buffer: &buffer)
-                context.fireChannelRead(self.wrapInboundOut(result))
-                return .continue
-            } catch NIOIMAP.ParsingError.incompleteMessage {
-                return .needMoreData
+                if let result = try self.parser.parseCommandStream(buffer: &buffer) {
+                    context.fireChannelRead(self.wrapInboundOut(result))
+                    return .continue
+                } else {
+                    return .needMoreData
+                }
             } catch {
                 throw IMAPDecoderError(parserError: error, buffer: save)
             }

--- a/Sources/NIOIMAP/Parser/Coders/ResponseDecoder.swift
+++ b/Sources/NIOIMAP/Parser/Coders/ResponseDecoder.swift
@@ -29,11 +29,12 @@ extension NIOIMAP {
         public mutating func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
             let save = buffer
             do {
-                let result = try self.parser.parseResponseStream(buffer: &buffer)
-                context.fireChannelRead(self.wrapInboundOut(result))
-                return .continue
-            } catch NIOIMAP.ParsingError.incompleteMessage {
-                return .needMoreData
+                if let result = try self.parser.parseResponseStream(buffer: &buffer) {
+                    context.fireChannelRead(self.wrapInboundOut(result))
+                    return .continue
+                } else {
+                    return .needMoreData
+                }
             } catch {
                 throw IMAPDecoderError(parserError: error, buffer: save)
             }

--- a/Sources/NIOIMAP/Parser/IMAPFramingParser.swift
+++ b/Sources/NIOIMAP/Parser/IMAPFramingParser.swift
@@ -1,0 +1,199 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+extension Optional where Wrapped == ByteBuffer {
+    mutating func append(_ buffer: inout ByteBuffer) {
+        switch self {
+        case .none:
+            self = buffer
+        case .some(var existing):
+            existing.writeBuffer(&buffer)
+            self = existing
+        }
+    }
+}
+
+internal struct IMAPFramingParser {
+    internal let bufferSizeLimit: Int
+    private var accumulator: ByteBuffer?
+    private var state = State.waitingForWholeLine
+
+    internal struct ParseResult {
+        var line: ByteBuffer?
+        var numberOfContinuationRequestsToSend: Int
+    }
+
+    private enum LineFragmentType {
+        case completeLine
+        case synchronisingLiteral(Int)
+        case nonSynchronisingLiteral(Int)
+    }
+
+    private enum State: Equatable {
+        case waitingForWholeLine
+        case waitingForBytes(Int)
+    }
+
+    init(bufferSizeLimit: Int) {
+        self.bufferSizeLimit = bufferSizeLimit
+    }
+
+    private func reverseParseTrailingNewlines(_ buffer: inout ByteBuffer) throws {
+        switch (buffer.readableBytesView.reversed().dropFirst().first, buffer.readableBytesView.last) {
+        case (UInt8(ascii: "\r"), UInt8(ascii: "\n")):
+            buffer.moveWriterIndex(to: buffer.writerIndex - 2)
+        case (_, UInt8(ascii: "\n")):
+            buffer.moveWriterIndex(to: buffer.writerIndex - 1)
+        default:
+            throw ParserError()
+        }
+    }
+
+    private func reverseParseIf(_ char: UInt8, _ buffer: inout ByteBuffer) throws -> Bool {
+        switch buffer.readableBytesView.last {
+        case .some(char):
+            buffer.moveWriterIndex(to: buffer.writerIndex - 1)
+            return true
+        case .some(_):
+            return false
+        case .none:
+            throw ParserError(hint: "whilst looking for \(char), found no bytes")
+        }
+    }
+
+    private func reverseParseNumber(_ buffer: inout ByteBuffer) throws -> Int {
+        var current = 0
+        var magnitude = 1
+        while true {
+            switch buffer.readableBytesView.last {
+            case .some(let digit) where (UInt8(ascii: "0") ... UInt8(ascii: "9")).contains(digit):
+                current += (magnitude * Int(digit - UInt8(ascii: "0")))
+                magnitude *= 10
+                buffer.moveWriterIndex(to: buffer.writerIndex - 1)
+            case .some(_):
+                if magnitude == 1 {
+                    throw ParserError()
+                } else {
+                    return current
+                }
+            case .none:
+                throw ParserError()
+            }
+        }
+    }
+
+    private func lineFragmentType(_ fragment: ByteBuffer) throws -> LineFragmentType {
+        var fragment = fragment
+        try reverseParseTrailingNewlines(&fragment)
+        guard fragment.readableBytes > 0 else {
+            return .completeLine // this is just an empty line
+        }
+        if try reverseParseIf(UInt8(ascii: "}"), &fragment) {
+            if try reverseParseIf(UInt8(ascii: "+"), &fragment) || reverseParseIf(UInt8(ascii: "-"), &fragment) {
+                let number = try reverseParseNumber(&fragment)
+                return .nonSynchronisingLiteral(number)
+            } else {
+                let number = try reverseParseNumber(&fragment)
+                return .synchronisingLiteral(number)
+            }
+        } else {
+            return .completeLine
+        }
+    }
+
+    private mutating func parseNewline(_ buffer: inout ByteBuffer) throws -> Bool {
+        switch (buffer.readableBytesView.first, buffer.readableBytesView.dropFirst().first) {
+        case (.some(UInt8(ascii: "\n")), _):
+            buffer.moveReaderIndex(forwardBy: 1)
+            return true
+        case (.some(UInt8(ascii: "\r")), .none):
+            buffer.moveReaderIndex(forwardBy: 1)
+            return false
+        case (.some(UInt8(ascii: "\r")), .some(UInt8(ascii: "\n"))):
+            buffer.moveReaderIndex(forwardBy: 2)
+            return true
+        case (.some(let char), _):
+            throw ParserError(hint: "found character \(char) when expecting newline")
+        case (.none, _):
+            return false
+        }
+    }
+
+    internal mutating func parse(_ buffer: inout ByteBuffer) throws -> ParseResult {
+        guard buffer.readableBytes > 0 else {
+            return ParseResult(line: nil, numberOfContinuationRequestsToSend: 0)
+        }
+
+        switch self.state {
+        case .waitingForWholeLine:
+            return try self.parseLine(&buffer)
+        case .waitingForBytes(let numberOfBytesExpected):
+            assert(self.accumulator == nil)
+            if let parsed = buffer.readSlice(length: numberOfBytesExpected) {
+                self.state = .waitingForWholeLine
+                return ParseResult(line: parsed, numberOfContinuationRequestsToSend: 0)
+            } else {
+                let outstanding = numberOfBytesExpected - buffer.readableBytes
+                precondition(outstanding > 0, "we have enough bytes, yet the test above failed")
+                self.state = .waitingForBytes(outstanding)
+                let parsed = buffer.readSlice(length: buffer.readableBytes)!
+                return ParseResult(line: parsed, numberOfContinuationRequestsToSend: 0)
+            }
+        }
+    }
+
+    private mutating func parseLine(_ buffer: inout ByteBuffer) throws -> ParseResult {
+        var continuations = 0
+        var bytesToConsiderThisTime = buffer.readableBytesView
+        while let firstNL = bytesToConsiderThisTime.firstIndex(of: UInt8(ascii: "\n")) {
+            var finishingSlice = buffer.readSlice(length: firstNL - bytesToConsiderThisTime.startIndex + 1)!
+            self.accumulator.append(&finishingSlice)
+
+            let allFragments = self.accumulator!
+
+            assert((allFragments.readableBytesView.last ?? 0)  == UInt8(ascii: "\n"))
+            let outstandingLiteralBytes: Int
+            switch try lineFragmentType(allFragments) {
+            case .completeLine:
+                // .clear() would CoW, so let's move manually
+                self.accumulator!.moveReaderIndex(to: 0)
+                self.accumulator!.moveWriterIndex(to: 0)
+                return .init(line: allFragments, numberOfContinuationRequestsToSend: continuations)
+            case .synchronisingLiteral(let number):
+                bytesToConsiderThisTime = bytesToConsiderThisTime[firstNL + 1 ..< buffer.readableBytesView.endIndex]
+                continuations += 1
+                outstandingLiteralBytes = number
+            case .nonSynchronisingLiteral(let number):
+                bytesToConsiderThisTime = bytesToConsiderThisTime[firstNL + 1 ..< buffer.readableBytesView.endIndex]
+                outstandingLiteralBytes = number
+            }
+            if allFragments.readableBytes + outstandingLiteralBytes > self.bufferSizeLimit {
+                // switching to streaming mode
+                assert(outstandingLiteralBytes > 0)
+                assert(self.state == .waitingForWholeLine, "illegal state: \(self.state)")
+                self.state = .waitingForBytes(outstandingLiteralBytes)
+                self.accumulator = nil
+                return .init(line: allFragments, numberOfContinuationRequestsToSend: continuations)
+            }
+        }
+
+        self.accumulator.append(&buffer)
+        guard self.accumulator!.readableBytes <= self.bufferSizeLimit else {
+            throw NIOIMAP.ParsingError.lineTooLong
+        }
+        return .init(line: nil, numberOfContinuationRequestsToSend: continuations)
+    }
+}

--- a/Sources/NIOIMAP/Parser/Parser.swift
+++ b/Sources/NIOIMAP/Parser/Parser.swift
@@ -17,20 +17,3 @@ import NIO
 protocol Parser {
     var bufferLimit: Int { get }
 }
-
-extension Parser {
-    
-    func throwIfExceededBufferLimit(_ buffer: inout ByteBuffer) throws {
-        // try to find LF in the first `self.bufferLimit` bytes
-        guard buffer.readableBytesView.prefix(self.bufferLimit).contains(UInt8(ascii: "\n")) else {
-            // We're in line-parsing mode and there's no newline, let's buffer more. But let's do a quick check
-            // that don't buffer too much.
-            guard buffer.readableBytes <= self.bufferLimit else {
-                // We're in line parsing mode
-                throw NIOIMAP.ParsingError.lineTooLong
-            }
-            throw NIOIMAP.ParsingError.incompleteMessage
-        }
-    }
-    
-}

--- a/Sources/NIOIMAP/Parser/ParserLibrary.swift
+++ b/Sources/NIOIMAP/Parser/ParserLibrary.swift
@@ -60,7 +60,7 @@ extension ParserLibrary {
             }
 
             guard let firstBad = maybeFirstBad else {
-                throw NIOIMAP.ParsingError.incompleteMessage
+                throw ParserError()
             }
             return buffer.readString(length: buffer.readableBytesView.startIndex.distance(to: firstBad))!
         }
@@ -73,7 +73,7 @@ extension ParserLibrary {
             }
 
             guard let firstBad = maybeFirstBad else {
-                throw NIOIMAP.ParsingError.incompleteMessage
+                throw ParserError() // TODO: this maybe should support parsing to EOF
             }
             guard firstBad != buffer.readableBytesView.startIndex else {
                 throw ParserError(hint: "couldn't find one or more of the required characters")
@@ -89,7 +89,7 @@ extension ParserLibrary {
             }
 
             guard let firstBad = maybeFirstBad else {
-                throw NIOIMAP.ParsingError.incompleteMessage
+                throw ParserError() // TODO: this maybe should support parsing to EOF
             }
             return buffer.readSlice(length: buffer.readableBytesView.startIndex.distance(to: firstBad))!
         }
@@ -102,7 +102,7 @@ extension ParserLibrary {
             }
 
             guard let firstBad = maybeFirstBad else {
-                throw NIOIMAP.ParsingError.incompleteMessage
+                throw ParserError() // TODO: this maybe should support parsing to EOF
             }
             guard firstBad != buffer.readableBytesView.startIndex else {
                 throw ParserError()
@@ -179,7 +179,7 @@ extension ParserLibrary {
                 guard needle.utf8.starts(with: buffer.readableBytesView, by: { $0 & 0xdf == $1 & 0xdf }) else {
                     throw ParserError(hint: "Tried to parse \(needle) in \(String(decoding: buffer.readableBytesView, as: Unicode.UTF8.self))")
                 }
-                throw NIOIMAP.ParsingError.incompleteMessage
+                throw ParserError(hint: "not enough bytes")
             }
 
             assert(needle.utf8.allSatisfy { $0 & 0b1000_0000 == 0 }, "needle needs to be ASCII but \(needle) isn't")
@@ -202,7 +202,7 @@ extension ParserLibrary {
     static func parseSpace(buffer: inout ByteBuffer, tracker: StackTracker) throws {
         return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             guard let actual = buffer.readString(length: 1) else {
-                throw NIOIMAP.ParsingError.incompleteMessage
+                throw ParserError(hint: "not enough bytes")
             }
             guard actual == " " else {
                 throw ParserError(hint: "Expected space, found \(actual)")
@@ -232,16 +232,14 @@ extension ParserLibrary {
             return
         case .none:
             guard let first = buffer.getInteger(at: buffer.readerIndex, as: UInt8.self) else {
-                throw NIOIMAP.ParsingError.incompleteMessage
+                throw ParserError(hint: "not enough bytes")
             }
             switch first {
             case UInt8(ascii: "\n"):
                 buffer.moveReaderIndex(forwardBy: 1)
                 return
-            case UInt8(ascii: "\r"):
-                throw NIOIMAP.ParsingError.incompleteMessage
             default:
-                // found only one byte which is neither CR nor LF.
+                // found only one byte which is not LF.
                 throw ParserError()
             }
         default:

--- a/Tests/CLILibTests/CommandRoundtripHandler+PromiseTests.swift
+++ b/Tests/CLILibTests/CommandRoundtripHandler+PromiseTests.swift
@@ -32,9 +32,10 @@ class CommandRoundtripHandler_PromiseTests: XCTestCase {
     }
     
     func testPromiseIsNotDropped_shouldThrow() {
-        let buffer = channel.allocator.buffer(capacity: 0)
+        var buffer = channel.allocator.buffer(capacity: 0)
+        buffer.writeString("definitely not IMAP\r\n")
         XCTAssertThrowsError(try self.channel.writeOutbound(buffer)) { e in
-            XCTAssertTrue(e is NIOIMAP.ParsingError, "Error \(e)")
+            XCTAssertTrue(e is ParserError, "Error \(e)")
         }
         XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound(as: ByteBuffer.self)))
     }

--- a/Tests/NIOIMAPTests/Parser/CommandParser+Tests.swift
+++ b/Tests/NIOIMAPTests/Parser/CommandParser+Tests.swift
@@ -34,18 +34,3 @@ extension CommandParser_Tests {
     }
     
 }
-
-// MARK: - throwIfExceededBufferLimit
-extension CommandParser_Tests {
-    
-    func testThrowIfExceededBufferLimit() {
-        let parser = NIOIMAP.CommandParser(bufferLimit: 2)
-        var b1 = "abc" as ByteBuffer
-        var b2 = "ab" as ByteBuffer
-        var b3 = "a" as ByteBuffer
-        XCTAssertThrowsError(try parser.throwIfExceededBufferLimit(&b1))
-        XCTAssertNoThrow(try parser.throwIfExceededBufferLimit(&b2))
-        XCTAssertNoThrow(try parser.throwIfExceededBufferLimit(&b3))
-    }
-    
-}

--- a/Tests/NIOIMAPTests/Parser/IMAPFramingParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPFramingParserTests.swift
@@ -1,0 +1,351 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import NIO
+@testable import NIOIMAP
+
+final class IMAPFramingParserTests: XCTestCase {
+    var parses: [ByteBuffer] = []
+    var continuationsParsed = 0
+    var parser: IMAPFramingParser! = nil
+
+    override func setUp() {
+        XCTAssertNil(self.parser)
+        XCTAssertEqual(0, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.parser = IMAPFramingParser(bufferSizeLimit: 100)
+    }
+
+    override func tearDown() {
+        XCTAssertNotNil(self.parser)
+        self.parser = nil
+        self.parses = []
+        self.continuationsParsed = 0
+    }
+
+    func feedAllowingErrors(_ string: String) throws {
+        var buffer = self.stringBuffer(string)
+        repeat {
+            let result = try self.parser.parse(&buffer)
+            self.continuationsParsed += result.numberOfContinuationRequestsToSend
+            if let line = result.line {
+                self.parses.append(line)
+            } else {
+                break
+            }
+        } while true
+    }
+
+    func feed(_ string: String, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertNoThrow(try self.feedAllowingErrors(string), file: file, line: line)
+    }
+
+    func testBasicLine() {
+        self.feed("a001 LOGIN")
+        XCTAssert(self.parses.isEmpty)
+        self.feed(#" "hello" "you""#)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("\r")
+        XCTAssert(self.parses.isEmpty)
+        self.feed("\n")
+        self.assertOneParse(#"a001 LOGIN "hello" "you""# + "\r\n")
+    }
+
+    func testBasicLineNoCR() {
+        self.feed("a001 LOGIN")
+        XCTAssert(self.parses.isEmpty)
+        self.feed(#" "hello" "you""#)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("\n")
+        self.assertOneParse(#"a001 LOGIN "hello" "you""# + "\n")
+    }
+
+    func testTwoLinesInOne() {
+        self.feed(#"a001 LOGIN "hello" "you""# + "\r\n" + #"a002 LOGIN "hello" "again""# + "\n")
+        self.assertMultipleParses([#"a001 LOGIN "hello" "you""# + "\r\n",
+                                   #"a002 LOGIN "hello" "again""# + "\n"
+        ])
+    }
+
+    func testTwoRegularLiteralsChunked() {
+        self.feed("a001 LOGIN")
+        XCTAssert(self.parses.isEmpty)
+        self.feed(#" {5}"# + "\r\n")
+        XCTAssertEqual(1, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("hello ")
+        XCTAssertEqual(1, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("{3}\r")
+        XCTAssertEqual(1, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("\n")
+        XCTAssertEqual(2, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("you\r\n")
+        self.assertOneParse("a001 LOGIN {5}\r\nhello {3}\r\nyou\r\n", numberOfContinuations: 2)
+    }
+
+    func testRegularLiteralOfZeroSize() {
+        self.feed("a001 LOGIN \"\" {0}\r\n\r\n")
+        self.assertOneParse("a001 LOGIN \"\" {0}\r\n\r\n", numberOfContinuations: 1)
+    }
+
+    func testPlusLiteralOfZeroSize() {
+        self.feed("a001 LOGIN \"\" {0+}\r\n\r\n")
+        self.assertOneParse("a001 LOGIN \"\" {0+}\r\n\r\n", numberOfContinuations: 0)
+    }
+
+    func testTwoRegularLiteralOfZeroSize() {
+        self.feed("a001 LOGIN {0}\r\n {0}\r\n\r\n")
+        self.assertOneParse("a001 LOGIN {0}\r\n {0}\r\n\r\n", numberOfContinuations: 2)
+    }
+
+    func testTwoRegularLiteralsOneShot() {
+        self.feed("a001 LOGIN {5}\r\nhello {3}\r\nyou\r\n")
+        self.assertOneParse("a001 LOGIN {5}\r\nhello {3}\r\nyou\r\n", numberOfContinuations: 2)
+    }
+
+    func testTwoRegularLiteralsChunkedPlusExtraBits() {
+        self.feed("a001 LOGIN {5}\r\nhello {3}\r\nyou\r\nLOGIN {4}\r\nwhat")
+        self.assertOneParse("a001 LOGIN {5}\r\nhello {3}\r\nyou\r\n", numberOfContinuations: 3)
+    }
+
+    func testTwoRegularLiteralsOnePlusLiteralOneShot() {
+        self.feed("a001 LOGIN {5}\r\nhello {3}\r\nyou\r\nLOGIN {4+}\r\nwhat")
+        self.assertOneParse("a001 LOGIN {5}\r\nhello {3}\r\nyou\r\n", numberOfContinuations: 2)
+    }
+
+    func testOnePlusLiteralOneRegularLiteral() {
+        self.feed("a001 LOGIN {5+}\r\nhello {3}\r\nyou\r\n")
+        self.assertOneParse("a001 LOGIN {5+}\r\nhello {3}\r\nyou\r\n", numberOfContinuations: 1)
+    }
+
+    func testOnePlusLiteralOneMinusLiteral() {
+        self.feed("a001 LOGIN {5+}\r\nhello {3-}\r\nyou\r\n")
+        self.assertOneParse("a001 LOGIN {5+}\r\nhello {3-}\r\nyou\r\n", numberOfContinuations: 0)
+    }
+
+    func testTwoRegularTildeLiterals() {
+        self.feed("a001 LOGIN {~5}\r\nhello {~3}\r\nyou\r\n")
+        self.assertOneParse("a001 LOGIN {~5}\r\nhello {~3}\r\nyou\r\n", numberOfContinuations: 2)
+    }
+
+    func testTwoPlusLiteralsChunked() {
+        self.feed("a001 LOGIN")
+        XCTAssert(self.parses.isEmpty)
+        self.feed(#" {5+}"# + "\r\n")
+        XCTAssertEqual(0, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("hello ")
+        XCTAssertEqual(0, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("{3+}\r")
+        XCTAssertEqual(0, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("\n")
+        XCTAssertEqual(0, self.continuationsParsed)
+        XCTAssert(self.parses.isEmpty)
+        self.feed("you\r\n")
+        self.assertOneParse("a001 LOGIN {5+}\r\nhello {3+}\r\nyou\r\n", numberOfContinuations: 0)
+    }
+
+    func testWeCanGoOverBufferLimitIfWeManageToMakeCompleteLine() {
+        self.feed("a001 LOGIN {5+}\r\nhello {3+}\r\nyou\r\n" + String(repeating: "X", count: 100))
+        self.assertOneParse("a001 LOGIN {5+}\r\nhello {3+}\r\nyou\r\n", numberOfContinuations: 0)
+    }
+
+    func testWeStartStreamingWhenWeGoOverChunked1() {
+        let hundredXs = String(repeating: "X", count: 100)
+        let xs799 = String(repeating: "X", count: 799)
+        self.feed("a001 LOGIN {1000}\r\n" + hundredXs)
+        XCTAssertEqual(2, self.parses.count)
+        XCTAssertEqual(1, self.continuationsParsed)
+        self.feed(hundredXs + "Y")
+        XCTAssertEqual(3, self.parses.count)
+        self.feed(xs799)
+        XCTAssertEqual(4, self.parses.count)
+        self.feed("\r")
+        XCTAssertEqual(4, self.parses.count)
+        self.feed("\n")
+        XCTAssertEqual(5, self.parses.count)
+        self.feed(#"LOGIN "a" "b""# + "\r\n")
+        XCTAssertEqual(6, self.parses.count)
+        self.assertMultipleParses(["a001 LOGIN {1000}\r\n",
+                                   hundredXs,       // 100
+                                   hundredXs + "Y", // 201
+                                   xs799,
+                                   "\r\n",
+                                   #"LOGIN "a" "b""# + "\r\n"
+                                  ], numberOfContinuations: 1)
+    }
+
+    func testWeStartStreamingWhenWeGoOverChunked2() {
+        let hundredXs = String(repeating: "X", count: 100)
+        let xs799 = String(repeating: "X", count: 799)
+        self.feed("a001 LOGIN {1000}\r\n" + hundredXs)
+        XCTAssertEqual(2, self.parses.count)
+        XCTAssertEqual(1, self.continuationsParsed)
+        self.feed(hundredXs + "Y")
+        XCTAssertEqual(3, self.parses.count)
+        self.feed(xs799)
+        XCTAssertEqual(4, self.parses.count)
+        self.feed("\r\n")
+        XCTAssertEqual(5, self.parses.count)
+        self.feed(#"LOGIN "a" "b""# + "\r\n")
+        XCTAssertEqual(6, self.parses.count)
+        self.assertMultipleParses(["a001 LOGIN {1000}\r\n",
+                                   hundredXs,       // 100
+                                   hundredXs + "Y", // 201
+                                   xs799,
+                                   "\r\n",
+                                   #"LOGIN "a" "b""# + "\r\n"
+                                  ], numberOfContinuations: 1)
+    }
+
+    func testWeStartStreamingWhenWeGoOverChunked3() {
+        let hundredXs = String(repeating: "X", count: 100)
+        let xs799 = String(repeating: "X", count: 799)
+        self.feed("a001 LOGIN {1000}\r\n" + hundredXs)
+        XCTAssertEqual(2, self.parses.count)
+        XCTAssertEqual(1, self.continuationsParsed)
+        self.feed(hundredXs + "Y")
+        XCTAssertEqual(3, self.parses.count)
+        self.feed(xs799)
+        XCTAssertEqual(4, self.parses.count)
+        self.feed("\r")
+        XCTAssertEqual(4, self.parses.count)
+        self.feed("\n" + #"LOGIN "a" "b""# + "\r\n")
+        XCTAssertEqual(6, self.parses.count)
+        self.assertMultipleParses(["a001 LOGIN {1000}\r\n",
+                                   hundredXs,       // 100
+                                   hundredXs + "Y", // 201
+                                   xs799,
+                                   "\r\n",
+                                   #"LOGIN "a" "b""# + "\r\n"
+                                  ], numberOfContinuations: 1)
+    }
+
+    func testWeStartStreamingWhenWeGoOverChunked4() {
+        let hundredXs = String(repeating: "X", count: 100)
+        let xs799 = String(repeating: "X", count: 799)
+        self.feed("a001 LOGIN {1000}\r\n" + hundredXs)
+        XCTAssertEqual(2, self.parses.count)
+        XCTAssertEqual(1, self.continuationsParsed)
+        self.feed(hundredXs + "Y")
+        XCTAssertEqual(3, self.parses.count)
+        self.feed(xs799)
+        XCTAssertEqual(4, self.parses.count)
+        self.feed("\r\n" + #"LOGIN "a" "b""# + "\r\n")
+        XCTAssertEqual(6, self.parses.count)
+        self.assertMultipleParses(["a001 LOGIN {1000}\r\n",
+                                   hundredXs,       // 100
+                                   hundredXs + "Y", // 201
+                                   xs799,
+                                   "\r\n",
+                                   #"LOGIN "a" "b""# + "\r\n"
+                                  ], numberOfContinuations: 1)
+    }
+
+    func testWeStartStreamingWhenWeGetEverythingOneShot() {
+        let hundredXs = String(repeating: "X", count: 100)
+        let xs799 = String(repeating: "X", count: 799)
+        self.feed("a001 LOGIN {1000}\r\n" + hundredXs + hundredXs + "Y" + xs799 + "\r\n" + #"LOGIN "a" "b""# + "\r\n")
+        self.assertMultipleParses(["a001 LOGIN {1000}\r\n",
+                                   hundredXs + hundredXs + "Y" + xs799,
+                                   "\r\n",
+                                   #"LOGIN "a" "b""# + "\r\n"
+                                  ], numberOfContinuations: 1)
+    }
+
+    func testStreamingResponse() {
+        let hundredXs = String(repeating: "X", count: 100)
+        self.feed("* 1 FETCH (BODY[TEXT] {101}\r\n\(hundredXs)")
+        XCTAssertEqual(2, self.parses.count)
+        XCTAssertEqual(1, self.continuationsParsed)
+        self.feed("Y FLAGS (\\seen \\answered))\r\n")
+        self.assertMultipleParses(["* 1 FETCH (BODY[TEXT] {101}\r\n",
+                                   hundredXs,
+                                   "Y",
+                                   " FLAGS (\\seen \\answered))\r\n",
+                                  ], numberOfContinuations: 1)
+    }
+
+    func testLimitWorks() {
+        var justTooLong = #"a LOGIN ""#
+        justTooLong.append(String(repeating: "X",
+                                  count: self.parser.bufferSizeLimit - justTooLong.utf8.count + 1))
+        XCTAssertThrowsError(try self.feedAllowingErrors(justTooLong)) { error in
+            XCTAssertEqual(.lineTooLong, error as? NIOIMAP.ParsingError)
+        }
+    }
+
+    func testObviouslyBogusCommands() {
+        for badString in ["a LOGIN {}\r\n", "a LOGIN {+}\r\n", "a LOGIN {-}\r\n", "a LOGIN ~{}\r\n",
+                          "}\r\n"] {
+            XCTAssertThrowsError(try self.feedAllowingErrors(badString), "'\(badString)'") { error in
+                XCTAssert(error is ParserError, "\(error) for \(badString) isn't right")
+            }
+        }
+    }
+
+    func testOkayWithNothing() {
+        self.feed("")
+        XCTAssertEqual(0, self.parses.count)
+        XCTAssertEqual(0, self.continuationsParsed)
+    }
+
+    func testOkayWithJustNewlines() {
+        for goods in ["\n", "\r\n"].enumerated() {
+            self.feed(goods.element)
+            XCTAssertEqual(goods.offset + 1, self.parses.count)
+            XCTAssertEqual(0, self.continuationsParsed)
+        }
+    }
+
+
+    private func assertOneParse(_ expected: String,
+                                numberOfContinuations: Int? = 0,
+                                file: StaticString = #file,
+                                line: UInt = #line) {
+        let expectedArray = [self.stringBuffer(expected)]
+        let actual = self.parses
+        func whyUnequal() -> String {
+            guard !actual.isEmpty else {
+                return "<no parses>"
+            }
+            return "expected: \(String(decoding: expectedArray[0].readableBytesView, as: Unicode.UTF8.self)), " +
+                   "actual: \(String(decoding: actual[0].readableBytesView, as: Unicode.UTF8.self))"
+        }
+        XCTAssertEqual(numberOfContinuations, self.continuationsParsed, file: file, line: line)
+        XCTAssertEqual(expectedArray, actual, whyUnequal(), file: file, line: line)
+    }
+
+    private func assertMultipleParses(_ expected: [String],
+                                      numberOfContinuations: Int? = 0,
+                                      file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(numberOfContinuations, self.continuationsParsed)
+        XCTAssertEqual(expected.map(self.stringBuffer(_:)), self.parses, file: file, line: line)
+    }
+
+    private func stringBuffer(_ string: String) -> ByteBuffer {
+        var buffer = ByteBufferAllocator().buffer(capacity: string.utf8.count + 10)
+        buffer.writeString("01234")
+        buffer.moveReaderIndex(to: buffer.writerIndex)
+        buffer.writeString(string)
+        buffer.setString("56789", at: buffer.writerIndex)
+        return buffer
+    }
+}

--- a/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
@@ -92,6 +92,9 @@ final class ParserUnitTests: XCTestCase {
                 ()
             }
             XCTFail("unhandled error: \(error)")
+            if let error = error as? NIOIMAP.IMAPDecoderError {
+                print(String(decoding: error.buffer.readableBytesView, as: Unicode.UTF8.self))
+            }
         }
     }
 
@@ -276,7 +279,7 @@ extension ParserUnitTests {
     func testAddress_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: #"("a" "b" "c""#)
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseAddress(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -472,7 +475,7 @@ extension ParserUnitTests {
     func testAtom_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "hello")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseAtom(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -618,7 +621,7 @@ extension ParserUnitTests {
     func testParseBodyFieldParam_invalid_oneObject() {
         var buffer = TestUtilities.createTestByteBuffer(for: #"("p1" "#)
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseBodyFieldParam(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -675,7 +678,7 @@ extension ParserUnitTests {
     func testCapability_invalid_empty() {
         var buffer = TestUtilities.createTestByteBuffer(for: "")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseSequenceNumber(buffer: &buffer, tracker: .testTracker)) { error in
-            XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+            XCTAssertTrue(error is ParserError)
         }
     }
 
@@ -756,7 +759,7 @@ extension ParserUnitTests {
     func testCreate_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "CREATE ")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseCreate(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1077,7 +1080,7 @@ extension ParserUnitTests {
     func testDateMonth_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "ju")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseDateMonth(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1103,7 +1106,7 @@ extension ParserUnitTests {
     func testDateText_invalid_missing_year() {
         var buffer = TestUtilities.createTestByteBuffer(for: "25-Jun-")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseDateText(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1126,7 +1129,7 @@ extension ParserUnitTests {
     func testParseDateTime__invalid_incomplete() {
         var buffer = #""25-Jun-1994 01"# as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseDateTime(buffer: &buffer, tracker: .testTracker)) { error in
-            XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+            XCTAssertTrue(error is ParserError)
         }
     }
 
@@ -1167,7 +1170,7 @@ extension ParserUnitTests {
     func testDelete_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "DELETE ")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseDelete(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1292,7 +1295,7 @@ extension ParserUnitTests {
     func testParseEnvelopeBCC_invalid_incomplete() {
         var buffer = #"(("1" "2" "3" "4")("5" "6" "7""# as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseEnvelopeBcc(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1326,7 +1329,7 @@ extension ParserUnitTests {
     func testParseEnvelopeCC_invalid_incomplete() {
         var buffer = #"(("1" "2" "3" "4")("5" "6" "7""# as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseEnvelopeCc(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1360,7 +1363,7 @@ extension ParserUnitTests {
     func testParseEnvelopeFrom_invalid_incomplete() {
         var buffer = #"(("1" "2" "3" "4")("5" "6" "7""# as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseEnvelopeFrom(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1394,7 +1397,7 @@ extension ParserUnitTests {
     func testParseEnvelopeReplyTo_invalid_incomplete() {
         var buffer = #"(("1" "2" "3" "4")("5" "6" "7""# as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseEnvelopeReplyTo(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1428,7 +1431,7 @@ extension ParserUnitTests {
     func testParseEnvelopeSender_invalid_incomplete() {
         var buffer = #"(("1" "2" "3" "4")("5" "6" "7""# as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseEnvelopeSender(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1462,7 +1465,7 @@ extension ParserUnitTests {
     func testParseEnvelopeTo_invalid_incomplete() {
         var buffer = #"(("1" "2" "3" "4")("5" "6" "7""# as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseEnvelopeTo(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1499,7 +1502,7 @@ extension ParserUnitTests {
     func testExamine_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "EXAMINE ")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseExamine(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1848,7 +1851,7 @@ extension ParserUnitTests {
     func testParseMailboxList_invalid_character_incomplete() {
         var buffer = "() \"" as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseMailboxList(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -1994,7 +1997,7 @@ extension ParserUnitTests {
     func testMediaMessage_invalid_partial() {
         var buffer = TestUtilities.createTestByteBuffer(for: "\"messAGE\"")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseMediaMessage(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -2027,7 +2030,7 @@ extension ParserUnitTests {
     func testMediaText_invalid_missingSubtype() {
         var buffer = TestUtilities.createTestByteBuffer(for: #""TEXT""#)
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseMediaText(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -2246,7 +2249,7 @@ extension ParserUnitTests {
     func test_parseNewlineFailure() {
         var buffer = TestUtilities.createTestByteBuffer(for: "\r")
         XCTAssertThrowsError(try ParserLibrary.parseNewline(buffer: &buffer, tracker: .testTracker)) { error in
-            XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+            XCTAssertTrue(error is ParserError)
         }
         XCTAssertEqual(UInt8(ascii: "\r"), buffer.readInteger(as: UInt8.self))
 
@@ -2292,7 +2295,7 @@ extension ParserUnitTests {
     func testNil_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "N")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseNil(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -2359,7 +2362,7 @@ extension ParserUnitTests {
     func testNumber_invalid_empty() {
         var buffer = TestUtilities.createTestByteBuffer(for: "")
         XCTAssertThrowsError(try ParserLibrary.parseNewline(buffer: &buffer, tracker: .testTracker)) { error in
-            XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+            XCTAssertTrue(error is ParserError)
         }
     }
 
@@ -2406,7 +2409,7 @@ extension ParserUnitTests {
     func testNZNumber_invalid_empty() {
         var buffer = TestUtilities.createTestByteBuffer(for: "")
         XCTAssertThrowsError(try ParserLibrary.parseNewline(buffer: &buffer, tracker: .testTracker)) { error in
-            XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+            XCTAssertTrue(error is ParserError)
         }
     }
 
@@ -2846,7 +2849,7 @@ extension ParserUnitTests {
     func testParseSection_invalid_none() {
         var buffer = "" as ByteBuffer
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseSectionPart(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -2880,7 +2883,7 @@ extension ParserUnitTests {
     func testSelect_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "SELECT ")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseSelect(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -2989,7 +2992,7 @@ extension ParserUnitTests {
     func testSequenceSet_invalid_none() {
         var buffer = TestUtilities.createTestByteBuffer(for: "")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseSequenceSet(buffer: &buffer, tracker: .testTracker)) { error in
-            XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+            XCTAssertTrue(error is ParserError)
         }
     }
 
@@ -3091,7 +3094,7 @@ extension ParserUnitTests {
     func testStatusAttributeList_invalid_none() {
         var buffer = TestUtilities.createTestByteBuffer(for: "")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseStatusAttributeList(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3155,7 +3158,7 @@ extension ParserUnitTests {
     func testSubscribe_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "SUBSCRIBE ")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseSubscribe(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3238,7 +3241,7 @@ extension ParserUnitTests {
     func testTag_invalid_short() {
         var buffer = TestUtilities.createTestByteBuffer(for: "")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseTag(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3297,14 +3300,14 @@ extension ParserUnitTests {
     func testText_empty() {
         var buffer = TestUtilities.createTestByteBuffer(for: "")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseText(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
     func testText_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "hello world!")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseText(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3351,7 +3354,7 @@ extension ParserUnitTests {
     func testDateTime_invalid_partial() {
         var buffer = TestUtilities.createTestByteBuffer(for: "12:")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseTime(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3443,7 +3446,7 @@ extension ParserUnitTests {
     func testUniqueID_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "123")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseUniqueID(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3463,7 +3466,7 @@ extension ParserUnitTests {
     func testUnsubscribe_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "UNSUBSCRIBE ")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseUnsubscribe(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3509,7 +3512,7 @@ extension ParserUnitTests {
     func testXCommand_invalid_incomplete() {
         var buffer = TestUtilities.createTestByteBuffer(for: "xhello")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseXCommand(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3537,7 +3540,7 @@ extension ParserUnitTests {
     func testZone_short() {
         var buffer = TestUtilities.createTestByteBuffer(for: "+12")
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parseZone(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage, "e has type \(e)")
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3577,7 +3580,7 @@ extension ParserUnitTests {
     func test2digit_invalid_short() {
         var buffer = TestUtilities.createTestByteBuffer(for: [UInt8(ascii: "1")  ])
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parse2Digit(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 
@@ -3610,7 +3613,7 @@ extension ParserUnitTests {
     func test4digit_invalid_short() {
         var buffer = TestUtilities.createTestByteBuffer(for: [UInt8(ascii: "1")])
         XCTAssertThrowsError(try NIOIMAP.GrammarParser.parse4Digit(buffer: &buffer, tracker: .testTracker)) { e in
-            XCTAssertEqual(e as? NIOIMAP.ParsingError, .incompleteMessage)
+            XCTAssertTrue(e is ParserError)
         }
     }
 

--- a/Tests/NIOIMAPTests/Parser/ParserLibraryTests.swift
+++ b/Tests/NIOIMAPTests/Parser/ParserLibraryTests.swift
@@ -23,11 +23,9 @@ final class ParserLibraryTests: XCTestCase {
 extension ParserLibraryTests {
     func test_parseOptionalWorksForNothing() {
         var buffer = TestUtilities.createTestByteBuffer(for: "")
-        XCTAssertThrowsError(try ParserLibrary.parseOptional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
+        XCTAssertNoThrow(XCTAssertNil(try ParserLibrary.parseOptional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
             try ParserLibrary.parseFixedString("x", buffer: &buffer, tracker: tracker)
-        }) { error in
-            XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
-        }
+        }))
     }
 
     func test_parseOptionalWorks() {
@@ -47,12 +45,10 @@ extension ParserLibraryTests {
 
     func test_parseOptionalCorrectlyResetsForCompositesIfNotEnough() {
         var buffer = TestUtilities.createTestByteBuffer(for: "x")
-        XCTAssertThrowsError(try ParserLibrary.parseOptional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
+        XCTAssertNoThrow(XCTAssertNil(try ParserLibrary.parseOptional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker -> Void in
             try ParserLibrary.parseFixedString("x", buffer: &buffer, tracker: tracker)
             try ParserLibrary.parseFixedString("y", buffer: &buffer, tracker: tracker)
-        }) { error in
-            XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
-        }
+        }))
         XCTAssertEqual(1, buffer.readableBytes)
     }
 
@@ -91,7 +87,7 @@ extension ParserLibraryTests {
                                                                 caseSensitive: true,
                                                                 buffer: &buffer,
                                                                 tracker: .testTracker)) { error in
-                                                                    XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+                                                                    XCTAssertTrue(error is ParserError)
         }
     }
 
@@ -111,7 +107,7 @@ extension ParserLibraryTests {
         XCTAssertThrowsError(try ParserLibrary.parseFixedString("fooFooFOO",
                                                                 buffer: &buffer,
                                                                 tracker: .testTracker)) { error in
-                                                                    XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+                                                                    XCTAssertTrue(error is ParserError)
         }
     }
 
@@ -144,12 +140,11 @@ extension ParserLibraryTests {
 
     func test_parseZeroOrMoreParsesNothingNoData() {
         TestUtilities.withBuffer("") { buffer in
-            XCTAssertThrowsError(try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker in
+            XCTAssertNoThrow(XCTAssertEqual(0,
+                                            try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker in
                 try ParserLibrary.parseFixedString("x", buffer: &buffer, tracker: tracker)
                 try ParserLibrary.parseFixedString("x", buffer: &buffer, tracker: tracker)
-            }) { error in
-                XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
-            }
+            }.count))
         }
     }
 
@@ -197,7 +192,7 @@ extension ParserLibraryTests {
                 try ParserLibrary.parseFixedString("x", buffer: &buffer, tracker: tracker)
                 try ParserLibrary.parseFixedString("x", buffer: &buffer, tracker: tracker)
             }) { error in
-                XCTAssertEqual(error as? NIOIMAP.ParsingError, NIOIMAP.ParsingError.incompleteMessage)
+                XCTAssertTrue(error is ParserError)
             }
         }
     }

--- a/Tests/NIOIMAPTests/TestUtilities.swift
+++ b/Tests/NIOIMAPTests/TestUtilities.swift
@@ -56,9 +56,12 @@ extension TestUtilities {
             let expectedString = String(decoding: expected.readableBytesView, as: Unicode.UTF8.self)
             let remainingString = String(decoding: inputBuffer.readableBytesView, as: Unicode.UTF8.self)
             if shouldRemainUnchanged {
-                XCTAssertEqual(beforeRunningBody, inputBuffer, file: file, line: line)
+                XCTAssertEqual(beforeRunningBody, inputBuffer,
+                               "change detected, despite shouldRemainUnchanged=true", file: file, line: line)
             } else {
-                XCTAssertEqual(remainingString, expectedString, file: file, line: line)
+                XCTAssertEqual(remainingString, expectedString,
+                               "remaining bytes '\(remainingString)' but expected '\(expectedString)'",
+                               file: file, line: line)
             }
         }
 


### PR DESCRIPTION
### Motivation:

This adds support for synchronising literals to the parser and an IMAP framing parser which means we can ditch `.incompleteMessage`.

### Modifications:

- add the framing parser
- wire it up
- remove `.incompleteMessage`

### Result:

Much closer than before to actually speaking IMAP with synchronising literals.