### PR TITLE
Make PermanentFlag Hashable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Flag/PermanentFlag.swift
+++ b/Sources/NIOIMAPCore/Grammar/Flag/PermanentFlag.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// IMAPv4 `flag-perm`
-public enum PermanentFlag: Equatable {
+public enum PermanentFlag: Hashable {
     case flag(Flag)
     case wildcard
 }


### PR DESCRIPTION
Make `PermanentFlag` conform to `Hashable`.

### Motivation:

It's useful to put `PermanentFlag`s in `Set`s and use them as keys in `Dictionary`s.