### PR TITLE
Refactor namespaces to remove nil

### DIFF
--- a/Sources/NIOIMAP/Grammar/Namespace/Namespace.swift
+++ b/Sources/NIOIMAP/Grammar/Namespace/Namespace.swift
@@ -17,13 +17,14 @@ import NIO
 // MARK: - Encoding
 extension ByteBuffer {
 
-    @discardableResult mutating func writeNamespace(_ namespace: [NIOIMAP.NamespaceDescription]?) -> Int {
-        if let namespace = namespace {
-            return self.writeArray(namespace, separator: "") { (description, self) in
-                self.writeNamespaceDescription(description)
-            }
-        } else {
+    @discardableResult mutating func writeNamespace(_ namespace: [NIOIMAP.NamespaceDescription]) -> Int {
+        
+        guard namespace.count > 0 else {
             return self.writeNil()
+        }
+        
+        return self.writeArray(namespace, separator: "") { (description, self) in
+            self.writeNamespaceDescription(description)
         }
     }
     

--- a/Sources/NIOIMAP/Grammar/Namespace/NamespaceResponse.swift
+++ b/Sources/NIOIMAP/Grammar/Namespace/NamespaceResponse.swift
@@ -18,11 +18,11 @@ extension NIOIMAP {
 
     /// IMAPv4 `Namespace-Response`
     public struct NamespaceResponse: Equatable {
-        public var userNamespace: [NamespaceDescription]?
-        public var otherUserNamespace: [NamespaceDescription]?
-        public var sharedNamespace: [NamespaceDescription]?
+        public var userNamespace: [NamespaceDescription]
+        public var otherUserNamespace: [NamespaceDescription]
+        public var sharedNamespace: [NamespaceDescription]
 
-        public static func userNamespace(_ userNamespace: [NamespaceDescription]?, otherUserNamespace: [NamespaceDescription]?, sharedNamespace: [NamespaceDescription]?) -> Self {
+        public static func userNamespace(_ userNamespace: [NamespaceDescription], otherUserNamespace: [NamespaceDescription], sharedNamespace: [NamespaceDescription]) -> Self {
             return Self(userNamespace: userNamespace, otherUserNamespace: otherUserNamespace, sharedNamespace: sharedNamespace)
         }
     }

--- a/Sources/NIOIMAP/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAP/Parser/GrammarParser.swift
@@ -2401,14 +2401,14 @@ extension NIOIMAP.GrammarParser {
     }
 
     // Namespace         = nil / "(" 1*Namespace-Descr ")"
-    static func parseNamespace(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.NamespaceDescription]? {
+    static func parseNamespace(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.NamespaceDescription] {
 
-        func parseNamespace_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.NamespaceDescription]? {
+        func parseNamespace_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.NamespaceDescription] {
             try self.parseNil(buffer: &buffer, tracker: tracker)
-            return nil
+            return []
         }
 
-        func parseNamespace_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.NamespaceDescription]? {
+        func parseNamespace_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.NamespaceDescription] {
             try ParserLibrary.parseFixedString("(", buffer: &buffer, tracker: tracker)
             let descriptions = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: self.parseNamespaceDescription)
             try ParserLibrary.parseFixedString(")", buffer: &buffer, tracker: tracker)

--- a/Tests/NIOIMAPTests/Grammar/Mailbox/MailboxData+Tests.swift
+++ b/Tests/NIOIMAPTests/Grammar/Mailbox/MailboxData+Tests.swift
@@ -37,7 +37,7 @@ extension MailboxDataTests {
             (.search(NIOIMAP.ESearchResponse(correlator: nil, uid: false, returnData: [.count(1), .count(2)])), "ESEARCH COUNT 1 COUNT 2", #line),
             (.status(.inbox, [.messages(1)]), "STATUS \"INBOX\" (MESSAGES 1)", #line),
             (.status(.inbox, [.messages(1), .unseen(2)]), "STATUS \"INBOX\" (MESSAGES 1 UNSEEN 2)", #line),
-            (.namespace(.userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil)), "NAMESPACE NIL NIL NIL", #line),
+            (.namespace(.userNamespace([], otherUserNamespace: [], sharedNamespace: [])), "NAMESPACE NIL NIL NIL", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPTests/Grammar/Namespace/Namespace+Tests.swift
+++ b/Tests/NIOIMAPTests/Grammar/Namespace/Namespace+Tests.swift
@@ -24,8 +24,8 @@ class Namespace_Tests: EncodeTestClass {
 extension Namespace_Tests {
 
     func testEncode() {
-        let inputs: [([NIOIMAP.NamespaceDescription]?, String, UInt)] = [
-            (nil, "NIL", #line),
+        let inputs: [([NIOIMAP.NamespaceDescription], String, UInt)] = [
+            ([], "NIL", #line),
             ([.string("str1", char: nil, responseExtensions: [])], "((\"str1\" NIL))", #line),
             (
                 [

--- a/Tests/NIOIMAPTests/Grammar/Namespace/NamespaceResponse+Tests.swift
+++ b/Tests/NIOIMAPTests/Grammar/Namespace/NamespaceResponse+Tests.swift
@@ -25,7 +25,7 @@ extension NamespaceResponse_Tests {
 
     func testEncode() {
         let inputs: [(NIOIMAP.NamespaceResponse, String, UInt)] = [
-            (.userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil), "NAMESPACE NIL NIL NIL", #line),
+            (.userNamespace([], otherUserNamespace: [], sharedNamespace: []), "NAMESPACE NIL NIL NIL", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPTests/Grammar/Response/ResponseTextCodeTests.swift
+++ b/Tests/NIOIMAPTests/Grammar/Response/ResponseTextCodeTests.swift
@@ -42,7 +42,7 @@ extension ResponseTextCodeTests {
             (.capability([]), "CAPABILITY IMAP4 IMAP4rev1", #line),
             (.capability([.other("some"), .auth("SSL")]), "CAPABILITY IMAP4 IMAP4rev1 some AUTH=SSL", #line),
             (.capability([.other("some1"), .auth("SSL1"), .other("some2"), .auth("SSL2")]), "CAPABILITY IMAP4 IMAP4rev1 some1 AUTH=SSL1 some2 AUTH=SSL2", #line),
-            (.namespace(.userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil)), "NAMESPACE NIL NIL NIL", #line)
+            (.namespace(.userNamespace([], otherUserNamespace: [], sharedNamespace: [])), "NAMESPACE NIL NIL NIL", #line)
         ]
 
         for (code, expectedString, line) in inputs {

--- a/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
@@ -1966,7 +1966,7 @@ extension ParserUnitTests {
     
     func testParseNamespaceResponse() {
         let inputs: [(String, String, NIOIMAP.NamespaceResponse, UInt)] = [
-            ("NAMESPACE nil nil nil", " ", .userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil), #line),
+            ("NAMESPACE nil nil nil", " ", .userNamespace([], otherUserNamespace: [], sharedNamespace: []), #line),
         ]
         self.iterateTestInputs(inputs, testFunction: NIOIMAP.GrammarParser.parseNamespaceResponse)
     }
@@ -2268,7 +2268,7 @@ extension ParserUnitTests {
             ("UIDNEXT 12", "\r", .uidNext(12), #line),
             ("UIDVALIDITY 34", "\r", .uidValidity(34), #line),
             ("UNSEEN 56", "\r", .unseen(56), #line),
-            ("NAMESPACE NIL NIL NIL", "\r", .namespace(.userNamespace(nil, otherUserNamespace: nil, sharedNamespace: nil)), #line),
+            ("NAMESPACE NIL NIL NIL", "\r", .namespace(.userNamespace([], otherUserNamespace: [], sharedNamespace: [])), #line),
             ("some", "\r", .other("some", nil), #line),
             ("some thing", "\r", .other("some", "thing"), #line),
         ]


### PR DESCRIPTION
Namespaces previously allowed both empty arrays and `nil`, we know only allow empty arrays, and write `nil` automatically.