### PR TITLE
Cleanup of ByteBuffer NIO usage

### DIFF
--- a/Sources/NIOIMAPCore/_ByteBufferProtocol.swift
+++ b/Sources/NIOIMAPCore/_ByteBufferProtocol.swift
@@ -735,5 +735,5 @@ protocol _ByteBufferViewAPITemplate where Self: RandomAccessCollection, Self: Mu
     ///   *m* is the length of `newElements`. If the call to this method simply
     ///   appends the contents of `newElements` to the collection, this method is
     ///   equivalent to `append(contentsOf:)`.
-    mutating func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C: Collection, C.Element == NIO.ByteBufferView.Element
+    mutating func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C: Collection, C.Element == ByteBufferView.Element
 }


### PR DESCRIPTION
Change `import NIO` to targeted `import`s to make it clear what needs to be implemented for bring-your-own-I/O.

Remove `NIO` prefix from `NIO.ByteBufferView` usage.