### PR TITLE
Make SequenceSet Hashable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceNumber.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceNumber.swift
@@ -17,7 +17,7 @@
 /// See RFC 3501 section 2.3.1.2.
 ///
 /// IMAPv4 `seq-number`
-public struct SequenceNumber: RawRepresentable, Equatable {
+public struct SequenceNumber: RawRepresentable, Hashable {
     public var rawValue: UInt32
     public init?(rawValue: Int) {
         guard rawValue >= 1, rawValue <= UInt32.max else { return nil }

--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRange.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// IMAPv4 `seq-range`
-public struct SequenceRange: Equatable, RawRepresentable {
+public struct SequenceRange: Hashable, RawRepresentable {
     public var rawValue: ClosedRange<SequenceNumber>
 
     public var range: ClosedRange<SequenceNumber> { rawValue }

--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRangeSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRangeSet.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 // IMAPv4 sequence-set
-public struct SequenceRangeSet: Equatable {
+public struct SequenceRangeSet: Hashable {
     public var ranges: [SequenceRange]
 
     public init?(_ ranges: [SequenceRange]) {

--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceSet.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 // RFC 5182 extended sequence-set
-public enum SequenceSet: Equatable {
+public enum SequenceSet: Hashable {
     // IMAPv4 sequence-set
     case range(SequenceRangeSet)
     // RFC 5182 'seq-last-command'


### PR DESCRIPTION
Make `SequenceSet` conform to `Hashable`.

### Motivation:

It can be helpful to use these in sets and as dictionary keys.

### Modifications:

Make these types `Hashable`:

 - `SequenceNumber`
 - `SequenceRange`
 - `SequenceRangeSet`
 - `SequenceSet`
