### PR TITLE
Make the `MailboxAttribute` names follow Swift style guidelines.

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxAttribute.swift
@@ -16,13 +16,13 @@ import struct NIO.ByteBuffer
 
 /// IMAPv4 `status-att`
 public enum MailboxAttribute: String, CaseIterable {
-    case messages = "MESSAGES"
-    case recent = "RECENT"
-    case uidnext = "UIDNEXT"
-    case uidvalidity = "UIDVALIDITY"
-    case unseen = "UNSEEN"
+    case messageCount = "MESSAGES"
+    case recentCount = "RECENT"
+    case uidNext = "UIDNEXT"
+    case uidValidity = "UIDVALIDITY"
+    case unseenCount = "UNSEEN"
     case size = "SIZE"
-    case highestModSeq = "HIGHESTMODSEQ"
+    case highestModificationSequence = "HIGHESTMODSEQ"
 }
 
 /// IMAPv4 `status-att-val`

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxAttribute+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxAttribute+Tests.swift
@@ -24,7 +24,7 @@ extension MailboxAttribute_Tests {
     func testEncode() {
         let inputs: [([MailboxAttribute], String, UInt)] = [
             ([], "", #line),
-            ([MailboxAttribute.messages, .recent, .unseen], "MESSAGES RECENT UNSEEN", #line),
+            ([MailboxAttribute.messageCount, .recentCount, .unseenCount], "MESSAGES RECENT UNSEEN", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxValue+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxValue+Tests.swift
@@ -23,8 +23,8 @@ class MailboxValue_Tests: EncodeTestClass {}
 extension MailboxValue_Tests {
     func testEncode_statusOption() {
         let inputs: [([MailboxAttribute], String, UInt)] = [
-            ([.messages], "STATUS (MESSAGES)", #line),
-            ([.messages, .size, .recent], "STATUS (MESSAGES SIZE RECENT)", #line),
+            ([.messageCount], "STATUS (MESSAGES)", #line),
+            ([.messageCount, .size, .recentCount], "STATUS (MESSAGES SIZE RECENT)", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Grammar/ReturnOption+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/ReturnOption+Tests.swift
@@ -25,7 +25,7 @@ extension ReturnOption_Tests {
         let inputs: [(ReturnOption, String, UInt)] = [
             (.subscribed, "SUBSCRIBED", #line),
             (.children, "CHILDREN", #line),
-            (.statusOption([.messages]), "STATUS (MESSAGES)", #line),
+            (.statusOption([.messageCount]), "STATUS (MESSAGES)", #line),
             (.optionExtension(.init(type: .standard("atom"), value: nil)), "atom", #line),
         ]
 

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -2560,8 +2560,8 @@ extension ParserUnitTests {
 extension ParserUnitTests {
     func testParseStatus() {
         let inputs: [(String, String, Command, UInt)] = [
-            ("STATUS inbox (messages unseen)", "\r\n", .status(.inbox, [.messages, .unseen]), #line),
-            ("STATUS Deleted (messages unseen HIGHESTMODSEQ)", "\r\n", .status(MailboxName("Deleted"), [.messages, .unseen, .highestModSeq]), #line),
+            ("STATUS inbox (messages unseen)", "\r\n", .status(.inbox, [.messageCount, .unseenCount]), #line),
+            ("STATUS Deleted (messages unseen HIGHESTMODSEQ)", "\r\n", .status(MailboxName("Deleted"), [.messageCount, .unseenCount, .highestModificationSequence]), #line),
         ]
         self.iterateTestInputs(inputs, testFunction: GrammarParser.parseStatus)
     }

--- a/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
@@ -67,8 +67,8 @@ final class RoundtripTests: XCTestCase {
             (.lsub(.inbox, "\"something\""), #line),
             (.lsub(MailboxName("bar"), "{3}\r\nfoo"), #line),
 
-            (.status(.inbox, [.messages]), #line),
-            (.status(MailboxName("foobar"), [.messages, .recent, .uidnext]), #line),
+            (.status(.inbox, [.messageCount]), #line),
+            (.status(MailboxName("foobar"), [.messageCount, .recentCount, .uidNext]), #line),
 
             (.copy([2, .wildcard], .inbox), #line),
 


### PR DESCRIPTION
Make the `MailboxAttribute` names follow Swift style guidelines.