### PR TITLE
Add support for Gmail extensions

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Capability.swift
+++ b/Sources/NIOIMAPCore/Grammar/Capability.swift
@@ -188,6 +188,7 @@ extension Capability {
     public static let urlPartial = Self(unchecked: "URL-PARTIAL")
     public static let urlAuth = Self(unchecked: "URLAUTH")
     public static let within = Self(unchecked: "WITHIN")
+    public static let gmailExtensions = Self(unchecked: "X-GM-EXT")
 
     /// RFC 7888 LITERAL+
     public static let literalPlus = Self(unchecked: "LITERAL+")

--- a/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
@@ -34,6 +34,9 @@ public enum FetchAttribute: Equatable {
     case modifierSequenceValue(ModifierSequenceValue)
     case binary(peek: Bool, section: SectionSpecifier.Part, partial: ClosedRange<Int>?)
     case binarySize(section: SectionSpecifier.Part)
+    case gmailMessageID
+    case gmailThreadID
+    case gmailLabels
 }
 
 extension Array where Element == FetchAttribute {
@@ -98,6 +101,12 @@ extension EncodeBuffer {
             return self.writeFetchAttribute_binarySize(section)
         case .modifierSequence:
             return self.writeString("MODSEQ")
+        case .gmailMessageID:
+            return self.writeFetchAttribute_gmailMessageID()
+        case .gmailThreadID:
+            return self.writeFetchAttribute_gmailThreadID()
+        case .gmailLabels:
+            return self.writeFetchAttribute_gmailLabels()
         }
     }
 
@@ -159,5 +168,17 @@ extension EncodeBuffer {
             self.writeIfExists(partial) { (partial) -> Int in
                 self.writePartial(partial)
             }
+    }
+
+    @discardableResult mutating func writeFetchAttribute_gmailMessageID() -> Int {
+        self.writeString("X-GM-MSGID")
+    }
+
+    @discardableResult mutating func writeFetchAttribute_gmailThreadID() -> Int {
+        self.writeString("X-GM-THRID")
+    }
+
+    @discardableResult mutating func writeFetchAttribute_gmailLabels() -> Int {
+        self.writeString("X-GM-LABELS")
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Message/GmailLabel.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/GmailLabel.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import struct NIO.ByteBuffer
+
+public struct GmailLabel: RawRepresentable, Equatable {
+    public var rawValue: ByteBuffer
+
+    public init(rawValue: ByteBuffer) {
+        self.rawValue = rawValue
+    }
+}
+
+extension EncodeBuffer {
+    @discardableResult mutating func writeGmailLabel(_ label: GmailLabel) -> Int {
+        if label.rawValue.getInteger(at: label.rawValue.readerIndex) == UInt8(ascii: "\\") {
+            var rawValue = label.rawValue
+            return self.writeBuffer(&rawValue)
+        } else {
+            return self.writeIMAPString(label.rawValue)
+        }
+    }
+}

--- a/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
+++ b/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
@@ -230,6 +230,16 @@ extension ParserLibrary {
         return (int, string.count)
     }
 
+    static func parseUInt64(buffer: inout ByteBuffer, tracker: StackTracker) throws -> (number: UInt64, bytesConsumed: Int) {
+        let string = try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char in
+            char >= UInt8(ascii: "0") && char <= UInt8(ascii: "9")
+        }
+        guard let int = UInt64(string) else {
+            throw ParserError(hint: "\(string) is not a number")
+        }
+        return (int, string.count)
+    }
+
     static func parseNewline(buffer: inout ByteBuffer, tracker: StackTracker) throws {
         switch buffer.getInteger(at: buffer.readerIndex, as: UInt16.self) {
         case .some(UInt16(0x0D0A /* CRLF */ )):

--- a/Tests/NIOIMAPCoreTests/Grammar/FetchAttributeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/FetchAttributeTests.swift
@@ -41,6 +41,9 @@ extension FetchAttributeTests {
             (.modifierSequenceValue(.zero), .rfc3501, "0", #line),
             (.modifierSequenceValue(3), .rfc3501, "3", #line),
             (.modifierSequence, .rfc3501, "MODSEQ", #line),
+            (.gmailMessageID, .rfc3501, "X-GM-MSGID", #line),
+            (.gmailThreadID, .rfc3501, "X-GM-THRID", #line),
+            (.gmailLabels, .rfc3501, "X-GM-LABELS", #line),
         ]
         self.iterateInputs(inputs: inputs.map { ($0, $1, [$2], $3) }, encoder: { self.testBuffer.writeFetchAttribute($0) })
     }
@@ -56,6 +59,7 @@ extension FetchAttributeTests {
             ([.flags, .bodyStructure(extensions: false), .rfc822Size, .internalDate, .envelope], .rfc3501, "FULL", #line),
             ([.flags, .bodyStructure(extensions: true), .rfc822Size, .internalDate, .envelope], .rfc3501, "(FLAGS BODYSTRUCTURE RFC822.SIZE INTERNALDATE ENVELOPE)", #line),
             ([.flags, .bodyStructure(extensions: false), .rfc822Size, .internalDate, .envelope, .uid], .rfc3501, "(FLAGS BODY RFC822.SIZE INTERNALDATE ENVELOPE UID)", #line),
+            ([.gmailLabels, .gmailMessageID, .gmailThreadID], .rfc3501, "(X-GM-LABELS X-GM-MSGID X-GM-THRID)", #line),
         ]
         self.iterateInputs(inputs: inputs.map { ($0, $1, [$2], $3) }, encoder: { self.testBuffer.writeFetchAttributeList($0) })
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/Message/MessageAtributesTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Message/MessageAtributesTests.swift
@@ -42,6 +42,9 @@ extension MessageAttributesTests {
             (.flags([.draft]), "FLAGS (\\Draft)", #line),
             (.flags([.flagged, .draft]), "FLAGS (\\Flagged \\Draft)", #line),
             (.fetchModifierResponse(.init(modifierSequenceValue: 3)), "MODSEQ (3)", #line),
+            (.gmailMessageID(1278455344230334865), "X-GM-MSGID 1278455344230334865", #line),
+            (.gmailThreadID(1266894439832287888), "X-GM-THRID 1266894439832287888", #line),
+            (.gmailLabels([GmailLabel(rawValue: "\\Inbox"), GmailLabel(rawValue: "\\Sent"), GmailLabel(rawValue: "Important"), GmailLabel(rawValue: "Muy Importante")]), "X-GM-LABELS (\\Inbox \\Sent \"Important\" \"Muy Importante\")", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -1604,6 +1604,9 @@ extension ParserUnitTests {
                 ("BINARY.PEEK[1]<3.4>", " ", .binary(peek: true, section: [1], partial: 3 ... 6 as ClosedRange), #line),
                 ("BINARY[2]<4.5>", " ", .binary(peek: false, section: [2], partial: 4 ... 8 as ClosedRange), #line),
                 ("BINARY.SIZE[5]", " ", .binarySize(section: [5]), #line),
+                ("X-GM-MSGID", " ", .gmailMessageID, #line),
+                ("X-GM-THRID", " ", .gmailThreadID, #line),
+                ("X-GM-LABELS", " ", .gmailLabels, #line),
             ],
             parserErrorInputs: [],
             incompleteMessageInputs: []
@@ -2069,6 +2072,12 @@ extension ParserUnitTests {
                     #line
                 ),
                 ("MODSEQ (3)", " ", .fetchModifierResponse(.init(modifierSequenceValue: 3)), #line),
+                ("X-GM-MSGID 1278455344230334865", " ", .gmailMessageID(1278455344230334865), #line),
+                ("X-GM-THRID 1278455344230334865", " ", .gmailThreadID(1278455344230334865), #line),
+                ("X-GM-LABELS (\\Inbox \\Sent Important \"Muy Importante\")", " ", .gmailLabels([GmailLabel(rawValue: "\\Inbox"), GmailLabel(rawValue: "\\Sent"), GmailLabel(rawValue: "Important"), GmailLabel(rawValue: "Muy Importante")]), #line),
+                ("X-GM-LABELS (foo)", " ", .gmailLabels([GmailLabel(rawValue: "foo")]), #line),
+                ("X-GM-LABELS ()", " ", .gmailLabels([]), #line),
+                ("X-GM-LABELS (\\Drafts)", " ", .gmailLabels([GmailLabel(rawValue: "\\Drafts")]), #line),
             ],
             parserErrorInputs: [],
             incompleteMessageInputs: []

--- a/Tests/NIOIMAPCoreTests/Parser/ParserLibraryTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/ParserLibraryTests.swift
@@ -240,3 +240,24 @@ extension ParserLibraryTests {
         }
     }
 }
+
+// MARK: - parseUInt64
+
+extension ParserLibraryTests {
+    func testParseUInt64() {
+        let inputs: [(ByteBuffer, UInt64, Int, UInt)] = [
+            ("12345\r", 12345, 5, #line),
+            ("18446744073709551615\r", UInt64.max, 20, #line),
+            ("12345 a", 12345, 5, #line),
+            ("18446744073709551615b", UInt64.max, 20, #line),
+        ]
+        for (string, result, consumed, line) in inputs {
+            var string = string
+            var id = UInt64(0)
+            var actualConsumed = 0
+            XCTAssertNoThrow((id, actualConsumed) = try ParserLibrary.parseUInt64(buffer: &string, tracker: .makeNewDefaultLimitStackTracker), line: line)
+            XCTAssertEqual(actualConsumed, consumed, line: line)
+            XCTAssertEqual(id, result, line: line)
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Gmail has a couple of common extensions to the IMAP specification for
Gmail specific features. It'd be good to support them. This patch adds
support for the most important three: Gmail message ID, Gmail thread ID,
and the Gmail label functionality.

Modifications:

- Added new Fetch and Message attributes for the three Gmail extensions.
- Added parsing and serialization support.

Result:

Users can interact with Gmail-specific features.
