### PR TITLE
Implement RFC 4469 CATENATE

### DIFF
--- a/Sources/NIOIMAPCore/CommandEncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/CommandEncodeBuffer.swift
@@ -17,6 +17,9 @@ import struct NIO.ByteBuffer
 public struct CommandEncodeBuffer {
     public var buffer: EncodeBuffer
 
+    /// Tracks whether we have encoded at least one catenate element.
+    internal var encodedAtLeastOneCatenateElement = false
+
     public init(buffer: ByteBuffer, options: CommandEncodingOptions) {
         self.buffer = .clientEncodeBuffer(buffer: buffer, options: options)
     }

--- a/Sources/NIOIMAPCore/Parser/CommandParser.swift
+++ b/Sources/NIOIMAPCore/Parser/CommandParser.swift
@@ -39,6 +39,9 @@ public struct CommandParser: Parser {
         case waitingForMessage
         case streamingBytes(Int)
         case streamingEnd
+        case waitingForCatenatePart(seenPreviousPart: Bool)
+        case streamingCatenateBytes(Int)
+        case streamingCatenateEnd
 
         var isStreamingAppend: Bool {
             if case .streamingBytes = self {
@@ -114,6 +117,12 @@ public struct CommandParser: Parser {
                 return self.handleStreamingBytes(buffer: &buffer, remaining: remaining)
             case .streamingEnd:
                 return try self.handleStreamingEnd(buffer: &buffer, tracker: tracker)
+            case .waitingForCatenatePart(seenPreviousPart: let seenPreviousPart):
+                return try self.handleCatenatePart(expectPrecedingSpace: seenPreviousPart, buffer: &buffer, tracker: tracker)
+            case .streamingCatenateBytes(let remaining):
+                return try self.handleStreamingCatenateBytes(buffer: &buffer, remaining: remaining)
+            case .streamingCatenateEnd:
+                return try self.handleStreamingCatenateEnd(buffer: &buffer, tracker: tracker)
             }
         }
     }
@@ -160,9 +169,16 @@ public struct CommandParser: Parser {
 
     private mutating func handleWaitingForMessage(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CommandStream {
         do {
-            let message = try GrammarParser.parseAppendMessage(buffer: &buffer, tracker: tracker)
-            self.mode = .streamingBytes(message.data.byteCount)
-            return .append(.beginMessage(messsage: message))
+            let command = try GrammarParser.parseAppendOrCatenateMessage(buffer: &buffer, tracker: tracker)
+
+            switch command {
+            case .append(let message):
+                self.mode = .streamingBytes(message.data.byteCount)
+                return .append(.beginMessage(message: message))
+            case .catenate(let options):
+                self.mode = .waitingForCatenatePart(seenPreviousPart: false)
+                return .append(.beginCatenate(options: options))
+            }
         } catch is ParserError {
             let save = buffer
             do {
@@ -185,5 +201,36 @@ public struct CommandParser: Parser {
         try GrammarParser.parseIdleDone(buffer: &buffer, tracker: tracker)
         self.mode = .lines
         return .idleDone
+    }
+
+    private mutating func handleCatenatePart(expectPrecedingSpace: Bool, buffer: inout ByteBuffer, tracker: StackTracker) throws -> CommandStream {
+        let result = try GrammarParser.parseCatenatePart(expectPrecedingSpace: expectPrecedingSpace, buffer: &buffer, tracker: tracker)
+        switch result {
+        case .url(let url):
+            self.mode = .waitingForCatenatePart(seenPreviousPart: true)
+            return .append(.catenateURL(url))
+        case .text(let length):
+            self.mode = .streamingCatenateBytes(length)
+            return .append(.catenateData(.begin(size: length)))
+        case .end:
+            self.mode = .waitingForMessage
+            return .append(.endCatenate)
+        }
+    }
+
+    private mutating func handleStreamingCatenateBytes(buffer: inout ByteBuffer, remaining: Int) throws -> CommandStream {
+        if buffer.readableBytes >= remaining {
+            self.mode = .streamingCatenateEnd
+            return .append(.catenateData(.bytes(buffer.readSlice(length: remaining)!)))
+        }
+
+        let bytes = buffer.readSlice(length: buffer.readableBytes)!
+        self.mode = .streamingCatenateBytes(remaining - bytes.readableBytes)
+        return .append(.catenateData(.bytes(bytes)))
+    }
+
+    private mutating func handleStreamingCatenateEnd(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CommandStream {
+        self.mode = .waitingForCatenatePart(seenPreviousPart: true)
+        return .append(.catenateData(.end))
     }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandStream+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandStream+Tests.swift
@@ -25,12 +25,12 @@ extension CommandStream_Tests {
         let inputs: [(AppendCommand, String, UInt)] = [
             (.start(tag: "1", appendingTo: .inbox), "1 APPEND \"INBOX\"", #line),
             (
-                .beginMessage(messsage: .init(options: .init(flagList: [], extensions: []), data: .init(byteCount: 3))),
+                .beginMessage(message: .init(options: .init(flagList: [], extensions: []), data: .init(byteCount: 3))),
                 " {3}\r\n",
                 #line
             ),
             (
-                .beginMessage(messsage: .init(options: .init(flagList: [.seen, .deleted], extensions: []), data: .init(byteCount: 3))),
+                .beginMessage(message: .init(options: .init(flagList: [.seen, .deleted], extensions: []), data: .init(byteCount: 3))),
                 " (\\Seen \\Deleted) {3}\r\n",
                 #line
             ),
@@ -49,7 +49,7 @@ extension CommandStream_Tests {
     func testContinuation_synchronizing() throws {
         let parts: [AppendCommand] = [
             .start(tag: "1", appendingTo: .inbox),
-            .beginMessage(messsage: .init(options: .init(flagList: [], extensions: []), data: .init(byteCount: 7))),
+            .beginMessage(message: .init(options: .init(flagList: [], extensions: []), data: .init(byteCount: 7))),
             .messageBytes("Foo Bar"),
             .endMessage,
             .finish,
@@ -74,7 +74,7 @@ extension CommandStream_Tests {
     func testContinuation_nonSynchronizing() throws {
         let parts: [AppendCommand] = [
             .start(tag: "1", appendingTo: .inbox),
-            .beginMessage(messsage: .init(options: .init(flagList: [], extensions: []), data: .init(byteCount: 3))),
+            .beginMessage(message: .init(options: .init(flagList: [], extensions: []), data: .init(byteCount: 3))),
             .messageBytes("abc"),
             .endMessage,
             .finish,
@@ -93,5 +93,133 @@ extension CommandStream_Tests {
             XCTFail("Should not have had a continuation.")
             return
         }
+    }
+
+    func testCatenate_exampleOne() throws {
+        let parts: [AppendCommand] = [
+            .start(tag: "A003", appendingTo: MailboxName("Drafts")),
+            .beginCatenate(options: .init(flagList: [.seen, .draft, .keyword(.mdnSent)], extensions: [])),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=20/;section=HEADER"),
+            .catenateData(.begin(size: 42)),
+            .catenateData(.bytes("\r\n--------------030308070208000400050907\r\n")),
+            .catenateData(.end),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=20/;section=1.MIME"),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=20/;section=1"),
+            .catenateData(.begin(size: 42)),
+            .catenateData(.bytes("\r\n--------------030308070208000400050907\r\n")),
+            .catenateData(.end),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=30"),
+            .catenateData(.begin(size: 44)),
+            .catenateData(.bytes("\r\n--------------030308070208000400050907--\r\n")),
+            .catenateData(.end),
+            .endCatenate,
+            .finish,
+        ]
+
+        var buffer = CommandEncodeBuffer(buffer: "", capabilities: [])
+        parts.forEach {
+            buffer.writeAppendCommand($0)
+        }
+
+        var encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: encodedCommand.bytes), #"A003 APPEND "Drafts" (\Seen \Draft $MDNSent) CATENATE (URL "/Drafts;UIDVALIDITY=385759045/;UID=20/;section=HEADER" TEXT {42}\#r\#n"#)
+        guard encodedCommand.waitForContinuation else {
+            XCTFail("Should have had a continuation.")
+            return
+        }
+
+        encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: encodedCommand.bytes), #"\#r\#n--------------030308070208000400050907\#r\#n URL "/Drafts;UIDVALIDITY=385759045/;UID=20/;section=1.MIME" URL "/Drafts;UIDVALIDITY=385759045/;UID=20/;section=1" TEXT {42}\#r\#n"#)
+        guard encodedCommand.waitForContinuation else {
+            XCTFail("Should have had a continuation.")
+            return
+        }
+
+        encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: encodedCommand.bytes), #"\#r\#n--------------030308070208000400050907\#r\#n URL "/Drafts;UIDVALIDITY=385759045/;UID=30" TEXT {44}\#r\#n"#)
+        guard encodedCommand.waitForContinuation else {
+            XCTFail("Should have had a continuation.")
+            return
+        }
+
+        encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: encodedCommand.bytes), #"\#r\#n--------------030308070208000400050907--\#r\#n)\#r\#n"#)
+        XCTAssertFalse(encodedCommand.waitForContinuation, "Should not have additional continuations.")
+    }
+
+    func testCatenate_exampleOne_nonSynchronizing() throws {
+        let parts: [AppendCommand] = [
+            .start(tag: "A003", appendingTo: MailboxName("Drafts")),
+            .beginCatenate(options: .init(flagList: [.seen, .draft, .keyword(.mdnSent)], extensions: [])),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=20/;section=HEADER"),
+            .catenateData(.begin(size: 42)),
+            .catenateData(.bytes("\r\n--------------030308070208000400050907\r\n")),
+            .catenateData(.end),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=20/;section=1.MIME"),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=20/;section=1"),
+            .catenateData(.begin(size: 42)),
+            .catenateData(.bytes("\r\n--------------030308070208000400050907\r\n")),
+            .catenateData(.end),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=30"),
+            .catenateData(.begin(size: 44)),
+            .catenateData(.bytes("\r\n--------------030308070208000400050907--\r\n")),
+            .catenateData(.end),
+            .endCatenate,
+            .finish,
+        ]
+
+        var options = CommandEncodingOptions()
+        options.useNonSynchronizingLiteralPlus = true
+        var buffer = CommandEncodeBuffer(buffer: "", options: options)
+        parts.forEach {
+            buffer.writeAppendCommand($0)
+        }
+
+        let encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(
+            String(buffer: encodedCommand.bytes),
+            #"A003 APPEND "Drafts" (\Seen \Draft $MDNSent) CATENATE (URL "/Drafts;UIDVALIDITY=385759045/;UID=20/;section=HEADER" TEXT {42+}\#r\#n"# +
+            #"\#r\#n--------------030308070208000400050907\#r\#n URL "/Drafts;UIDVALIDITY=385759045/;UID=20/;section=1.MIME" URL "/Drafts;UIDVALIDITY=385759045/;UID=20/;section=1" TEXT {42+}\#r\#n"# +
+            #"\#r\#n--------------030308070208000400050907\#r\#n URL "/Drafts;UIDVALIDITY=385759045/;UID=30" TEXT {44+}\#r\#n"# +
+            #"\#r\#n--------------030308070208000400050907--\#r\#n)\#r\#n"#
+        )
+        XCTAssertFalse(encodedCommand.waitForContinuation, "Should not have additional continuations.")
+    }
+
+    func testCatenate_sequential() throws {
+        let parts: [AppendCommand] = [
+            .start(tag: "A003", appendingTo: MailboxName("Drafts")),
+            .beginCatenate(options: .init(flagList: [.seen, .draft, .keyword(.mdnSent)], extensions: [])),
+            .catenateURL("/Drafts;UIDVALIDITY=385759045/;UID=20/;section=HEADER"),
+            .catenateData(.begin(size: 5)),
+            .catenateData(.bytes("hello")),
+            .catenateData(.end),
+            .endCatenate,
+            .finish,
+        ]
+
+        // Apply parts twice.
+        var buffer = CommandEncodeBuffer(buffer: "", capabilities: [])
+        (parts + parts).forEach {
+            buffer.writeAppendCommand($0)
+        }
+
+        var encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: encodedCommand.bytes), #"A003 APPEND "Drafts" (\Seen \Draft $MDNSent) CATENATE (URL "/Drafts;UIDVALIDITY=385759045/;UID=20/;section=HEADER" TEXT {5}\#r\#n"#)
+        guard encodedCommand.waitForContinuation else {
+            XCTFail("Should have had a continuation.")
+            return
+        }
+
+        encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: encodedCommand.bytes), #"hello)\#r\#nA003 APPEND "Drafts" (\Seen \Draft $MDNSent) CATENATE (URL "/Drafts;UIDVALIDITY=385759045/;UID=20/;section=HEADER" TEXT {5}\#r\#n"#)
+        guard encodedCommand.waitForContinuation else {
+            XCTFail("Should have had a continuation.")
+            return
+        }
+
+        encodedCommand = buffer.buffer.nextChunk()
+        XCTAssertEqual(String(buffer: encodedCommand.bytes), #"hello)\#r\#n"#)
+        XCTAssertFalse(encodedCommand.waitForContinuation, "Should not have additional continuations.")
     }
 }

--- a/Tests/NIOIMAPTests/B2MV+Tests.swift
+++ b/Tests/NIOIMAPTests/B2MV+Tests.swift
@@ -126,7 +126,7 @@ extension B2MV_Tests {
 
             ("tag APPEND box (\\Seen) {1+}\r\na", [
                 .append(.start(tag: "tag", appendingTo: .init("box"))),
-                .append(.beginMessage(messsage: .init(options: .init(flagList: [.seen], extensions: []), data: .init(byteCount: 1)))),
+                .append(.beginMessage(message: .init(options: .init(flagList: [.seen], extensions: []), data: .init(byteCount: 1)))),
                 .append(.messageBytes("a")),
                 .append(.endMessage),
                 .append(.finish),

--- a/Tests/NIOIMAPTests/CommandDecoder+Tests.swift
+++ b/Tests/NIOIMAPTests/CommandDecoder+Tests.swift
@@ -31,7 +31,7 @@ extension CommandDecoder_Tests {
 
         let output: [(CommandStream, UInt)] = [
             (.append(.start(tag: "tag", appendingTo: .init("box"))), #line),
-            (.append(.beginMessage(messsage: .init(options: .init(flagList: [.seen], extensions: []), data: .init(byteCount: 1)))), #line),
+            (.append(.beginMessage(message: .init(options: .init(flagList: [.seen], extensions: []), data: .init(byteCount: 1)))), #line),
             (.append(.messageBytes("a")), #line),
             (.append(.endMessage), #line),
             (.append(.finish), #line),


### PR DESCRIPTION
Motivation:

CATENATE functionality is convenient for low-power client usage, as it
allows clients to stitch together new messages out of the parts of older
ones without needing to reupload (or indeed redownload) that content.

Modifications:

- Extend CommandStream to support CATENATE.
- Extend serializer and parser to work with new definitions.

Result:

CATENATE is parseable.