### PR TITLE
Make SectionSpecifier non-optional

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
@@ -28,7 +28,7 @@ public enum FetchAttribute: Hashable {
     /// will not.
     case bodyStructure(extensions: Bool)
     /// `BODY[<section>]<<partial>>` and `BODY.PEEK[<section>]<<partial>>`
-    case bodySection(peek: Bool, _ section: SectionSpecifier?, ClosedRange<UInt32>?)
+    case bodySection(peek: Bool, _ section: SectionSpecifier, ClosedRange<UInt32>?)
     case uid
     case modificationSequence
     case modificationSequenceValue(ModificationSequenceValue)

--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -3280,7 +3280,7 @@ extension GrammarParser {
             }
             try space(buffer: &buffer, tracker: tracker)
             let string = try self.parseNString(buffer: &buffer, tracker: tracker)
-            return .bodySection(section ?? SectionSpecifier(kind: .complete), offset: offset, data: string)
+            return .bodySection(section, offset: offset, data: string)
         }
 
         func parseMessageAttribute_uid(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
@@ -4598,15 +4598,15 @@ extension GrammarParser {
     }
 
     // section         = "[" [section-spec] "]"
-    static func parseSection(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier? {
-        func parseSection_none(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier? {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SectionSpecifier? in
+    static func parseSection(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
+        func parseSection_none(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
+            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SectionSpecifier in
                 try fixedString("[]", buffer: &buffer, tracker: tracker)
-                return nil
+                return .complete
             }
         }
 
-        func parseSection_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier? {
+        func parseSection_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
             try fixedString("[", buffer: &buffer, tracker: tracker)
             let spec = try self.parseSectionSpecifier(buffer: &buffer, tracker: tracker)
             try fixedString("]", buffer: &buffer, tracker: tracker)

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -3819,7 +3819,7 @@ extension ParserUnitTests {
         self.iterateTests(
             testFunction: GrammarParser.parseSection,
             validInputs: [
-                ("[]", "", nil, #line),
+                ("[]", "", .complete, #line),
                 ("[HEADER]", "", SectionSpecifier(kind: .header), #line),
             ],
             parserErrorInputs: [

--- a/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
@@ -76,7 +76,7 @@ final class RoundtripTests: XCTestCase {
             (.fetch([.all], .full, []), #line),
             (.fetch([5678], [.uid, .flags, .internalDate, .envelope], []), #line),
             (.fetch([5678], [.flags, .bodyStructure(extensions: true)], []), #line),
-            (.fetch([5678], [.flags, .bodySection(peek: false, nil, 3 ... 4)], []), #line),
+            (.fetch([5678], [.flags, .bodySection(peek: false, .complete, 3 ... 4)], []), #line),
             (.fetch([5678], [.flags, .bodySection(peek: false, .init(kind: .header), 3 ... 4)], []), #line),
             (.fetch([5678], [.bodySection(peek: false, .init(part: [12, 34], kind: .headerFields(["some", "header"])), 3 ... 4)], []), #line),
 


### PR DESCRIPTION
In `FetchAttribute.bodySection(peek: Bool, sectionSpecifier: ...)` a `nil` `SectionSpecifier` is equal to `.complete`, so remove the nil option and force manual `.complete`. Makes the API a little simpler.