### PR TITLE
Allow continuation request without space or text.

### DIFF
--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -814,6 +814,24 @@ extension ParserUnitTests {
     }
 }
 
+// MARK: - Parse Continue Request
+
+extension ParserUnitTests {
+    func testContinueRequest_valid() {
+        let inputs: [(String, UInt)] = [
+            ("+ Ready for additional command text\r\n", #line),
+            ("+ \r\n", #line),
+            ("+\r\n", #line), // This is not standard conformant, but we’re allowing this.
+        ]
+
+        for (input, line) in inputs {
+            TestUtilities.withBuffer(input, terminator: " ") { (buffer) in
+                XCTAssertNoThrow(try GrammarParser.parseContinueRequest(buffer: &buffer, tracker: .testTracker), line: line)
+            }
+        }
+    }
+}
+
 // MARK: - copy parseCopy
 
 extension ParserUnitTests {


### PR DESCRIPTION
Usually a continuation request looks like
```
+ Ready for additional command text␍␊
```
This changes the parser to also allow
```
+␍␊
```
even though RFC 3501 requires a space after the `+`.
