### PR TITLE
Make SectionSpecifier CustomStringConvertible

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
+++ b/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
@@ -65,6 +65,27 @@ extension SectionSpecifier: Comparable {
     }
 }
 
+extension SectionSpecifier: CustomStringConvertible {
+    public var description: String {
+        let kind: String
+        switch self.kind {
+        case .complete:
+            kind = ""
+        case .header:
+            kind = ".HEADER"
+        case .headerFields(let fields):
+            kind = ".HEADER.FIELDS (\(fields.joined(separator: ","))"
+        case .headerFieldsNot(let fields):
+            kind = ".HEADER.FIELDS.NOT (\(fields.joined(separator: ","))"
+        case .MIMEHeader:
+            kind = ".MIME"
+        case .text:
+            kind = ".TEXT"
+        }
+        return "\(part)\(kind)"
+    }
+}
+
 // MARK: - Types
 
 extension SectionSpecifier {


### PR DESCRIPTION
Make `SectionSpecifier` `CustomStringConvertible`.

### Motivation:

This is useful for logging and debugging.

### Modifications:

Make `SectionSpecifier` conform to `CustomStringConvertible`.

### Result:

`SectionSpecifier.description` should match the encoded value of the specifier.
