### PR TITLE
Use #filePath instead of #file

### DIFF
--- a/Tests/NIOIMAPCoreTests/Parser/SynchronizingLiteralParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/SynchronizingLiteralParserTests.swift
@@ -184,7 +184,7 @@ final class SynchronizingLiteralParserTests: XCTestCase {
     }
 
     private func assertMultipleParses(_ expectedStrings: [String], continuationsNecessary: Int = 0,
-                                      file: StaticString = #file,
+                                      file: StaticString = #filePath,
                                       line: UInt = #line) {
         guard expectedStrings.count == self.parses.count else {
             XCTFail("Unexpected number of parses: \(self.parses.count)", file: file, line: line)
@@ -216,7 +216,7 @@ final class SynchronizingLiteralParserTests: XCTestCase {
     }
 
     private func assertOneParse(_ string: String, continuationsNecessary: Int = 0,
-                                file: StaticString = #file,
+                                file: StaticString = #filePath,
                                 line: UInt = #line) {
         XCTAssertEqual(1, self.parses.count)
         guard let parse = self.parses.first else {

--- a/Tests/NIOIMAPCoreTests/TestUtilities.swift
+++ b/Tests/NIOIMAPCoreTests/TestUtilities.swift
@@ -37,7 +37,7 @@ extension TestUtilities {
     static func withBuffer(_ string: String,
                            terminator: String = "",
                            shouldRemainUnchanged: Bool = false,
-                           file: StaticString = #file, line: UInt = #line, _ body: (inout ByteBuffer) throws -> Void) {
+                           file: StaticString = #filePath, line: UInt = #line, _ body: (inout ByteBuffer) throws -> Void) {
         var inputBuffer = ByteBufferAllocator().buffer(capacity: string.utf8.count + terminator.utf8.count + 10)
         inputBuffer.writeString("hello")
         inputBuffer.moveReaderIndex(forwardBy: 5)

--- a/Tests/NIOIMAPTests/TestUtilities.swift
+++ b/Tests/NIOIMAPTests/TestUtilities.swift
@@ -36,7 +36,7 @@ extension TestUtilities {
     static func withBuffer(_ string: String,
                            terminator: String = "",
                            shouldRemainUnchanged: Bool = false,
-                           file: StaticString = #file, line: UInt = #line, _ body: (inout ByteBuffer) throws -> Void) {
+                           file: StaticString = #filePath, line: UInt = #line, _ body: (inout ByteBuffer) throws -> Void) {
         var inputBuffer = ByteBufferAllocator().buffer(capacity: string.utf8.count + terminator.utf8.count + 10)
         inputBuffer.writeString("hello")
         inputBuffer.moveReaderIndex(forwardBy: 5)


### PR DESCRIPTION
_note_: This won't pass CI until we add support for 5.3 and drop support for the other 2, which I think is the plan.

This silences compiler warnings as the default argument to our helper functions used `#file`, but the XCT methods default to `#filePath`.