### PR TITLE
Encode FETCH attributes using macros when possible.

### DIFF
--- a/Tests/NIOIMAPCoreTests/Grammar/Fetch/FetchAttributeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Fetch/FetchAttributeTests.swift
@@ -40,4 +40,19 @@ extension FetchAttributeTests {
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeFetchAttribute($0) })
     }
+
+    func testEncodeList() {
+        let inputs: [([FetchAttribute], EncodingCapabilities, String, UInt)] = [
+            ([.envelope], [], "(ENVELOPE)", #line),
+            ([.flags, .internalDate, .rfc822(.size)], [], "FAST", #line),
+            ([.internalDate, .rfc822(.size), .flags], [], "FAST", #line),
+            ([.flags, .internalDate, .rfc822(.size), .envelope], [], "ALL", #line),
+            ([.rfc822(.size), .flags, .envelope, .internalDate], [], "ALL", #line),
+            ([.flags, .internalDate, .rfc822(.size), .envelope, .bodyStructure(extensions: false)], [], "FULL", #line),
+            ([.flags, .bodyStructure(extensions: false), .rfc822(.size), .internalDate, .envelope], [], "FULL", #line),
+            ([.flags, .bodyStructure(extensions: true), .rfc822(.size), .internalDate, .envelope], [], "(FLAGS BODYSTRUCTURE RFC822.SIZE INTERNALDATE ENVELOPE)", #line),
+            ([.flags, .bodyStructure(extensions: false), .rfc822(.size), .internalDate, .envelope, .uid], [], "(FLAGS BODY RFC822.SIZE INTERNALDATE ENVELOPE UID)", #line),
+        ]
+        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeFetchAttributeList($0) })
+    }
 }


### PR DESCRIPTION
RFC 3501 section 6.4.5 “FETCH Command”:
> There are three macros which specify commonly-used sets of data items, and can be used instead of data items.  A macro must be used by itself, and not in conjunction with other macros or data items.
>
> `ALL`
>    Macro equivalent to: `(FLAGS INTERNALDATE RFC822.SIZE ENVELOPE)`
>
> `FAST`
>    Macro equivalent to: `(FLAGS INTERNALDATE RFC822.SIZE)`
>
> `FULL`
>    Macro equivalent to: `(FLAGS INTERNALDATE RFC822.SIZE ENVELOPE BODY)`


