### PR TITLE
Back UID, UIDValidity, and SequenceNumber as UInt32

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceNumber.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceNumber.swift
@@ -36,7 +36,7 @@ public struct SequenceNumber: RawRepresentable, Equatable {
 // MARK: - Integer literal
 
 extension SequenceNumber: ExpressibleByIntegerLiteral {
-    public init(integerLiteral value: Int) {
+    public init(integerLiteral value: UInt32) {
         self.init(rawValue: value)!
     }
 
@@ -65,13 +65,12 @@ extension SequenceNumber: Strideable {
     }
 
     /// Advances the current `SequenceNumber` by `n`.
-    /// IMPORTANT: `n` *must* be `<= UInt32.max`. `Int64` is used as the stridable type as it is allows
-    /// values equal `UInt32.max` on all platforms (including 32 bit platforms where `Int.max < UInt32.max`.
+    /// IMPORTANT: `n` *must* be `<= UInt32.max`. `Int64` is used as the stridable type as it allows
+    /// values equal to `UInt32.max` on all platforms (including 32 bit platforms where `Int.max < UInt32.max`.
     /// - parameter n: How many to advance by.
     /// - returns: A new `SequenceNumber`.
     public func advanced(by n: Int64) -> SequenceNumber {
         precondition(n <= UInt32.max, "`n` must be less than UInt32.max")
-        precondition(UInt32(n) + self.rawValue <= UInt32.max, "`self.rawValue + n` must be <= UInt32.max")
         return SequenceNumber(rawValue: self.rawValue + UInt32(n))!
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRange.swift
@@ -48,7 +48,7 @@ extension SequenceRange {
 }
 
 extension SequenceRange: ExpressibleByIntegerLiteral {
-    public init(integerLiteral value: Int) {
+    public init(integerLiteral value: UInt32) {
         self.init(SequenceNumber(integerLiteral: value))
     }
 

--- a/Sources/NIOIMAPCore/Grammar/UID/UID.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UID.swift
@@ -35,7 +35,7 @@ public struct UID: RawRepresentable, Hashable, Codable {
 // MARK: - Integer literal
 
 extension UID: ExpressibleByIntegerLiteral {
-    public init(integerLiteral value: Int) {
+    public init(integerLiteral value: UInt32) {
         self.init(value)
     }
 
@@ -70,13 +70,12 @@ extension UID: Strideable {
     }
 
     /// Advances the current UID by `n`.
-    /// IMPORTANT: `n` *must* be `<= UInt32.max`. `Int64` is used as the stridable type as it is allows
-    /// values equal `UInt32.max` on all platforms (including 32 bit platforms where `Int.max < UInt32.max`.
+    /// IMPORTANT: `n` *must* be `<= UInt32.max`. `Int64` is used as the stridable type as it allows
+    /// values equal to `UInt32.max` on all platforms (including 32 bit platforms where `Int.max < UInt32.max`.
     /// - parameter n: How many to advance by.
     /// - returns: A new `UID`.
     public func advanced(by n: Int64) -> UID {
         precondition(n <= UInt32.max, "`n` must be less than UInt32.max")
-        precondition(UInt32(n) + self.rawValue <= UInt32.max, "`self.rawValue + n` must be <= UInt32.max")
         return UID(rawValue: self.rawValue + UInt32(n))!
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDRange.swift
@@ -48,7 +48,7 @@ extension UIDRange {
 }
 
 extension UIDRange: ExpressibleByIntegerLiteral {
-    public init(integerLiteral value: Int) {
+    public init(integerLiteral value: UInt32) {
         self.init(UID(integerLiteral: value))
     }
 

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDValidity.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDValidity.swift
@@ -29,7 +29,7 @@ public struct UIDValidity: RawRepresentable, Hashable {
 // MARK: - Integer literal
 
 extension UIDValidity: ExpressibleByIntegerLiteral {
-    public init(integerLiteral value: Int) {
+    public init(integerLiteral value: UInt32) {
         self.init(value)
     }
 


### PR DESCRIPTION
Back `UID`, `UIDValidity`, and `SequenceNumber` by `UInt32` internally.

### Motivation:

It's not possible to represent high UInt32 values (as required by RFC 3501) using an `Int` on 32-bit platforms.

### Modifications:

The types are now backed by a `UInt32`, but with an additional `Int` convenience API. `Stridable` conformance needs `Int64` as this is the only signed type that is guaranteed to be larger than `UInt32.max` on any platform.

### Result:

Full support on watchOS with 32-bit pointers.
