### PR TITLE
Remove ParameterValue.number

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Tagged/ParameterValue.swift
+++ b/Sources/NIOIMAPCore/Grammar/Tagged/ParameterValue.swift
@@ -17,8 +17,6 @@ import struct NIO.ByteBuffer
 /// IMAPv4 `tagged-ext-val`
 public enum ParameterValue: Equatable {
     case sequence(SequenceSet)
-    case number(Int)
-    case number64(Int)
     case comp([String])
 }
 
@@ -29,10 +27,6 @@ extension EncodeBuffer {
         switch value {
         case .sequence(let set):
             return self.writeSequenceSet(set)
-        case .number(let num):
-            return self.writeString("\(num)")
-        case .number64(let num):
-            return self.writeString("\(num)")
         case .comp(let comp):
             return
                 self.writeString("(") +

--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -4159,14 +4159,6 @@ extension GrammarParser {
             .sequence(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
         }
 
-        func parseTaggedExtensionSimple_number(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ParameterValue {
-            .number(try self.parseNumber(buffer: &buffer, tracker: tracker))
-        }
-
-        func parseTaggedExtensionSimple_number64(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ParameterValue {
-            .number64(try self.parseNumber(buffer: &buffer, tracker: tracker))
-        }
-
         func parseTaggedExtensionVal_comp(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ParameterValue {
             try ParserLibrary.parseFixedString("(", buffer: &buffer, tracker: tracker)
             let comp = try ParserLibrary.parseOptional(buffer: &buffer, tracker: tracker, parser: self.parseTaggedExtensionComplex) ?? []
@@ -4176,8 +4168,6 @@ extension GrammarParser {
 
         return try ParserLibrary.parseOneOf([
             parseTaggedExtensionSimple_set,
-            parseTaggedExtensionSimple_number,
-            parseTaggedExtensionSimple_number64,
             parseTaggedExtensionVal_comp,
         ], buffer: &buffer, tracker: tracker)
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/CreateParameter+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CreateParameter+Tests.swift
@@ -24,7 +24,7 @@ extension CreateParameter_Tests {
     func testEncode() {
         let inputs: [(CreateParameter, String, UInt)] = [
             (.labelled(.init(name: "name")), "name", #line),
-            (.labelled(.init(name: "name", value: .number(1))), "name 1", #line),
+            (.labelled(.init(name: "name", value: .sequence([1]))), "name 1", #line),
             (.attributes([]), "USE ()", #line),
             (.attributes([.all]), "USE (\\All)", #line),
             (.attributes([.all, .flagged]), "USE (\\All \\Flagged)", #line),

--- a/Tests/NIOIMAPCoreTests/Grammar/FetchModifier+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/FetchModifier+Tests.swift
@@ -25,7 +25,7 @@ extension FetchModifier_Tests {
         let inputs: [(FetchModifier, String, UInt)] = [
             (.changedSince(.init(modifiedSequence: 4)), "CHANGEDSINCE 4", #line),
             (.other(.init(name: "test")), "test", #line),
-            (.other(.init(name: "test", value: .number(4))), "test 4", #line),
+            (.other(.init(name: "test", value: .sequence([4]))), "test 4", #line),
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeFetchModifier($0) })
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnData+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnData+Tests.swift
@@ -27,7 +27,7 @@ extension SearchReturnData_Tests {
             (.max(1), "MAX 1", #line),
             (.all(SequenceSet(1 ... 3)), "ALL 1:3", #line),
             (.count(1), "COUNT 1", #line),
-            (.dataExtension(.init(modifier: "modifier", returnValue: .number(3))), "modifier 3", #line),
+            (.dataExtension(.init(modifier: "modifier", returnValue: .sequence([3]))), "modifier 3", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnDataExtension+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnDataExtension+Tests.swift
@@ -23,7 +23,7 @@ class SearchReturnDataExtension_Tests: EncodeTestClass {}
 extension SearchReturnDataExtension_Tests {
     func testEncode() {
         let inputs: [(SearchReturnDataExtension, String, UInt)] = [
-            (.init(modifier: "modifier", returnValue: .number(123)), "modifier 123", #line),
+            (.init(modifier: "modifier", returnValue: .sequence([123])), "modifier 123", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnOptionExtension+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnOptionExtension+Tests.swift
@@ -24,7 +24,7 @@ extension SearchReturnOptionExtension_Tests {
     func testEncode() {
         let inputs: [(SearchReturnOptionExtension, String, UInt)] = [
             (.init(modifierName: "modifier", params: nil), "modifier", #line),
-            (.init(modifierName: "modifier", params: .number(4)), "modifier 4", #line),
+            (.init(modifierName: "modifier", params: .sequence([4])), "modifier 4", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Grammar/SelectParameter+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/SelectParameter+Tests.swift
@@ -25,7 +25,7 @@ extension SelectParameter_Tests {
         let inputs: [(SelectParameter, String, UInt)] = [
             (.condstore, "CONDSTORE", #line),
             (.basic(.init(name: "test")), "test", #line),
-            (.basic(.init(name: "test", value: .number(1))), "test 1", #line),
+            (.basic(.init(name: "test", value: .sequence([1]))), "test 1", #line),
             (
                 .qresync(.init(uidValiditiy: 1, modifierSequenceValue: .zero, knownUids: nil, sequenceMatchData: nil)),
                 "QRESYNC (1 0)",

--- a/Tests/NIOIMAPCoreTests/Grammar/TaggedExtension/TaggedExtension+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/TaggedExtension/TaggedExtension+Tests.swift
@@ -23,7 +23,7 @@ class TaggedExtension_Tests: EncodeTestClass {}
 extension TaggedExtension_Tests {
     func testEncode() {
         let inputs: [(TaggedExtension, String, UInt)] = [
-            (.init(label: "label", value: .number(1)), "label 1", #line),
+            (.init(label: "label", value: .sequence([1])), "label 1", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Grammar/TaggedExtension/TaggedExtensionValue+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/TaggedExtension/TaggedExtensionValue+Tests.swift
@@ -23,7 +23,7 @@ class TaggedExtensionValue_Tests: EncodeTestClass {}
 extension TaggedExtensionValue_Tests {
     func testEncode() {
         let inputs: [(ParameterValue, String, UInt)] = [
-            (.number(123), "123", #line),
+            (.sequence([123]), "123", #line),
             (.comp(["testComp"]), "((\"testComp\"))", #line),
         ]
 


### PR DESCRIPTION
Resolves #307 

Removes the redundant `ParameterValue.number(64)` cases.

### Motivation:

A single number is the same as a set with a single value. This reduces the amount of code and ambiguity when parsing a single number, which could be parsed correctly as both `.number(1)` and `.sequence([1])`.

### Modifications:

Remove `.number` and `.number64` cases, and replace inside tests with `sequence`
