### PR TITLE
Remove writeAString

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/HeaderList.swift
+++ b/Sources/NIOIMAPCore/Grammar/HeaderList.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 extension EncodeBuffer {
     @discardableResult mutating func writeHeaderList(_ headers: [String]) -> Int {
         self.writeArray(headers) { (element, self) in
-            self.writeAString(element)
+            self.writeIMAPString(element)
         }
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Helpers.swift
+++ b/Sources/NIOIMAPCore/Grammar/Helpers.swift
@@ -18,19 +18,4 @@ extension EncodeBuffer {
     mutating func writeAtom(_ str: String) -> Int {
         self.writeString(str)
     }
-
-    mutating func writeAString(_ str: String) -> Int {
-        // allSatisfy vs contains because IMO it's a little clearer
-        var foundNull = false
-        let canUseAtom = str.utf8.allSatisfy { c in
-            foundNull = foundNull || (c == 0)
-            return c.isAtomChar && !foundNull
-        }
-
-        if canUseAtom {
-            return self.writeString(str)
-        } else {
-            return self.writeIMAPString(str)
-        }
-    }
 }

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchKey.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchKey.swift
@@ -299,7 +299,7 @@ extension EncodeBuffer {
         case .header(let field, let value):
             return
                 self.writeString("HEADER ") +
-                self.writeAString(field) +
+                self.writeIMAPString(field) +
                 self.writeSpace() +
                 self.writeIMAPString(value)
 

--- a/Tests/NIOIMAPCoreTests/Grammar/HeaderListTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/HeaderListTests.swift
@@ -29,7 +29,7 @@ extension HeaderListsTests {
     }
 
     func testArray_full() {
-        let expected = "(hello there world)"
+        let expected = "(\"hello\" \"there\" \"world\")"
         let size = self.testBuffer.writeHeaderList(["hello", "there", "world"])
         XCTAssertEqual(size, expected.utf8.count)
         XCTAssertEqual(expected, self.testBufferString)

--- a/Tests/NIOIMAPCoreTests/Grammar/Search/SearchKeyTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Search/SearchKeyTests.swift
@@ -49,7 +49,7 @@ extension SearchKeyTests {
             (.text("some text"), "TEXT \"some text\"", #line),
             (.to("theboss@apple.com"), "TO \"theboss@apple.com\"", #line),
             (.unkeyword(Flag.Keyword("nokeyword")), "UNKEYWORD nokeyword", #line),
-            (.header("header", "value"), "HEADER header \"value\"", #line),
+            (.header("header", "value"), "HEADER \"header\" \"value\"", #line),
             (.messageSizeLarger(333), "LARGER 333", #line),
             (.not(.messageSizeLarger(444)), "NOT LARGER 444", #line),
             (.or(.messageSizeSmaller(444), .messageSizeLarger(666)), "OR SMALLER 444 LARGER 666", #line),


### PR DESCRIPTION
Resolves #236 

Every `quoted/literal` is a valid `astring`, so let's reduce complexity by always using `writeIMAPString` and remove the redundant `writeAString` code.