### PR TITLE
Call namespace parser in mailbox data parser

### DIFF
--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -1811,7 +1811,7 @@ extension GrammarParser {
             try ParserLibrary.parseFixedString(" RECENT", buffer: &buffer, tracker: tracker)
             return .exists(number)
         }
-        
+
         func parseMailboxData_namespace(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxName.Data {
             .namespace(try self.parseNamespaceResponse(buffer: &buffer, tracker: tracker))
         }
@@ -1825,7 +1825,7 @@ extension GrammarParser {
             parseMailboxData_exists,
             parseMailboxData_recent,
             parseMailboxData_search,
-            parseMailboxData_namespace
+            parseMailboxData_namespace,
         ], buffer: &buffer, tracker: tracker)
     }
 

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -1398,7 +1398,7 @@ extension ParserUnitTests {
             ("SEARCH", "\r\n", .search([]), #line),
             ("SEARCH 1", "\r\n", .search([1]), #line),
             ("SEARCH 1 2 3 4 5", "\r\n", .search([1, 2, 3, 4, 5]), #line),
-            ("NAMESPACE NIL NIL NIL", "\r\n", .namespace(.init(userNamespace: [], otherUserNamespace: [], sharedNamespace: [])), #line)
+            ("NAMESPACE NIL NIL NIL", "\r\n", .namespace(.init(userNamespace: [], otherUserNamespace: [], sharedNamespace: [])), #line),
         ]
         self.iterateTestInputs(inputs, testFunction: GrammarParser.parseMailboxData)
     }


### PR DESCRIPTION
Resolves #141 

We weren't previously calling the namespace parser inside mailbox data, now we do. This bug meant that the proxy would occasionally break whenever Mail.app requested the namespace for a given mailbox.