### PR TITLE
Remove String typealias

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Address.swift
+++ b/Sources/NIOIMAPCore/Grammar/Address.swift
@@ -16,12 +16,12 @@ import struct NIO.ByteBuffer
 
 /// IMAPv4 `address`
 public struct Address: Equatable {
-    public var name: NString
-    public var adl: NString
-    public var mailbox: NString
-    public var host: NString
+    public var name: ByteBuffer?
+    public var adl: ByteBuffer?
+    public var mailbox: ByteBuffer?
+    public var host: ByteBuffer?
 
-    public init(name: NString, adl: NString, mailbox: NString, host: NString) {
+    public init(name: ByteBuffer?, adl: ByteBuffer?, mailbox: ByteBuffer?, host: ByteBuffer?) {
         self.name = name
         self.adl = adl
         self.mailbox = mailbox

--- a/Sources/NIOIMAPCore/Grammar/Body/BodyExtension.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/BodyExtension.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 /// IMAPv4 `body-extension`
 public enum BodyExtension: Equatable {
-    case string(NString)
+    case string(ByteBuffer?)
     case number(Int)
 }
 

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/Fields.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/Fields.swift
@@ -18,12 +18,12 @@ extension BodyStructure {
     /// IMAPv4 `body-fields`
     public struct Fields: Equatable {
         public var parameter: [BodyStructure.ParameterPair]
-        public var id: NString
-        public var description: NString
+        public var id: ByteBuffer?
+        public var description: ByteBuffer?
         public var encoding: Encoding
         public var octetCount: Int
 
-        public init(parameter: [BodyStructure.ParameterPair], id: NString, description: NString, encoding: BodyStructure.Encoding, octetCount: Int) {
+        public init(parameter: [BodyStructure.ParameterPair], id: ByteBuffer?, description: ByteBuffer?, encoding: BodyStructure.Encoding, octetCount: Int) {
             self.parameter = parameter
             self.id = id
             self.description = description

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/LocationAndExtensions.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/LocationAndExtensions.swift
@@ -17,10 +17,10 @@ import struct NIO.ByteBuffer
 extension BodyStructure {
     /// Extracted from IMAPv4 `body-ext-1part`
     public struct LocationAndExtensions: Equatable {
-        public var location: NString
+        public var location: ByteBuffer?
         public var extensions: [[BodyExtension]]
 
-        public init(location: NString, extensions: [[BodyExtension]]) {
+        public init(location: ByteBuffer?, extensions: [[BodyExtension]]) {
             self.location = location
             self.extensions = extensions
         }

--- a/Sources/NIOIMAPCore/Grammar/Body/Singlepart.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Singlepart.swift
@@ -67,11 +67,11 @@ extension BodyStructure.Singlepart {
     /// IMAPv4 `body-ext-1part`
     public struct Extension: Equatable {
         /// A string giving the body MD5 value.
-        public let digest: NString
+        public let digest: ByteBuffer?
         public var dispositionAndLanguage: BodyStructure.DispositionAndLanguage?
 
         /// Convenience function for a better experience when chaining multiple types.
-        init(fieldMD5: NString, dispositionAndLanguage: BodyStructure.DispositionAndLanguage?) {
+        init(fieldMD5: ByteBuffer?, dispositionAndLanguage: BodyStructure.DispositionAndLanguage?) {
             self.digest = fieldMD5
             self.dispositionAndLanguage = dispositionAndLanguage
         }

--- a/Sources/NIOIMAPCore/Grammar/Envelope.swift
+++ b/Sources/NIOIMAPCore/Grammar/Envelope.swift
@@ -16,18 +16,18 @@ import struct NIO.ByteBuffer
 
 /// IMAPv4 `envelope`
 public struct Envelope: Equatable {
-    public var date: NString
-    public var subject: NString
+    public var date: ByteBuffer?
+    public var subject: ByteBuffer?
     public var from: [Address]
     public var sender: [Address]
     public var reply: [Address]
     public var to: [Address]
     public var cc: [Address]
     public var bcc: [Address]
-    public var inReplyTo: NString
-    public var messageID: NString
+    public var inReplyTo: ByteBuffer?
+    public var messageID: ByteBuffer?
 
-    public init(date: NString, subject: NString, from: [Address], sender: [Address], reply: [Address], to: [Address], cc: [Address], bcc: [Address], inReplyTo: NString, messageID: NString) {
+    public init(date: ByteBuffer?, subject: ByteBuffer?, from: [Address], sender: [Address], reply: [Address], to: [Address], cc: [Address], bcc: [Address], inReplyTo: ByteBuffer?, messageID: ByteBuffer?) {
         self.date = date
         self.subject = subject
         self.from = from

--- a/Sources/NIOIMAPCore/Grammar/ID/ID.swift
+++ b/Sources/NIOIMAPCore/Grammar/ID/ID.swift
@@ -17,9 +17,9 @@ import struct NIO.ByteBuffer
 // Exracted from `IDParamsList`
 public struct IDParameter: Equatable {
     public var key: String
-    public var value: NString
+    public var value: ByteBuffer?
 
-    public init(key: String, value: NString) {
+    public init(key: String, value: ByteBuffer?) {
         self.key = key
         self.value = value
     }

--- a/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
@@ -27,20 +27,20 @@ public enum MessageAttribute: Equatable {
     /// The unique identifier of the message.
     case uid(UID)
     /// `RFC822` -- Equivalent to `BODY[]`.
-    case rfc822(NString)
+    case rfc822(ByteBuffer?)
     /// `RFC822.HEADER` -- Equivalent to `BODY[HEADER]`.
-    case rfc822Header(NString)
-    case rfc822Text(NString)
+    case rfc822Header(ByteBuffer?)
+    case rfc822Text(ByteBuffer?)
     /// `RFC822.SIZE` -- A number expressing the RFC 2822 size of the message.
     case rfc822Size(Int)
     /// `BODY[<section>]<<origin octet>>` -- The body contents of the specified section.
     case body(BodyStructure, structure: Bool)
     /// `BODYSTRUCTURE` -- A list that describes the MIME body structure of a message.
-    case bodySection(SectionSpecifier, offset: Int?, data: NString)
+    case bodySection(SectionSpecifier, offset: Int?, data: ByteBuffer?)
     /// `BINARY<section-binary>[<<number>>]` -- The content of the
     /// specified section after removing any content-transfer-encoding related encoding.
     /// - SeeAlso: RFC 3516 “IMAP4 Binary Content Extension”
-    case binary(section: SectionSpecifier.Part, data: NString)
+    case binary(section: SectionSpecifier.Part, data: ByteBuffer?)
     /// `BINARY.SIZE<section-binary>` -- The size of the section after
     /// removing any content-transfer-encoding related encoding.
     /// - SeeAlso: RFC 3516 “IMAP4 Binary Content Extension”
@@ -85,7 +85,7 @@ extension EncodeBuffer {
         }
     }
 
-    @discardableResult mutating func writeMessageAttribute_binaryString(section: SectionSpecifier.Part, string: NString) -> Int {
+    @discardableResult mutating func writeMessageAttribute_binaryString(section: SectionSpecifier.Part, string: ByteBuffer?) -> Int {
         self.writeString("BINARY") +
             self.writeSectionBinary(section) +
             self.writeSpace() +
@@ -115,19 +115,19 @@ extension EncodeBuffer {
             self.writeInternalDate(date)
     }
 
-    @discardableResult mutating func writeMessageAttribute_rfc822(_ string: NString) -> Int {
+    @discardableResult mutating func writeMessageAttribute_rfc822(_ string: ByteBuffer?) -> Int {
         self.writeString("RFC822") +
             self.writeSpace() +
             self.writeNString(string)
     }
 
-    @discardableResult mutating func writeMessageAttribute_rfc822Text(_ string: NString) -> Int {
+    @discardableResult mutating func writeMessageAttribute_rfc822Text(_ string: ByteBuffer?) -> Int {
         self.writeString("RFC822.TEXT") +
             self.writeSpace() +
             self.writeNString(string)
     }
 
-    @discardableResult mutating func writeMessageAttribute_rfc822Header(_ string: NString) -> Int {
+    @discardableResult mutating func writeMessageAttribute_rfc822Header(_ string: ByteBuffer?) -> Int {
         self.writeString("RFC822.HEADER") +
             self.writeSpace() +
             self.writeNString(string)
@@ -142,7 +142,7 @@ extension EncodeBuffer {
             self.writeBody(body)
     }
 
-    @discardableResult mutating func writeMessageAttribute_bodySection(_ section: SectionSpecifier?, number: Int?, string: NString) -> Int {
+    @discardableResult mutating func writeMessageAttribute_bodySection(_ section: SectionSpecifier?, number: Int?, string: ByteBuffer?) -> Int {
         self.writeString("BODY") +
             self.writeSection(section) +
             self.writeIfExists(number) { (number) -> Int in

--- a/Sources/NIOIMAPCore/Grammar/NString.swift
+++ b/Sources/NIOIMAPCore/Grammar/NString.swift
@@ -14,38 +14,11 @@
 
 import struct NIO.ByteBuffer
 
-// MARK: - NString
-
-/// IMAPv4 `nstring`
-public struct NString: Equatable {
-    var buffer: ByteBuffer?
-
-    public init(buffer: ByteBuffer) {
-        self.buffer = buffer
-    }
-}
-
-// MARK: - Conveniences
-
-extension NString: ExpressibleByNilLiteral {
-    public init(nilLiteral: ()) {
-        self.buffer = nil
-    }
-}
-
-extension NString: ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-
-    public init(stringLiteral value: String) {
-        self.buffer = ByteBuffer(string: value)
-    }
-}
-
 // MARK: - IMAP
 
 extension EncodeBuffer {
-    @discardableResult mutating func writeNString(_ string: NString) -> Int {
-        if let string = string.buffer {
+    @discardableResult mutating func writeNString(_ string: ByteBuffer?) -> Int {
+        if let string = string {
             return self.writeIMAPString(string)
         } else {
             return self.writeNil()

--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -389,7 +389,7 @@ extension GrammarParser {
     // body-fld-lang   = nstring / "(" string *(SP string) ")"
     static func parseBodyFieldLanguage(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [String] {
         func parseBodyFieldLanguage_single(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [String] {
-            guard let language = try self.parseNString(buffer: &buffer, tracker: tracker).buffer else {
+            guard let language = try self.parseNString(buffer: &buffer, tracker: tracker) else {
                 return []
             }
             return [String(buffer: language)]
@@ -2415,13 +2415,13 @@ extension GrammarParser {
     }
 
     // nstring         = string / nil
-    static func parseNString(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NString {
-        func parseNString_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NString {
+    static func parseNString(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer? {
+        func parseNString_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer? {
             try ParserLibrary.parseFixedString("NIL", buffer: &buffer, tracker: tracker)
             return nil
         }
 
-        func parseNString_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NString {
+        func parseNString_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer? {
             let buffer = try self.parseString(buffer: &buffer, tracker: tracker)
             return .init(buffer: buffer)
         }

--- a/Tests/NIOIMAPCoreTests/Grammar/AddressTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/AddressTests.swift
@@ -22,10 +22,10 @@ class AddressTests: EncodeTestClass {}
 
 extension AddressTests {
     func testInit() {
-        let name: NString = "a"
-        let adl: NString = "b"
-        let mailbox: NString = "c"
-        let host: NString = "d"
+        let name: ByteBuffer? = "a"
+        let adl: ByteBuffer? = "b"
+        let mailbox: ByteBuffer? = "c"
+        let host: ByteBuffer? = "d"
         let address = Address(name: name, adl: adl, mailbox: mailbox, host: host)
 
         XCTAssertEqual(address.name, name)


### PR DESCRIPTION
Resolves #256 

Remove `NString` typealias and convert into a struct.

Because the original definition used a `ByteBuffer`, the new one also uses a `ByteBuffer`, however it's easy to instead represent as a `String`, the question being _should_ we do that?