### PR TITLE
Re-add warnings as errors

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -swiftc -Xswiftc -warnings-as-errors --enable-test-discovery $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery $${SANITIZER_ARG-}"
 
   # util
 


### PR DESCRIPTION
Resolves #117 

Previously removed as NIO had some warnings in. These have been fixed, so we're ready to go.