### PR TITLE
don't make the user install SwiftFormat

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,10 +8,11 @@ let package = Package(
     products: [
         .library(name: "NIOIMAP", targets: ["NIOIMAPCore"]),
     ], dependencies: [
-        .package(url: "https://github.com/apple/swift-nio", from: "2.16.0"),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.17.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.7.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.2.0"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat.git", .exact("0.44.10")),
     ],
     targets: [
         .target(
@@ -75,6 +76,13 @@ let package = Package(
                 "NIOIMAP",
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
+            ]
+        ),
+
+        .target(
+            name: "NIOIMAPFormatter",
+            dependencies: [
+                .product(name: "swiftformat", package: "SwiftFormat"),
             ]
         ),
     ]

--- a/Sources/NIOIMAPFormatter/main.swift
+++ b/Sources/NIOIMAPFormatter/main.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+#if os(Linux) || os(macOS)
+let filePath: String
+#if compiler(>=5.3)
+filePath = #filePath
+#else
+filePath = #file
+#endif
+let swiftFormat = URL(fileURLWithPath: CommandLine.arguments.first!)
+    .deletingLastPathComponent()
+    .appendingPathComponent("swiftformat")
+let sourceCode = URL(fileURLWithPath: filePath)
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+
+if #available(macOS 10.13, /* Linux */ *) {
+    print("Alright, let's format the source code in \(sourceCode) using \(swiftFormat).")
+    let process = Process()
+    process.executableURL = swiftFormat
+    process.arguments = [sourceCode.path]
+    try process.run()
+    process.waitUntilExit()
+    switch process.terminationReason {
+    case .exit:
+        exit(process.terminationStatus)
+    case .uncaughtSignal:
+        kill(getpid(), process.terminationStatus)
+    #if canImport(Darwin)
+    @unknown default:
+        exit(process.terminationStatus)
+    #endif
+    }
+}
+#endif
+
+// Fallthrough, something wasn't right
+print("ERROR: Unsupported OS\n")
+exit(EXIT_FAILURE)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,10 +27,3 @@ RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 # script to allow mapping framepointers on linux (until part of the toolchain)
 RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.tools/symbolicate-linux-fatal
 RUN chmod 755 $HOME/.tools/symbolicate-linux-fatal
-
-# swiftformat (until part of the toolchain)
-
-ARG swiftformat_version=0.44.6
-RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
-RUN cd $HOME/.tools/swift-format && swift build -c release
-RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,8 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery $${SANITIZER_ARG-}"
+    # no -warnings-as-errors until https://github.com/nicklockwood/SwiftFormat/issues/628 is fixed
+    command: /bin/bash -xcl "swift test --enable-test-discovery $${SANITIZER_ARG-}"
 
   # util
 

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -23,7 +23,7 @@ function replace_acceptable_years() {
 
 printf "=> Checking format... "
 FIRST_OUT="$(git status --porcelain)"
-swiftformat . > /dev/null 2>&1
+swift run -c release NIOIMAPFormatter > /dev/null 2>&1
 SECOND_OUT="$(git status --porcelain)"
 if [[ "$FIRST_OUT" != "$SECOND_OUT" ]]; then
   printf "\033[0;31mformatting issues!\033[0m\n"


### PR DESCRIPTION
Motivation:

Requiring the user to install SwiftFormat is very hostile. First, we
shouldn't require them to install random tools. Second, it'll only work
if the user and the CI use the _exact same_ version of SwiftFormat.

Modification:

- Use SwiftPM to get SwiftFormat

Result:

scripts/sanity does more actual sanity.