### PR TITLE
Fix append not using a continuation.

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Command/CommandStream.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/CommandStream.swift
@@ -47,6 +47,7 @@ extension CommandEncodeBuffer {
                 self.buffer.writeString("\(tag) APPEND ") +
                 self.buffer.writeMailbox(mailbox)
         case .beginMessage(messsage: let messsage):
+            defer { self.buffer.markStopPoint() }
             return self.buffer.writeAppendMessage(messsage)
         case .messageBytes(var bytes):
             return self.buffer.writeBuffer(&bytes)

--- a/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandStream+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandStream+Tests.swift
@@ -45,4 +45,29 @@ extension CommandStream_Tests {
             XCTAssertEqual(String(buffer: commandEncodeBuffer.buffer._buffer), expected, line: line)
         }
     }
+
+    func testContinuation() throws {
+        let parts: [AppendCommand] = [
+            .start(tag: "1", appendingTo: .inbox),
+            .beginMessage(messsage: .init(options: .init(flagList: [], extensions: []), data: .init(byteCount: 7))),
+            .messageBytes("Foo Bar"),
+            .endMessage,
+            .finish,
+        ]
+
+        var buffer = CommandEncodeBuffer(buffer: "", capabilities: [])
+        try parts.forEach {
+            try buffer.writeAppendCommand($0)
+        }
+
+        let encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: encodedCommand.bytes), #"1 APPEND "INBOX" {7}\#r\#n"#)
+        guard encodedCommand.waitForContinuation else {
+            XCTFail("Should have had a continuation.")
+            return
+        }
+        let continuation = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: continuation.bytes), "Foo Bar\r\n")
+        XCTAssertFalse(continuation.waitForContinuation, "Should not have additional continuations.")
+    }
 }


### PR DESCRIPTION
This makes sure there’s a _stop point_ when encoding `APPEND`. This needs to be updated as part of #226, though, to make sure this does the right thing for _literal plus_, too.