### PR TITLE
Make UIDSet Hashable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/UID/UIDRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDRange.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// IMAPv4 `uid-range`
-public struct UIDRange: Equatable, RawRepresentable {
+public struct UIDRange: Hashable, RawRepresentable {
     public var rawValue: ClosedRange<UID>
 
     public var range: ClosedRange<UID> { rawValue }

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDSet.swift
@@ -14,7 +14,7 @@
 
 import struct NIO.ByteBuffer
 
-public struct UIDSet: Equatable {
+public struct UIDSet: Hashable {
     public var ranges: [UIDRange]
 
     public init?(_ ranges: [UIDRange]) {


### PR DESCRIPTION
Conform `UIDSet` to `Hashable`.

### Motivation:

We want to use these in sets and as dictionary keys.

### Modifications:

Make these types `Hashable`:

 - `UIDRange`
 - `UIDSet`