### PR TITLE
Allow space before newline (for CAPABILITY).

### DIFF
--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -2625,7 +2625,7 @@ extension GrammarParser {
         try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             try ParserLibrary.parseFixedString("* ", buffer: &buffer, tracker: tracker)
             let payload = try self.parseResponsePayload(buffer: &buffer, tracker: tracker)
-            try ParserLibrary.parseFixedString("\r\n", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.parseNewline(buffer: &buffer, tracker: tracker)
             return payload
         }
     }

--- a/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
+++ b/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
@@ -230,6 +230,12 @@ extension ParserLibrary {
             // other fast path: we find LF + some other byte
             buffer.moveReaderIndex(forwardBy: 1)
             return
+        case .some(let x) where UInt8(x >> 8) == UInt8(ascii: " "):
+            // found a space that we’ll skip. Some servers insert an extra space at the end.
+            try ParserLibrary.parseComposite(buffer: &buffer, tracker: tracker) { buffer, _ in
+                buffer.moveReaderIndex(forwardBy: 1)
+                try parseNewline(buffer: &buffer, tracker: tracker)
+            }
         case .none:
             guard let first = buffer.getInteger(at: buffer.readerIndex, as: UInt8.self) else {
                 throw _IncompleteMessage()

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -1848,6 +1848,10 @@ extension ParserUnitTests {
         buffer = TestUtilities.createTestByteBuffer(for: "\r\n")
         XCTAssertNoThrow(try ParserLibrary.parseNewline(buffer: &buffer, tracker: .testTracker))
         XCTAssertNil(buffer.readInteger(as: UInt8.self))
+
+        buffer = TestUtilities.createTestByteBuffer(for: " \r\nx")
+        XCTAssertNoThrow(try ParserLibrary.parseNewline(buffer: &buffer, tracker: .testTracker))
+        XCTAssertEqual(UInt8(ascii: "x"), buffer.readInteger(as: UInt8.self))
     }
 
     func test_parseNewlineFailure() {
@@ -1868,6 +1872,12 @@ extension ParserUnitTests {
             XCTAssert(error is ParserError)
         }
         XCTAssertEqual(UInt8(ascii: "x"), buffer.readInteger(as: UInt8.self))
+
+        buffer = TestUtilities.createTestByteBuffer(for: " x")
+        XCTAssertThrowsError(try ParserLibrary.parseNewline(buffer: &buffer, tracker: .testTracker)) { error in
+            XCTAssert(error is ParserError)
+        }
+        XCTAssertEqual(UInt8(ascii: " "), buffer.readInteger(as: UInt8.self))
 
         buffer = TestUtilities.createTestByteBuffer(for: "xy")
         XCTAssertThrowsError(try ParserLibrary.parseNewline(buffer: &buffer, tracker: .testTracker)) { error in

--- a/Tests/NIOIMAPTests/B2MV+Tests.swift
+++ b/Tests/NIOIMAPTests/B2MV+Tests.swift
@@ -191,6 +191,8 @@ extension B2MV_Tests {
             // MARK: Capability
 
             ("* CAPABILITY IMAP4rev1 CHILDREN CONDSTORE", [.untaggedResponse(.capabilityData([.imap4rev1, .children, .condStore]))]),
+            // With trailing space:
+            ("* CAPABILITY IMAP4rev1 CHILDREN CONDSTORE ", [.untaggedResponse(.capabilityData([.imap4rev1, .children, .condStore]))]),
 
             // MARK: LIST
 


### PR DESCRIPTION
See also: #232 — should probably do this for everything?

I added a test case for this for our parser, because I hit this with iCloud or Apple Corporate at one point.
