### PR TITLE
Add SectionSpecifier.init(_: Part)

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
+++ b/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
@@ -23,6 +23,10 @@ public struct SectionSpecifier: Equatable {
     public internal(set) var part: Part
     public internal(set) var kind: Kind
 
+    public init(_ part: Part) {
+        self.init(part: part, kind: .complete)
+    }
+
     public init(part: Part = .init(rawValue: []), kind: Kind) {
         if part.rawValue.count == 0 {
             precondition(kind != .MIMEHeader, "Cannot use MIME with an empty section part")


### PR DESCRIPTION
Add `SectionSpecifier.init(_: Part)`.

### Motivation:

This makes it easier to request a complete part, since that's something we frequently want to do.

This also makes sense because a part is logically a complete specifier—i.e. `1.1` both represents a part and a complete specifier.

### Modifications:

```swift
    public init(_ part: Part) {
        self.init(part: part, kind: .complete)
    }
```
