### PR TITLE
Use flag case from RFC 3501 for system flags.

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Flag/Flag.swift
+++ b/Sources/NIOIMAPCore/Grammar/Flag/Flag.swift
@@ -87,15 +87,15 @@ extension EncodeBuffer {
     @discardableResult mutating func writeFlag(_ flag: Flag) -> Int {
         switch flag._backing {
         case .answered:
-            return self.writeString("\\ANSWERED")
+            return self.writeString("\\Answered")
         case .flagged:
-            return self.writeString("\\FLAGGED")
+            return self.writeString("\\Flagged")
         case .deleted:
-            return self.writeString("\\DELETED")
+            return self.writeString("\\Deleted")
         case .seen:
-            return self.writeString("\\SEEN")
+            return self.writeString("\\Seen")
         case .draft:
-            return self.writeString("\\DRAFT")
+            return self.writeString("\\Draft")
         case .keyword(let keyword):
             return self.writeFlagKeyword(keyword)
         case .extension(let x):

--- a/Tests/NIOIMAPCoreTests/Grammar/Append/AppendOptions+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Append/AppendOptions+Tests.swift
@@ -24,8 +24,8 @@ extension AppendOptions_Tests {
 
         let inputs: [(AppendOptions, String, UInt)] = [
             (.init(flagList: [], internalDate: nil, extensions: []), "", #line),
-            (.init(flagList: [.answered], internalDate: nil, extensions: []), " (\\ANSWERED)", #line),
-            (.init(flagList: [.answered], internalDate: date, extensions: []), " (\\ANSWERED) \"25-jun-1994 01:02:03 +0000\"", #line),
+            (.init(flagList: [.answered], internalDate: nil, extensions: []), " (\\Answered)", #line),
+            (.init(flagList: [.answered], internalDate: date, extensions: []), " (\\Answered) \"25-jun-1994 01:02:03 +0000\"", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Grammar/Flag/Flag+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Flag/Flag+Tests.swift
@@ -44,11 +44,11 @@ extension Flag_Tests {
 extension Flag_Tests {
     func testEncode() {
         let inputs: [(Flag, String, UInt)] = [
-            (.answered, "\\ANSWERED", #line),
-            (.deleted, "\\DELETED", #line),
-            (.draft, "\\DRAFT", #line),
-            (.flagged, "\\FLAGGED", #line),
-            (.seen, "\\SEEN", #line),
+            (.answered, "\\Answered", #line),
+            (.deleted, "\\Deleted", #line),
+            (.draft, "\\Draft", #line),
+            (.flagged, "\\Flagged", #line),
+            (.seen, "\\Seen", #line),
             (.extension("\\extension"), "\\EXTENSION", #line),
             (.keyword(.forwarded), "$FORWARDED", #line),
         ]

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxData+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxData+Tests.swift
@@ -24,7 +24,7 @@ extension MailboxDataTests {
     func testEncode() {
         let inputs: [(MailboxName.Data, String, UInt)] = [
             (.exists(1), "1 EXISTS", #line),
-            (.flags([.answered, .deleted]), "FLAGS (\\ANSWERED \\DELETED)", #line),
+            (.flags([.answered, .deleted]), "FLAGS (\\Answered \\Deleted)", #line),
             (.list(MailboxInfo(attributes: [], pathSeparator: nil, mailbox: .inbox, extensions: [])), "LIST () \"INBOX\"", #line),
             (
                 .lsub(.init(attributes: [.init("\\draft")], pathSeparator: ".", mailbox: .init("Drafts"), extensions: [])),

--- a/Tests/NIOIMAPCoreTests/Grammar/Message/MessageAtributesTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Message/MessageAtributesTests.swift
@@ -38,8 +38,8 @@ extension MessageAttributesTests {
             (.binarySize(section: [2], size: 3), "BINARY.SIZE[2] 3", #line),
             (.binary(section: [3], data: nil), "BINARY[3] NIL", #line),
             (.binary(section: [3], data: "test"), "BINARY[3] \"test\"", #line),
-            (.flags([.draft]), "FLAGS (\\DRAFT)", #line),
-            (.flags([.flagged, .draft]), "FLAGS (\\FLAGGED \\DRAFT)", #line),
+            (.flags([.draft]), "FLAGS (\\Draft)", #line),
+            (.flags([.flagged, .draft]), "FLAGS (\\Flagged \\Draft)", #line),
         ]
 
         for (test, expectedString, line) in inputs {
@@ -52,9 +52,9 @@ extension MessageAttributesTests {
 
     func testEncode_multiple() {
         let inputs: [([MessageAttribute], String, UInt)] = [
-            ([.flags([.draft])], "(FLAGS (\\DRAFT))", #line),
-            ([.flags([.flagged]), .rfc822Size(123)], "(FLAGS (\\FLAGGED) RFC822.SIZE 123)", #line),
-            ([.flags([.flagged]), .rfc822Size(123), .uid(456)], "(FLAGS (\\FLAGGED) RFC822.SIZE 123 UID 456)", #line),
+            ([.flags([.draft])], "(FLAGS (\\Draft))", #line),
+            ([.flags([.flagged]), .rfc822Size(123)], "(FLAGS (\\Flagged) RFC822.SIZE 123)", #line),
+            ([.flags([.flagged]), .rfc822Size(123), .uid(456)], "(FLAGS (\\Flagged) RFC822.SIZE 123 UID 456)", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/PermanentFlagTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/PermanentFlagTests.swift
@@ -30,7 +30,7 @@ extension PermanentFlagTests {
     }
 
     func testEncoding_flag() {
-        let expected = "\\ANSWERED"
+        let expected = "\\Answered"
         let flag = PermanentFlag.flag(.answered)
         let size = self.testBuffer.writeFlagPerm(flag)
         XCTAssertEqual(size, expected.utf8.count)

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/ResponseTextCodeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/ResponseTextCodeTests.swift
@@ -34,7 +34,7 @@ extension ResponseTextCodeTests {
             (.badCharset(["some", "string"]), "BADCHARSET (some string)", #line),
             (.permanentFlags([.wildcard]), #"PERMANENTFLAGS (\*)"#, #line),
             (.permanentFlags([.wildcard, .wildcard]), #"PERMANENTFLAGS (\* \*)"#, #line),
-            (.permanentFlags([.flag(.deleted), .flag(.draft)]), #"PERMANENTFLAGS (\DELETED \DRAFT)"#, #line),
+            (.permanentFlags([.flag(.deleted), .flag(.draft)]), #"PERMANENTFLAGS (\Deleted \Draft)"#, #line),
             (.other("some", nil), "some", #line),
             (.other("some", "thing"), "some thing", #line),
             (.capability([]), "CAPABILITY IMAP4 IMAP4rev1", #line),

--- a/Tests/NIOIMAPCoreTests/Grammar/StoreAttributeFlags+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/StoreAttributeFlags+Tests.swift
@@ -23,12 +23,12 @@ class StoreAttributeFlags_Tests: EncodeTestClass {}
 extension StoreAttributeFlags_Tests {
     func testEncode() {
         let inputs: [(StoreFlags, String, UInt)] = [
-            (.add(silent: true, list: [.answered]), "+FLAGS.SILENT (\\ANSWERED)", #line),
-            (.add(silent: false, list: [.draft]), "+FLAGS (\\DRAFT)", #line),
-            (.remove(silent: true, list: [.deleted]), "-FLAGS.SILENT (\\DELETED)", #line),
-            (.remove(silent: false, list: [.flagged]), "-FLAGS (\\FLAGGED)", #line),
-            (.replace(silent: true, list: [.seen]), "FLAGS.SILENT (\\SEEN)", #line),
-            (.replace(silent: false, list: [.deleted]), "FLAGS (\\DELETED)", #line),
+            (.add(silent: true, list: [.answered]), "+FLAGS.SILENT (\\Answered)", #line),
+            (.add(silent: false, list: [.draft]), "+FLAGS (\\Draft)", #line),
+            (.remove(silent: true, list: [.deleted]), "-FLAGS.SILENT (\\Deleted)", #line),
+            (.remove(silent: false, list: [.flagged]), "-FLAGS (\\Flagged)", #line),
+            (.replace(silent: true, list: [.seen]), "FLAGS.SILENT (\\Seen)", #line),
+            (.replace(silent: false, list: [.deleted]), "FLAGS (\\Deleted)", #line),
         ]
 
         for (test, expectedString, line) in inputs {


### PR DESCRIPTION
`\Answered` instead of `\ANSWERED` — that’s how RFC 3501 shows those flags. Just stylistic, since flags are case insensitive.