### PR TITLE
Don't use new ByteBuffer methods

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
@@ -92,7 +92,7 @@ extension MailboxPath {
         return self.name.storage.readableBytesView
             .split(separator: pathSeparator.asciiValue!, omittingEmptySubsequences: omittingEmptySubsequences)
             .map { bytes in
-                self.decodeBufferToString(ByteBuffer(bytes: bytes))
+                self.decodeBufferToString(ByteBuffer(ByteBufferView(bytes)))
             }
     }
 
@@ -189,7 +189,7 @@ public struct MailboxName: Hashable {
 
     public init(_ bytes: ByteBuffer) {
         if String(buffer: bytes).uppercased() == "INBOX" {
-            self.storage = ByteBuffer(string: "INBOX")
+            self.storage = ByteBuffer(ByteBufferView("INBOX".utf8))
         } else {
             self.storage = bytes
         }

--- a/Sources/NIOIMAPCore/Grammar/Quota/QuotaRoot.swift
+++ b/Sources/NIOIMAPCore/Grammar/Quota/QuotaRoot.swift
@@ -28,7 +28,7 @@ public struct QuotaRoot: Equatable {
     /// Creates a new `QuotaRoot`.
     ///  - parameter string: The quota root name
     public init(_ string: String) {
-        self.storage = ByteBuffer(string: string)
+        self.storage = ByteBuffer(ByteBufferView(string.utf8))
     }
 
     public init(_ bytes: ByteBuffer) {


### PR DESCRIPTION
Slight modifications to avoid using new ByteBuffer initialisers that have been added since we defined the ByteBuffer protocol.

### Motivation:

Matt (Mail) noticed that we were using new initialisers that they didn't support, as they weren't in the protocol.

### Modifications:

Stop using these methods, defer to methods supported by the protocol.

### Result:

Mail should be able to continue
