### PR TITLE
Expose NIOIMAP target under NIOIMAP product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "swift-nio-email",
     products: [
-        .library(name: "NIOIMAP", targets: ["NIOIMAPCore"]),
+        .library(name: "NIOIMAP", targets: ["NIOIMAP"]),
     ], dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.17.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.4.0"),


### PR DESCRIPTION
Expose `NIOIMAP` target under `NIOIMAP` as the docs intended.

### Motivation:

Currently `NIOIMAP` product exports `NIOIMAPCore` target, but that is effectively internal implementation. Also, the docs talk about importing `NIOIMAP` module.

### Modifications:

`NIOIMAP` library product now contains `NIOIMAP` target and nothing else.

### Result:

The right target is exposed.