### PR TITLE
Make FetchAttribute Hashable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// IMAPv4 `fetch-att`
-public enum FetchAttribute: Equatable {
+public enum FetchAttribute: Hashable {
     case envelope
     case flags
     case internalDate

--- a/Sources/NIOIMAPCore/Grammar/Modifier/ModificationSequenceValue.swift
+++ b/Sources/NIOIMAPCore/Grammar/Modifier/ModificationSequenceValue.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// IMAP4 RFC 7162 `mod-sequence-value`
-public struct ModificationSequenceValue: Equatable {
+public struct ModificationSequenceValue: Hashable {
     public var value: Int
 
     public static var zero: Self {

--- a/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
+++ b/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
@@ -19,7 +19,7 @@ import struct NIO.ByteBuffer
 /// Is used in a `FETCH` command’s `BODY[<section>]<<partial>>` for the `<section>` part.
 ///
 /// Use `SectionSpecifier.complete` for an empty section specifier (i.e. the complete message).
-public struct SectionSpecifier: Equatable {
+public struct SectionSpecifier: Hashable {
     public internal(set) var part: Part
     public internal(set) var kind: Kind
 


### PR DESCRIPTION
Make `FetchAttribute` `Hashable`.

### Motivation:

It's handy to use these in sets and as dictionary keys.

### Modifications:

Make these types `Hashable`:

 - `SectionSpecifier`
 - `ModificationSequenceValue`
 - `FetchAttribute`
