### PR TITLE
Remove symbolicate from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,3 @@ RUN gem install jazzy --no-ri --no-rdoc
 # tools
 RUN mkdir -p $HOME/.tools
 RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
-
-# script to allow mapping framepointers on linux (until part of the toolchain)
-RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.tools/symbolicate-linux-fatal
-RUN chmod 755 $HOME/.tools/symbolicate-linux-fatal


### PR DESCRIPTION
Motivation:

It is not actually using symbolicate-linux-fatal in any meaningful way in CI and it's pinned to the master branch which has been removed.

Modifications:

Remove lines referring to symbolicate.

Result:

CI should work again.