### PR TITLE
Don't defer to literal8

### DIFF
--- a/Sources/NIOIMAPCore/ByteBuffer+WriteLiteral.swift
+++ b/Sources/NIOIMAPCore/ByteBuffer+WriteLiteral.swift
@@ -25,7 +25,8 @@ extension EncodeBuffer {
 
     fileprivate mutating func writeIMAPString<T: Collection>(_ bytes: T) -> Int where T.Element == UInt8 {
         // allSatisfy vs contains because IMO it's a little clearer
-        let canUseQuoted = bytes.allSatisfy { $0.isQuotedChar }
+        // if more than 70 bytes, always use a literal
+        let canUseQuoted = bytes.count <= 70 && bytes.allSatisfy { $0.isQuotedChar }
 
         if canUseQuoted {
             return self.writeString("\"") + self.writeBytes(bytes) + self.writeString("\"")

--- a/Tests/NIOIMAPCoreTests/Grammar/ByteBufferWriteLiteralTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/ByteBufferWriteLiteralTests.swift
@@ -29,6 +29,12 @@ extension ByteBufferWriteLiteralTests {
             (ByteBuffer(ByteBufferView(repeating: UInt8(ascii: "\\"), count: 1)), [], "{1}\r\n\\", #line),
             ("\\\"", [], "{2}\r\n\\\"", #line),
             ("a", [], "\"a\"", #line),
+            (
+                "01234567890123456789012345678901234567890123456789012345678901234567890",
+                [],
+                "{71}\r\n01234567890123456789012345678901234567890123456789012345678901234567890",
+                #line
+            ),
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeIMAPString($0) })
     }


### PR DESCRIPTION
Resolves #206 

We incorrectly deferred to writing a literal8 if a string was found to contain a NUL byte. This wasn't valid, as `literal8` is only valid in one very specific case, which is not when writing a generic IMAP string.