### PR TITLE
Make encoding command stream non-throwing

### DIFF
--- a/Sources/CLILib/Handlers/Outbound/CommandRoundtripHandler.swift
+++ b/Sources/CLILib/Handlers/Outbound/CommandRoundtripHandler.swift
@@ -47,7 +47,7 @@ public class CommandRoundtripHandler: ChannelOutboundHandler {
                 buffer: context.channel.allocator.buffer(capacity: originalBuffer.readableBytes),
                 capabilities: self.capabilities
             )
-            try encodeBuffer.writeCommandStream(command)
+            encodeBuffer.writeCommandStream(command)
             var roundtripBuffer = encodeBuffer.buffer.nextChunk().bytes
 
             if originalBuffer != roundtripBuffer {

--- a/Sources/NIOIMAP/Coders/CommandEncoder.swift
+++ b/Sources/NIOIMAP/Coders/CommandEncoder.swift
@@ -38,7 +38,7 @@ public class CommandEncoder: MessageToByteEncoder {
             out.writeString("DONE\r\n")
         case .command(let command):
             var encodeBuffer = EncodeBuffer.clientEncodeBuffer(buffer: out, capabilities: self.capabilities)
-            try encodeBuffer.writeCommand(command)
+            encodeBuffer.writeCommand(command)
             out = encodeBuffer.nextChunk().bytes
         case .append(let command):
             try self.encodeAppendCommand(command, into: &out)

--- a/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
@@ -72,13 +72,7 @@ public final class IMAPClientHandler: ChannelDuplexHandler {
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let command = self.unwrapOutboundIn(data)
         var encoder = CommandEncodeBuffer(buffer: context.channel.allocator.buffer(capacity: 1024), capabilities: [])
-        do {
-            try encoder.writeCommandStream(command)
-        } catch {
-            promise?.fail(error)
-            context.fireErrorCaught(error)
-            return
-        }
+        encoder.writeCommandStream(command)
         if self.bufferedWrites.isEmpty {
             let next = encoder.buffer.nextChunk()
 

--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -57,7 +57,7 @@ public enum Command: Equatable {
 // MARK: - IMAP
 
 extension EncodeBuffer {
-    @discardableResult mutating func writeCommand(_ command: Command) throws -> Int {
+    @discardableResult mutating func writeCommand(_ command: Command) -> Int {
         switch command {
         case .capability:
             return self.writeCommandKind_capability()
@@ -72,7 +72,7 @@ extension EncodeBuffer {
         case .examine(let mailbox, let params):
             return self.writeCommandKind_examine(mailbox: mailbox, parameters: params)
         case .list(let selectOptions, let mailbox, let mailboxPatterns, let returnOptions):
-            return try self.writeCommandKind_list(selectOptions: selectOptions, mailbox: mailbox, mailboxPatterns: mailboxPatterns, returnOptions: returnOptions)
+            return self.writeCommandKind_list(selectOptions: selectOptions, mailbox: mailbox, mailboxPatterns: mailboxPatterns, returnOptions: returnOptions)
         case .lsub(let mailbox, let listMailbox):
             return self.writeCommandKind_lsub(mailbox: mailbox, listMailbox: listMailbox)
         case .rename(let from, let to, let params):
@@ -171,7 +171,7 @@ extension EncodeBuffer {
             }
     }
 
-    private mutating func writeCommandKind_list(selectOptions: ListSelectOptions?, mailbox: MailboxName, mailboxPatterns: MailboxPatterns, returnOptions: [ReturnOption]) throws -> Int {
+    private mutating func writeCommandKind_list(selectOptions: ListSelectOptions?, mailbox: MailboxName, mailboxPatterns: MailboxPatterns, returnOptions: [ReturnOption]) -> Int {
         self.writeString("LIST") +
             self.writeIfExists(selectOptions) { (options) -> Int in
                 self.writeSpace() +

--- a/Sources/NIOIMAPCore/Grammar/Command/CommandStream.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/CommandStream.swift
@@ -29,18 +29,18 @@ public enum CommandStream: Equatable {
 }
 
 extension CommandEncodeBuffer {
-    @discardableResult public mutating func writeCommandStream(_ stream: CommandStream) throws -> Int {
+    @discardableResult public mutating func writeCommandStream(_ stream: CommandStream) -> Int {
         switch stream {
         case .idleDone:
             return self.buffer.writeString("DONE\r\n")
         case .command(let command):
-            return try self.buffer.writeCommand(command)
+            return self.buffer.writeCommand(command)
         case .append(let command):
-            return try self.writeAppendCommand(command)
+            return self.writeAppendCommand(command)
         }
     }
 
-    @discardableResult mutating func writeAppendCommand(_ command: AppendCommand) throws -> Int {
+    @discardableResult mutating func writeAppendCommand(_ command: AppendCommand) -> Int {
         switch command {
         case .start(tag: let tag, appendingTo: let mailbox):
             return

--- a/Sources/NIOIMAPCore/Grammar/Command/TaggedCommand.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/TaggedCommand.swift
@@ -26,11 +26,11 @@ public struct TaggedCommand: Equatable {
 }
 
 extension EncodeBuffer {
-    @discardableResult public mutating func writeCommand(_ command: TaggedCommand) throws -> Int {
+    @discardableResult public mutating func writeCommand(_ command: TaggedCommand) -> Int {
         guard case .client = mode else { preconditionFailure("only clients can send commands") }
         var size = 0
         size += self.writeString("\(command.tag) ")
-        size += try self.writeCommand(command.command)
+        size += self.writeCommand(command.command)
         size += self.writeString("\r\n")
         return size
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandStream+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandStream+Tests.swift
@@ -41,7 +41,7 @@ extension CommandStream_Tests {
 
         for (command, expected, line) in inputs {
             var commandEncodeBuffer = CommandEncodeBuffer(buffer: "", capabilities: [])
-            XCTAssertNoThrow(try commandEncodeBuffer.writeAppendCommand(command), line: line)
+            commandEncodeBuffer.writeAppendCommand(command)
             XCTAssertEqual(String(buffer: commandEncodeBuffer.buffer._buffer), expected, line: line)
         }
     }
@@ -56,8 +56,8 @@ extension CommandStream_Tests {
         ]
 
         var buffer = CommandEncodeBuffer(buffer: "", capabilities: [])
-        try parts.forEach {
-            try buffer.writeAppendCommand($0)
+        parts.forEach {
+            buffer.writeAppendCommand($0)
         }
 
         let encodedCommand = buffer.buffer.nextChunk()
@@ -83,8 +83,8 @@ extension CommandStream_Tests {
         var options = CommandEncodingOptions()
         options.useNonSynchronizingLiteral = true
         var buffer = CommandEncodeBuffer(buffer: "", options: options)
-        try parts.forEach {
-            try buffer.writeAppendCommand($0)
+        parts.forEach {
+            buffer.writeAppendCommand($0)
         }
 
         let encodedCommand = buffer.buffer.nextChunk()

--- a/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
@@ -42,6 +42,6 @@ extension CommandType_Tests {
             (.id([]), CommandEncodingOptions(), ["ID NIL"], #line),
         ]
 
-        self.iterateInputs(inputs: inputs, encoder: { try self.testBuffer.writeCommand($0) })
+        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeCommand($0) })
     }
 }

--- a/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
@@ -101,11 +101,7 @@ final class RoundtripTests: XCTestCase {
             let line = test.1
             let tag = "\(i + 1)"
             let command = TaggedCommand(tag: tag, command: commandType)
-            do {
-                try encodeBuffer.writeCommand(command)
-            } catch {
-                XCTFail("\(error)")
-            }
+            encodeBuffer.writeCommand(command)
             encodeBuffer.writeString("\r\n") // required for commands that might terminate with a literal (e.g. append)
             var buffer = ByteBufferAllocator().buffer(capacity: 128)
             while true {


### PR DESCRIPTION
Resolves #270 

There's no reason for the encoder to throw anymore, so now all `try` and `throws` are gone gone gone.