### PR TITLE
Make Flag.Keyword ExpressibleByStringLiteral

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Flag/FlagKeyword.swift
+++ b/Sources/NIOIMAPCore/Grammar/Flag/FlagKeyword.swift
@@ -84,6 +84,14 @@ extension Flag.Keyword {
     public static let mdnSent = Self(unchecked: "$MDNSent")
 }
 
+// MARK: - String Literal
+
+extension Flag.Keyword: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+}
+
 // MARK: - Encoding
 
 extension EncodeBuffer {


### PR DESCRIPTION
Conform `Flag.Keyword` to `ExpressibleByStringLiteral`.

### Motivation:

This can be handy, especially in tests.