### PR TITLE
Remove Body.Basic type

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Body/Singlepart.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Singlepart.swift
@@ -33,18 +33,9 @@ extension BodyStructure {
 
 extension BodyStructure.Singlepart {
     public indirect enum Kind: Equatable {
-        case basic(Basic)
+        case basic(Media.Basic)
         case message(Message)
         case text(Text)
-    }
-
-    /// IMAPv4 `body-type-basic`
-    public struct Basic: Equatable {
-        public var media: Media.Basic
-
-        public init(media: Media.Basic) {
-            self.media = media
-        }
     }
 
     /// IMAPv4 `body-type-message`
@@ -93,7 +84,7 @@ extension EncodeBuffer {
         var size = 0
         switch part.type {
         case .basic(let basic):
-            size += self.writeBodyTypeBasic(basic, fields: part.fields)
+            size += self.writeBodyTypeBasic(mediaType: basic, fields: part.fields)
         case .message(let message):
             size += self.writeBodyTypeMessage(message, fields: part.fields)
         case .text(let text):
@@ -125,8 +116,8 @@ extension EncodeBuffer {
             self.writeString(" \(message.fieldLines)")
     }
 
-    @discardableResult private mutating func writeBodyTypeBasic(_ body: BodyStructure.Singlepart.Basic, fields: BodyStructure.Fields) -> Int {
-        self.writeMediaBasic(body.media) +
+    @discardableResult private mutating func writeBodyTypeBasic(mediaType: Media.Basic, fields: BodyStructure.Fields) -> Int {
+        self.writeMediaBasic(mediaType) +
             self.writeSpace() +
             self.writeBodyFields(fields)
     }

--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -462,9 +462,8 @@ extension GrammarParser {
             let media = try self.parseMediaBasic(buffer: &buffer, tracker: tracker)
             try ParserLibrary.parseSpace(buffer: &buffer, tracker: tracker)
             let fields = try self.parseBodyFields(buffer: &buffer, tracker: tracker)
-            let basic = BodyStructure.Singlepart.Basic(media: media)
             let ext = try parseBodyTypeSinglePart_extension(buffer: &buffer, tracker: tracker)
-            return BodyStructure.Singlepart(type: .basic(basic), fields: fields, extension: ext)
+            return BodyStructure.Singlepart(type: .basic(media), fields: fields, extension: ext)
         }
 
         func parseBodyTypeSinglePart_message(buffer: inout ByteBuffer, tracker: StackTracker) throws -> BodyStructure.Singlepart {

--- a/Tests/NIOIMAPCoreTests/Grammar/Body/Type/BodySinglepartTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Body/Type/BodySinglepartTests.swift
@@ -25,7 +25,7 @@ extension BodySinglepartTests {
         let inputs: [(BodyStructure.Singlepart, String, UInt)] = [
             (
                 .init(
-                    type: .basic(.init(media: .init(type: .application, subtype: .alternative))),
+                    type: .basic(.init(type: .application, subtype: .alternative)),
                     fields: .init(parameter: [], id: nil, description: nil, encoding: .base64, octets: 6),
                     extension: nil
                 ),
@@ -34,7 +34,7 @@ extension BodySinglepartTests {
             ),
             (
                 .init(
-                    type: .basic(.init(media: .init(type: .application, subtype: .related))),
+                    type: .basic(.init(type: .application, subtype: .related)),
                     fields: .init(parameter: [], id: nil, description: nil, encoding: .base64, octets: 7),
                     extension: .init(fieldMD5: "md5", dspLanguage: nil)
                 ),

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -522,7 +522,7 @@ extension ParserUnitTests {
                 "\"AUDIO\" \"multipart/alternative\" NIL NIL NIL \"BASE64\" 1",
                 "\r\n",
                 .init(
-                    type: .basic(.init(media: .init(type: .audio, subtype: .alternative))),
+                    type: .basic(.init(type: .audio, subtype: .alternative)),
                     fields: .init(parameter: [], id: nil, description: nil, encoding: .base64, octets: 1),
                     extension: nil
                 ),
@@ -532,7 +532,7 @@ extension ParserUnitTests {
                 "\"APPLICATION\" \"multipart/mixed\" NIL \"id\" \"description\" \"7BIT\" 2",
                 "\r\n",
                 .init(
-                    type: .basic(.init(media: .init(type: .application, subtype: .mixed))),
+                    type: .basic(.init(type: .application, subtype: .mixed)),
                     fields: .init(parameter: [], id: "id", description: "description", encoding: .sevenBit, octets: 2),
                     extension: nil
                 ),
@@ -542,7 +542,7 @@ extension ParserUnitTests {
                 "\"VIDEO\" \"multipart/related\" (\"f1\" \"v1\") NIL NIL \"8BIT\" 3",
                 "\r\n",
                 .init(
-                    type: .basic(.init(media: .init(type: .video, subtype: .related))),
+                    type: .basic(.init(type: .video, subtype: .related)),
                     fields: .init(parameter: [.init(field: "f1", value: "v1")], id: nil, description: nil, encoding: .eightBit, octets: 3),
                     extension: nil
                 ),
@@ -559,7 +559,7 @@ extension ParserUnitTests {
                         .init(
                             message: .rfc822,
                             envelope: Envelope(date: nil, subject: nil, from: [], sender: [], reply: [], to: [], cc: [], bcc: [], inReplyTo: nil, messageID: nil),
-                            body: .singlepart(.init(type: .basic(.init(media: .init(type: .image, subtype: .related))), fields: .init(parameter: [], id: nil, description: nil, encoding: .binary, octets: 5))),
+                            body: .singlepart(.init(type: .basic(.init(type: .image, subtype: .related)), fields: .init(parameter: [], id: nil, description: nil, encoding: .binary, octets: 5))),
                             fieldLines: 8
                         )
                     ),


### PR DESCRIPTION
Resolves #118 

`Body.Basic` contained only a single `Media.Basic`, so we might as well defer directly to `Media.Basic` anyway.