### PR TITLE
Don't add an empty parameter list to SELECT

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -204,9 +204,7 @@ extension CommandEncodeBuffer {
     private mutating func writeCommandKind_examine(mailbox: MailboxName, parameters: [Parameter]) -> Int {
         self.buffer.writeString("EXAMINE ") +
             self.buffer.writeMailbox(mailbox) +
-            self.buffer.writeIfExists(parameters) { (params) -> Int in
-                self.buffer.writeParameters(params)
-            }
+            self.buffer.writeParameters(parameters)
     }
 
     private mutating func writeCommandKind_list(selectOptions: ListSelectOptions?, mailbox: MailboxName, mailboxPatterns: MailboxPatterns, returnOptions: [ReturnOption]) -> Int {
@@ -262,10 +260,7 @@ extension CommandEncodeBuffer {
     private mutating func writeCommandKind_select(mailbox: MailboxName, params: [SelectParameter]) -> Int {
         self.buffer.writeString("SELECT ") +
             self.buffer.writeMailbox(mailbox) +
-            self.buffer.writeSpace() +
-            self.buffer.writeArray(params, callback: { (element, buffer) -> Int in
-                buffer.writeSelectParameter(element)
-                })
+            self.buffer.writeSelectParameters(params)
     }
 
     private mutating func writeCommandKind_status(mailbox: MailboxName, attributes: [MailboxAttribute]) -> Int {

--- a/Sources/NIOIMAPCore/Grammar/SelectParameter.swift
+++ b/Sources/NIOIMAPCore/Grammar/SelectParameter.swift
@@ -40,6 +40,18 @@ public enum SelectParameter: Equatable {
 // MARK: - Encoding
 
 extension EncodeBuffer {
+    @discardableResult mutating func writeSelectParameters(_ params: [SelectParameter]) -> Int {
+        if params.isEmpty {
+            return 0
+        }
+
+        return
+            self.writeSpace() +
+            self.writeArray(params) { (param, self) -> Int in
+                self.writeSelectParameter(param)
+            }
+    }
+
     @discardableResult public mutating func writeSelectParameter(_ param: SelectParameter) -> Int {
         switch param {
         case .qresync(let param):

--- a/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
@@ -36,10 +36,11 @@ extension CommandType_Tests {
             (.login(username: "david evans", password: "great password"), CommandEncodingOptions(), [#"LOGIN "david evans" "great password""#], #line),
             (.login(username: "\r\n", password: "\\\""), CommandEncodingOptions(), ["LOGIN {2}\r\n", "\r\n {2}\r\n", "\\\""], #line),
 
-            (.select(MailboxName("Events")), CommandEncodingOptions(), [#"SELECT "Events" ()"#], #line),
+            (.select(MailboxName("Events")), CommandEncodingOptions(), [#"SELECT "Events""#], #line),
             (.select(.inbox, [.basic(.init(name: "test"))]), CommandEncodingOptions(), [#"SELECT "INBOX" (test)"#], #line),
             (.select(.inbox, [.basic(.init(name: "test1")), .basic(.init(name: "test2"))]), CommandEncodingOptions(), [#"SELECT "INBOX" (test1 test2)"#], #line),
             (.examine(MailboxName("Events")), CommandEncodingOptions(), [#"EXAMINE "Events""#], #line),
+            (.examine(.inbox, [.init(name: "test")]), CommandEncodingOptions(), [#"EXAMINE "INBOX" (test)"#], #line),
             (.move([1], .inbox), CommandEncodingOptions(), ["MOVE 1 \"INBOX\""], #line),
             (.id([]), CommandEncodingOptions(), ["ID NIL"], #line),
             (.getMetadata(options: [], mailbox: .inbox, entries: ["a"]), CommandEncodingOptions(), ["GETMETADATA \"INBOX\" (\"a\")"], #line),


### PR DESCRIPTION
Don't add an empty parameter list to `SELECT` commands.

### Motivation:

RFC 3501 doesn't include `SELECT` parameters. Those were added in RFC 4466. Since there's no reason to include an empty parameter list and it can only cause trouble, it's better not to send it.

This also brings the implementation of `SELECT` in line with the implementation of `EXAMINE`.

### Modifications:

 - Changed the encoding of `SELECT` commands
 - Made a small improvement to the implementation of `EXAMINE`

### Result:

`SELECT "INBOX"` instead of `SELECT "INBOX" ()`.
