### PR TITLE
Fix writing the start of a fetch response

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Response/Response.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/Response.swift
@@ -83,8 +83,8 @@ extension EncodeBuffer {
 
     @discardableResult mutating func writeFetchResponse(_ response: FetchResponse) -> Int {
         switch response {
-        case .start:
-            return self.writeString("(")
+        case .start(let num):
+            return self.writeString("* \(num) FETCH (")
         case .simpleAttribute(let att):
             if case .server(streamingAttributes: true) = self.mode {
                 return self.writeSpace() + self.writeMessageAttribute(att)

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/Response+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/Response+Tests.swift
@@ -23,11 +23,11 @@ class Response_Tests: EncodeTestClass {}
 extension Response_Tests {
     func testEncode_fetchResponse_multiple() {
         let inputs: [([NIOIMAPCore.FetchResponse], String, UInt)] = [
-            ([.start(1), .simpleAttribute(.rfc822Size(123)), .finish], "(RFC822.SIZE 123)\r\n", #line),
-            ([.start(1), .simpleAttribute(.uid(123)), .simpleAttribute(.rfc822Size(456)), .finish], "(UID 123 RFC822.SIZE 456)\r\n", #line),
+            ([.start(1), .simpleAttribute(.rfc822Size(123)), .finish], "* 1 FETCH (RFC822.SIZE 123)\r\n", #line),
+            ([.start(2), .simpleAttribute(.uid(123)), .simpleAttribute(.rfc822Size(456)), .finish], "* 2 FETCH (UID 123 RFC822.SIZE 456)\r\n", #line),
             (
-                [.start(1), .simpleAttribute(.uid(123)), .streamingBegin(type: .rfc822, byteCount: 0), .streamingEnd, .simpleAttribute(.uid(456)), .finish],
-                "(UID 123 RFC822.TEXT {0}\r\n UID 456)\r\n",
+                [.start(3), .simpleAttribute(.uid(123)), .streamingBegin(type: .rfc822, byteCount: 0), .streamingEnd, .simpleAttribute(.uid(456)), .finish],
+                "* 3 FETCH (UID 123 RFC822.TEXT {0}\r\n UID 456)\r\n",
                 #line
             ),
         ]


### PR DESCRIPTION
Resolves #159 

When writing a fetch response we weren't writing the first part, which is obviously a major flaw. This meant that a response couldn't be identified.

Fixed the test, and also started adding roundtrip tests to try and prevent future regressions.