### PR TITLE
Use UIDs for nextUIDs and UIDValiditys for uidValiditys

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/IMailboxReference.swift
+++ b/Sources/NIOIMAPCore/Grammar/IMailboxReference.swift
@@ -30,7 +30,7 @@ extension EncodeBuffer {
     @discardableResult mutating func writeIMailboxReference(_ ref: IMailboxReference) -> Int {
         self.writeEncodedMailbox(ref.encodedMailbox) +
             self.writeIfExists(ref.uidValidity) { value in
-                self.writeUIDValidaty(value)
+                self.writeString(";UIDVALIDITY=") + self.writeUIDValidity(value)
             }
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxAttribute.swift
@@ -57,10 +57,10 @@ public struct MailboxStatus: Equatable {
     public var recentCount: Int?
     /// `UIDNEXT`
     /// The next unique identifier value of the mailbox.
-    public var nextUID: Int?
+    public var nextUID: UID?
     /// `UIDVALIDITY`
     /// The unique identifier validity value of the mailbox.
-    public var uidValidity: Int?
+    public var uidValidity: UIDValidity?
     /// `UNSEEN`
     /// The number of messages which do not have the `\Seen` flag set.
     public var unseenCount: Int?
@@ -86,8 +86,8 @@ public struct MailboxStatus: Equatable {
     public init(
         messageCount: Int? = nil,
         recentCount: Int? = nil,
-        nextUID: Int? = nil,
-        uidValidity: Int? = nil,
+        nextUID: UID? = nil,
+        uidValidity: UIDValidity? = nil,
         unseenCount: Int? = nil,
         size: Int? = nil,
         highestModificationSequence: ModificationSequenceValue? = nil
@@ -132,8 +132,8 @@ extension EncodeBuffer {
 
         append(\.messageCount, "MESSAGES")
         append(\.recentCount, "RECENT")
-        append(\.nextUID, "UIDNEXT")
-        append(\.uidValidity, "UIDVALIDITY")
+        append(\.nextUID?.rawValue, "UIDNEXT")
+        append(\.uidValidity?.rawValue, "UIDVALIDITY")
         append(\.unseenCount, "UNSEEN")
         append(\.size, "SIZE")
         append(\.highestModificationSequence, "HIGHESTMODSEQ")

--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
@@ -25,8 +25,8 @@ public enum ResponseTextCode: Equatable {
     case readOnly
     case readWrite
     case tryCreate
-    case uidNext(Int)
-    case uidValidity(Int)
+    case uidNext(UID)
+    case uidValidity(UIDValidity)
     case unseen(Int)
     case namespace(NamespaceResponse)
     case uidAppend(ResponseCodeAppend)
@@ -71,9 +71,9 @@ extension EncodeBuffer {
         case .tryCreate:
             return self.writeString("TRYCREATE")
         case .uidNext(let number):
-            return self.writeString("UIDNEXT \(number)")
+            return self.writeString("UIDNEXT ") + self.writeUID(number)
         case .uidValidity(let number):
-            return self.writeString("UIDVALIDITY \(number)")
+            return self.writeString("UIDVALIDITY ") + self.writeUIDValidity(number)
         case .unseen(let number):
             return self.writeString("UNSEEN \(number)")
         case .other(let atom, let string):

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchCorrelator.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchCorrelator.swift
@@ -23,9 +23,9 @@ public struct SearchCorrelator: Equatable {
     public var mailbox: MailboxName?
 
     /// Required iff using RFC 6237
-    public var uidValidity: Int?
+    public var uidValidity: UIDValidity?
 
-    public init(tag: ByteBuffer, mailbox: MailboxName? = nil, uidValidity: Int? = nil) {
+    public init(tag: ByteBuffer, mailbox: MailboxName? = nil, uidValidity: UIDValidity? = nil) {
         self.tag = tag
         self.mailbox = mailbox
         self.uidValidity = uidValidity
@@ -42,7 +42,7 @@ extension EncodeBuffer {
                 self.writeString(" MAILBOX ") + self.writeMailbox(mailbox)
             } +
             self.writeIfExists(correlator.uidValidity) { uidValidity in
-                self.writeString(" UIDVALIDITY \(uidValidity)")
+                self.writeString(" UIDVALIDITY ") + self.writeUIDValidity(uidValidity)
             } +
             self.writeString(")")
     }

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDValidity.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDValidity.swift
@@ -51,7 +51,7 @@ extension UIDValidity: ExpressibleByIntegerLiteral {
 // MARK: - Encoding
 
 extension EncodeBuffer {
-    @discardableResult mutating func writeUIDValidaty(_ data: UIDValidity) -> Int {
-        self.writeString(";UIDVALIDITY=\(data.rawValue)")
+    @discardableResult mutating func writeUIDValidity(_ data: UIDValidity) -> Int {
+        self.writeString("\(data.rawValue)")
     }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDValidity+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDValidity+Tests.swift
@@ -23,8 +23,8 @@ class UIDValidity_Tests: EncodeTestClass {}
 extension UIDValidity_Tests {
     func testEncode() {
         let inputs: [(UIDValidity, String, UInt)] = [
-            (123, ";UIDVALIDITY=123", #line),
+            (123, "123", #line),
         ]
-        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeUIDValidaty($0) })
+        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeUIDValidity($0) })
     }
 }

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -4487,15 +4487,15 @@ extension ParserUnitTests {
         self.iterateTests(
             testFunction: GrammarParser.parseUIDValidity,
             validInputs: [
-                (";UIDVALIDITY=1", " ", 1, #line),
-                (";UIDVALIDITY=12", " ", 12, #line),
-                (";UIDVALIDITY=123", " ", 123, #line),
+                ("1", " ", 1, #line),
+                ("12", " ", 12, #line),
+                ("123", " ", 123, #line),
             ],
             parserErrorInputs: [
                 ("0", " ", #line),
             ],
             incompleteMessageInputs: [
-                (";UIDVALIDITY=1", "", #line),
+                ("1", "", #line),
             ]
         )
     }


### PR DESCRIPTION
Use `UID` for `nextUID` properties/cases and `UIDValidity` for `uidValidity` properties/cases.

### Motivation:

It's easier if we use these types consistently—especially since they need to validate values.

### Modifications:

 - Use `UID` and `UIDValidity`, along with internal helpers
 - Change the behavior of `writeUIDValidaty` [sic] to be more reusable and fix the typo in the name

