### PR TITLE
Remove `nil` ID parameter list

### DIFF
--- a/Sources/NIOIMAP/Grammar/Command/CommandType.swift
+++ b/Sources/NIOIMAP/Grammar/Command/CommandType.swift
@@ -48,7 +48,7 @@ extension NIOIMAP {
         case store([NIOIMAP.SequenceRange], [StoreModifier]?, StoreAttributeFlags)
         case search(returnOptions: [SearchReturnOption]?, program: SearchProgram)
         case move([NIOIMAP.SequenceRange], Mailbox)
-        case id([IDParamsListElement]?)
+        case id([IDParameter])
         case namespace
     }
 

--- a/Sources/NIOIMAP/Grammar/ID/ID.swift
+++ b/Sources/NIOIMAP/Grammar/ID/ID.swift
@@ -17,11 +17,11 @@ import NIO
 extension NIOIMAP {
     
     // Exracted from `IDParamsList`
-    public struct IDParamsListElement: Equatable {
-        public var key: ByteBuffer
+    public struct IDParameter: Equatable {
+        public var key: String
         public var value: NString
         
-        public static func key(_ key: ByteBuffer, value: NString) -> Self {
+        public static func key(_ key: String, value: NString) -> Self {
             return Self(key: key, value: value)
         }
     }
@@ -31,30 +31,29 @@ extension NIOIMAP {
 // MARK: - Encoding
 extension ByteBuffer {
     
-    @discardableResult mutating func writeIDParamsListElement(_ element: NIOIMAP.IDParamsListElement) -> Int {
-        self.writeIMAPString(element.key) +
+    @discardableResult mutating func writeIDParameter(_ parameter: NIOIMAP.IDParameter) -> Int {
+        self.writeIMAPString(parameter.key) +
         self.writeSpace() +
-        self.writeNString(element.value)
+        self.writeNString(parameter.value)
     }
     
-    @discardableResult mutating func writeIDParamsList(_ list: [NIOIMAP.IDParamsListElement]?) -> Int {
-        if let array = list {
-            return self.writeArray(array) { (element, self) in
-                self.writeIDParamsListElement(element)
-            }
-        } else {
+    @discardableResult mutating func writeIDParameters(_ array: [NIOIMAP.IDParameter]) -> Int {
+        guard array.count > 0 else {
             return self.writeNil()
+        }
+        return self.writeArray(array) { (element, self) in
+            self.writeIDParameter(element)
         }
     }
     
-    @discardableResult mutating func writeIDResponse(_ response: [NIOIMAP.IDParamsListElement]?) -> Int {
+    @discardableResult mutating func writeIDResponse(_ response: [NIOIMAP.IDParameter]) -> Int {
         self.writeString("ID ") +
-        self.writeIDParamsList(response)
+        self.writeIDParameters(response)
     }
     
-    @discardableResult mutating func writeID(_ id: [NIOIMAP.IDParamsListElement]?) -> Int {
+    @discardableResult mutating func writeID(_ id: [NIOIMAP.IDParameter]) -> Int {
         self.writeString("ID ") +
-        self.writeIDParamsList(id)
+        self.writeIDParameters(id)
     }
     
 }

--- a/Sources/NIOIMAP/Grammar/Response/ResponsePayload.swift
+++ b/Sources/NIOIMAP/Grammar/Response/ResponsePayload.swift
@@ -23,7 +23,7 @@ extension NIOIMAP {
         case messageData(MessageData)
         case capabilityData([Capability])
         case enableData([NIOIMAP.Capability])
-        case id([IDParamsListElement]?)
+        case id([IDParameter])
     }
 
 }

--- a/Sources/NIOIMAP/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAP/Parser/GrammarParser.swift
@@ -1529,7 +1529,7 @@ extension NIOIMAP.GrammarParser {
     }
 
     // id = "ID" SP id-params-list
-    static func parseID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParamsListElement]? {
+    static func parseID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParameter] {
         return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             try ParserLibrary.parseFixedString("ID ", buffer: &buffer, tracker: tracker)
             return try parseIDParamsList(buffer: &buffer, tracker: tracker)
@@ -1537,7 +1537,7 @@ extension NIOIMAP.GrammarParser {
     }
 
     // id-response = "ID" SP id-params-list
-    static func parseIDResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParamsListElement]? {
+    static func parseIDResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParameter] {
         return try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             try ParserLibrary.parseFixedString("ID ", buffer: &buffer, tracker: tracker)
             return try parseIDParamsList(buffer: &buffer, tracker: tracker)
@@ -1545,24 +1545,24 @@ extension NIOIMAP.GrammarParser {
     }
 
     // id-params-list = "(" *(string SP nstring) ")" / nil
-    static func parseIDParamsList(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParamsListElement]? {
+    static func parseIDParamsList(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParameter] {
 
-        func parseIDParamsList_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParamsListElement]? {
+        func parseIDParamsList_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParameter] {
             try self.parseNil(buffer: &buffer, tracker: tracker)
-            return nil
+            return []
         }
 
-        func parseIDParamsList_element(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.IDParamsListElement {
-            let key = try self.parseString(buffer: &buffer, tracker: tracker)
+        func parseIDParamsList_element(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAP.IDParameter {
+            let key = String(buffer: try self.parseString(buffer: &buffer, tracker: tracker))
             try ParserLibrary.parseSpace(buffer: &buffer, tracker: tracker)
             let value = try self.parseNString(buffer: &buffer, tracker: tracker)
             return .key(key, value: value)
         }
 
-        func parseIDParamsList_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParamsListElement]? {
+        func parseIDParamsList_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NIOIMAP.IDParameter] {
             try ParserLibrary.parseFixedString("(", buffer: &buffer, tracker: tracker)
             var array = [try parseIDParamsList_element(buffer: &buffer, tracker: tracker)]
-            try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> NIOIMAP.IDParamsListElement in
+            try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> NIOIMAP.IDParameter in
                 try ParserLibrary.parseSpace(buffer: &buffer, tracker: tracker)
                 return try parseIDParamsList_element(buffer: &buffer, tracker: tracker)
             }

--- a/Tests/NIOIMAPTests/Grammar/ID/ID+Tests.swift
+++ b/Tests/NIOIMAPTests/Grammar/ID/ID+Tests.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import NIO
+@testable import NIOIMAP
+
+class ID_Tests: EncodeTestClass {
+
+}
+
+// MARK: - Encoding
+extension ID_Tests {
+
+    func testEncode() {
+        let inputs: [(NIOIMAP.IDParameter, String, UInt)] = [
+            (.key("key", value: "value"), #""key" "value""#, #line),
+            (.key("key", value: nil), #""key" NIL"#, #line),
+        ]
+
+        for (test, expectedString, line) in inputs {
+            self.testBuffer.clear()
+            let size = self.testBuffer.writeIDParameter(test)
+            XCTAssertEqual(size, expectedString.utf8.count, line: line)
+            XCTAssertEqual(self.testBufferString, expectedString, line: line)
+        }
+    }
+    
+    func testEncode_array() {
+        let inputs: [([NIOIMAP.IDParameter], String, UInt)] = [
+            ([], "NIL", #line),
+            ([.key("key", value: "value")], #"("key" "value")"#, #line),
+        ]
+
+        for (test, expectedString, line) in inputs {
+            self.testBuffer.clear()
+            let size = self.testBuffer.writeIDParameters(test)
+            XCTAssertEqual(size, expectedString.utf8.count, line: line)
+            XCTAssertEqual(self.testBufferString, expectedString, line: line)
+        }
+    }
+    
+}

--- a/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPTests/Parser/IMAPParserTests.swift
@@ -1482,8 +1482,8 @@ extension ParserUnitTests {
 extension ParserUnitTests {
     
     func testParseIDParamsList() {
-        let inputs: [(String, String, [NIOIMAP.IDParamsListElement]?, UInt)] = [
-            ("NIL", " ", nil, #line),
+        let inputs: [(String, String, [NIOIMAP.IDParameter], UInt)] = [
+            ("NIL", " ", [], #line),
             (#"("key1" "value1")"#, "" , [.key("key1", value: "value1")], #line),
             (
                 #"("key1" "value1" "key2" "value2" "key3" "value3")"#,


### PR DESCRIPTION
Same as the other couple of PRs. Previously we allowed both `nil` and empty arrays of ID parameters. Now we only allow empty arrays, and we'll handle writing `nil` for you. Also added some missing tests for encoding ID parameters.