### PR TITLE
Make UID conform to Codable.

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/UID/UID.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UID.swift
@@ -15,7 +15,7 @@
 /// Unique Message Identifier
 ///
 /// See RFC 3501 section 2.3.1.1.
-public struct UID: RawRepresentable, Hashable {
+public struct UID: RawRepresentable, Hashable, Codable {
     public var rawValue: Int
     public init?(rawValue: Int) {
         guard rawValue >= 1, rawValue <= UInt32.max else { return nil }

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDTests.swift
@@ -55,3 +55,13 @@ extension UIDTests {
         XCTAssertEqual(expected, self.testBufferString)
     }
 }
+
+// MARK: - Codable
+
+extension UIDTests {
+    func testRoundTripCodable() {
+        XCTAssertEqual(try TestUtilities.roundTripCodable(XCTUnwrap(UID(rawValue: 1))), try XCTUnwrap(UID(rawValue: 1)))
+        XCTAssertEqual(try TestUtilities.roundTripCodable(XCTUnwrap(UID(rawValue: 45_678))), try XCTUnwrap(UID(rawValue: 45_678)))
+        XCTAssertEqual(try TestUtilities.roundTripCodable(XCTUnwrap(UID.max)), try XCTUnwrap(UID.max))
+    }
+}

--- a/Tests/NIOIMAPCoreTests/TestUtilities.swift
+++ b/Tests/NIOIMAPCoreTests/TestUtilities.swift
@@ -72,3 +72,11 @@ extension ByteBuffer: ExpressibleByStringLiteral {
         self.writeString(value)
     }
 }
+
+extension TestUtilities {
+    static func roundTripCodable<A>(_ value: A) throws -> A where A: Codable {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        return try decoder.decode(A.self, from: encoder.encode(value))
+    }
+}


### PR DESCRIPTION
We need to embed UIDs into `Codable` types.