### PR TITLE
Remove SwiftNIO-Extras dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let package = Package(
         .library(name: "NIOIMAP", targets: ["NIOIMAP"]),
     ], dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.18.0"),
-        .package(url: "https://github.com/apple/swift-nio-extras", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.7.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.2.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.44.11")),


### PR DESCRIPTION
Remove reference to swift-nio-extras in the package

### Motivation:

We weren't using it, so there's no point wasting time building it.

### Modifications:

Removed the dependency from `Package.swift`

### Result:

Dependency removed
