### PR TITLE
Expose underlying value through RawRepresentable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Body/Body.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Body.swift
@@ -88,8 +88,12 @@ extension BodyStructure: RandomAccessCollection {
 
 extension BodyStructure {
     /// IMAPv4rev1 media-subtype
-    public struct MediaSubtype: Equatable {
-        var _backing: String
+    public struct MediaSubtype: RawRepresentable, CustomStringConvertible, Equatable {
+        public var rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue.lowercased()
+        }
 
         public static var alternative: Self {
             .init("multipart/alternative")
@@ -103,8 +107,12 @@ extension BodyStructure {
             .init("multipart/mixed")
         }
 
-        public init(_ string: String) {
-            self._backing = string.lowercased()
+        public var description: String {
+            rawValue
+        }
+
+        public init(_ rawValue: String) {
+            self.init(rawValue: rawValue)
         }
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/Encoding.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/Encoding.swift
@@ -16,8 +16,12 @@ import struct NIO.ByteBuffer
 
 extension BodyStructure {
     /// IMAPv4 `body-fld-enc`
-    public struct Encoding: CustomStringConvertible, Equatable {
-        public typealias StringLiteralType = String
+    public struct Encoding: RawRepresentable, CustomStringConvertible, Equatable {
+        public var rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue.uppercased()
+        }
 
         public static var sevenBit: Self { Self("7BIT") }
         public static var eightBit: Self { Self("8BIT") }
@@ -25,10 +29,14 @@ extension BodyStructure {
         public static var base64: Self { Self("BASE64") }
         public static var quotedPrintable: Self { Self("QUOTED-PRINTABLE") }
 
-        public var description: String
+        public var description: String {
+            rawValue
+        }
 
-        public init(_ description: String) {
-            self.description = description
+        /// Creates a new type with the given `String`.
+        /// - Note: the `String` will be uppercased.
+        public init(_ rawValue: String) {
+            self.init(rawValue: rawValue)
         }
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Body/Multipart.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Multipart.swift
@@ -66,6 +66,6 @@ extension EncodeBuffer {
     }
 
     @discardableResult mutating func writeMediaSubtype(_ type: BodyStructure.MediaSubtype) -> Int {
-        self.writeString("\"\(type._backing)\"")
+        self.writeString("\"\(type.rawValue)\"")
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Media/Basic.swift
+++ b/Sources/NIOIMAPCore/Grammar/Media/Basic.swift
@@ -15,32 +15,40 @@
 import struct NIO.ByteBuffer
 
 extension Media {
-    public struct BasicType: Equatable {
-        var _backing: String
+    public struct BasicType: RawRepresentable, CustomStringConvertible, Equatable {
+        public var rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue.uppercased()
+        }
 
         /// IMAP4rev1 APPLICATION
-        public static var application: Self { .init(_backing: "APPLICATION") }
+        public static var application: Self { .init(rawValue: "APPLICATION") }
 
         /// IMAP4rev1 AUDIO
-        public static var audio: Self { .init(_backing: "AUDIO") }
+        public static var audio: Self { .init(rawValue: "AUDIO") }
 
         /// IMAP4rev1 IMAGE
-        public static var image: Self { .init(_backing: "IMAGE") }
+        public static var image: Self { .init(rawValue: "IMAGE") }
 
         /// IMAP4rev1 MESSAGE
-        public static var message: Self { .init(_backing: "MESSAGE") }
+        public static var message: Self { .init(rawValue: "MESSAGE") }
 
         /// IMAP4rev1 VIDEO
-        public static var video: Self { .init(_backing: "VIDEO") }
+        public static var video: Self { .init(rawValue: "VIDEO") }
 
         /// IMAP4rev1 FONT
-        public static var font: Self { .init(_backing: "FONT") }
+        public static var font: Self { .init(rawValue: "FONT") }
 
         /// Creates a new type with the given `String`.
         /// - parameter string: The type to create. Note that the `String` will be uppercased.
         /// - returns: A new type from the given `String`.
         public static func other(_ string: String) -> Self {
-            self.init(_backing: string.uppercased())
+            self.init(rawValue: string)
+        }
+
+        public var description: String {
+            rawValue
         }
     }
 
@@ -62,9 +70,9 @@ extension EncodeBuffer {
     @discardableResult mutating func writeMediaBasicType(_ type: Media.BasicType) -> Int {
         switch type {
         case .application, .audio, .image, .message, .video:
-            return self.writeString("\"\(type._backing)\"")
+            return self.writeString("\"\(type.rawValue)\"")
         default:
-            return self.writeString(type._backing)
+            return self.writeString(type.rawValue)
         }
     }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
@@ -23,7 +23,7 @@ class BodyStructure_Tests: EncodeTestClass {}
 extension BodyStructure_Tests {
     func testInit_mediaSubtype() {
         let type = BodyStructure.MediaSubtype("TYPE")
-        XCTAssertEqual(type._backing, "type")
+        XCTAssertEqual(type.rawValue, "type")
     }
 }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/Body/Field/BodyFieldEncodingTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Body/Field/BodyFieldEncodingTests.swift
@@ -28,7 +28,7 @@ extension BodyEncodingTests {
             (.binary, #""BINARY""#, #line),
             (.base64, #""BASE64""#, #line),
             (.quotedPrintable, #""QUOTED-PRINTABLE""#, #line),
-            (.init("some"), "\"some\"", #line),
+            (.init("some"), "\"SOME\"", #line),
         ]
 
         for (test, expectedString, line) in inputs {


### PR DESCRIPTION
There are a few `BodyStructure` related types which should expose their underlying value:
 * `MediaSubtype`
 * `Encoding`
 * `BasicType`
