### PR TITLE
Rename → Continuation Request

### DIFF
--- a/Sources/CLILib/Handlers/Inbound/ResponseRoundtripHandler.swift
+++ b/Sources/CLILib/Handlers/Inbound/ResponseRoundtripHandler.swift
@@ -36,7 +36,7 @@ public class ResponseRoundtripHandler: ChannelInboundHandler {
 //        var buffer = self.unwrapInboundIn(data)
 //        let originalString = String(buffer: buffer)
 //
-//        var responses = [ResponseOrContinueRequest]()
+//        var responses = [ResponseOrContinuationRequest]()
 //        do {
 //            try self.processor.process(buffer: buffer) { (response) in
 //                responses.append(response)
@@ -54,8 +54,8 @@ public class ResponseRoundtripHandler: ChannelInboundHandler {
 //            switch response {
 //            case .response(let response):
 //                encodeBuffer.writeResponse(response)
-//            case .continueRequest(let req):
-//                encodeBuffer.writeContinueRequest(req)
+//            case .continuationRequest(let req):
+//                encodeBuffer.writeContinuationRequest(req)
 //            }
 //        }
 //

--- a/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
@@ -35,7 +35,7 @@ public final class IMAPClientHandler: ChannelDuplexHandler {
         do {
             try self.decoder.process(buffer: data) { response in
                 switch response {
-                case .continueRequest:
+                case .continuationRequest:
                     self.writeNextChunks(context: context)
                 case .response(let response):
                     context.fireChannelRead(self.wrapInboundOut(response))

--- a/Sources/NIOIMAP/Coders/ResponseDecoder.swift
+++ b/Sources/NIOIMAP/Coders/ResponseDecoder.swift
@@ -16,7 +16,7 @@ import NIO
 import NIOIMAPCore
 
 struct ResponseDecoder: NIOSingleStepByteToMessageDecoder {
-    typealias InboundOut = ResponseOrContinueRequest
+    typealias InboundOut = ResponseOrContinuationRequest
 
     var parser: ResponseParser
 
@@ -24,7 +24,7 @@ struct ResponseDecoder: NIOSingleStepByteToMessageDecoder {
         self.parser = ResponseParser()
     }
 
-    mutating func decode(buffer: inout ByteBuffer) throws -> ResponseOrContinueRequest? {
+    mutating func decode(buffer: inout ByteBuffer) throws -> ResponseOrContinuationRequest? {
         let save = buffer
         do {
             return try self.parser.parseResponseStream(buffer: &buffer)
@@ -33,7 +33,7 @@ struct ResponseDecoder: NIOSingleStepByteToMessageDecoder {
         }
     }
 
-    mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> ResponseOrContinueRequest? {
+    mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> ResponseOrContinuationRequest? {
         try self.decode(buffer: &buffer)
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Response/ContinuationRequest.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ContinuationRequest.swift
@@ -14,8 +14,12 @@
 
 import struct NIO.ByteBuffer
 
+/// A “Command Continuation Request” from the server.
+///
+/// RFC 3501 section 7.5
+///
 /// IMAPv4 `continue-req`
-public enum ContinueRequest: Equatable {
+public enum ContinuationRequest: Equatable {
     case responseText(ResponseText)
     case data(ByteBuffer)
 }

--- a/Sources/NIOIMAPCore/Grammar/Response/Response.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/Response.swift
@@ -15,8 +15,8 @@
 import struct NIO.ByteBuffer
 import struct NIO.ByteBufferAllocator
 
-public enum ResponseOrContinueRequest: Equatable {
-    case continueRequest(ContinueRequest)
+public enum ResponseOrContinuationRequest: Equatable {
+    case continuationRequest(ContinuationRequest)
     case response(Response)
 }
 

--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -886,29 +886,29 @@ extension GrammarParser {
     }
 
     // continue-req    = "+" SP (resp-text / base64) CRLF
-    static func parseContinueRequest(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ContinueRequest {
-        func parseContinueReq_responseText(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ContinueRequest {
+    static func parseContinuationRequest(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ContinuationRequest {
+        func parseContinuation_responseText(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ContinuationRequest {
             .responseText(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        func parseContinueReq_base64(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ContinueRequest {
+        func parseContinuation_base64(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ContinuationRequest {
             .data(try self.parseBase64(buffer: &buffer, tracker: tracker))
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ContinueRequest in
+        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ContinuationRequest in
             try fixedString("+", buffer: &buffer, tracker: tracker)
             // Allow no space and no additional text after "+":
-            let continueReq: ContinueRequest
+            let req: ContinuationRequest
             if try optional(buffer: &buffer, tracker: tracker, parser: space) != nil {
-                continueReq = try oneOf([
-                    parseContinueReq_base64,
-                    parseContinueReq_responseText,
+                req = try oneOf([
+                    parseContinuation_base64,
+                    parseContinuation_responseText,
                 ], buffer: &buffer, tracker: tracker)
             } else {
-                continueReq = .responseText(ResponseText(code: nil, text: ""))
+                req = .responseText(ResponseText(code: nil, text: ""))
             }
             try newline(buffer: &buffer, tracker: tracker)
-            return continueReq
+            return req
         }
     }
 

--- a/Sources/NIOIMAPCore/Parser/ResponseParser.swift
+++ b/Sources/NIOIMAPCore/Parser/ResponseParser.swift
@@ -39,7 +39,7 @@ public struct ResponseParser: Parser {
         self.mode = .response(.fetchOrNormal)
     }
 
-    public mutating func parseResponseStream(buffer: inout ByteBuffer) throws -> ResponseOrContinueRequest? {
+    public mutating func parseResponseStream(buffer: inout ByteBuffer) throws -> ResponseOrContinuationRequest? {
         let tracker = StackTracker.makeNewDefaultLimitStackTracker
         do {
             switch self.mode {
@@ -70,7 +70,7 @@ public struct ResponseParser: Parser {
 // MARK: - Parse responses
 
 extension ResponseParser {
-    fileprivate mutating func parseResponse(state: ResponseState, buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseOrContinueRequest {
+    fileprivate mutating func parseResponse(state: ResponseState, buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseOrContinuationRequest {
         func parseResponse_fetch(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Response {
             switch state {
             case .fetchOrNormal:
@@ -113,12 +113,12 @@ extension ResponseParser {
         }
     }
 
-    private mutating func _parseResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseOrContinueRequest {
-        func parseResponse_continuation(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseOrContinueRequest {
-            .continueRequest(try GrammarParser.parseContinueRequest(buffer: &buffer, tracker: tracker))
+    private mutating func _parseResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseOrContinuationRequest {
+        func parseResponse_continuation(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseOrContinuationRequest {
+            .continuationRequest(try GrammarParser.parseContinuationRequest(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponse_tagged(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseOrContinueRequest {
+        func parseResponse_tagged(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseOrContinuationRequest {
             .response(.taggedResponse(try GrammarParser.parseTaggedResponse(buffer: &buffer, tracker: tracker)))
         }
 

--- a/Sources/NIOIMAPCore/ResponseEncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/ResponseEncodeBuffer.swift
@@ -33,10 +33,10 @@ extension ResponseEncodeBuffer {
     }
 }
 
-// MARK: - Encode ContinueRequest
+// MARK: - Encode ContinuationRequest
 
 extension ResponseEncodeBuffer {
-    @discardableResult public mutating func writeContinueRequest(_ data: ContinueRequest) -> Int {
+    @discardableResult public mutating func writeContinuationRequest(_ data: ContinuationRequest) -> Int {
         var size = 0
         size += self.buffer.writeString("+ ")
         switch data {

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/ContinuationRequestTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/ContinuationRequestTests.swift
@@ -16,13 +16,13 @@ import NIO
 @testable import NIOIMAPCore
 import XCTest
 
-class ContinueRequestTests: EncodeTestClass {}
+class ContinuationRequestTests: EncodeTestClass {}
 
 // MARK: - Encoding
 
-extension ContinueRequestTests {
+extension ContinuationRequestTests {
     func testEncode() {
-        let inputs: [(ContinueRequest, String, UInt)] = [
+        let inputs: [(ContinuationRequest, String, UInt)] = [
             (.data("a"), "+ YQ==\r\n", #line),
             (.responseText(.init(code: .alert, text: "text")), "+ [ALERT] text\r\n", #line),
         ]
@@ -31,7 +31,7 @@ extension ContinueRequestTests {
             defer {
                 self.testBuffer = EncodeBuffer.serverEncodeBuffer(buffer: encoder.bytes, options: ResponseEncodingOptions())
             }
-            return encoder.writeContinueRequest(req)
+            return encoder.writeContinuationRequest(req)
         })
     }
 }

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -997,12 +997,12 @@ extension ParserUnitTests {
     }
 }
 
-// MARK: - parseContinueRequest
+// MARK: - testParseContinuationRequest
 
 extension ParserUnitTests {
-    func testParseContinueRequest() {
+    func testParseContinuationRequest() {
         self.iterateTests(
-            testFunction: GrammarParser.parseContinueRequest,
+            testFunction: GrammarParser.parseContinuationRequest,
             validInputs: [
                 ("+ OK\r\n", " ", .responseText(.init(code: nil, text: "OK")), #line),
                 ("+ YQ==\r\n", " ", .data("a"), #line),
@@ -1244,10 +1244,10 @@ extension ParserUnitTests {
     }
 }
 
-// MARK: - Parse Continue Request
+// MARK: - Parse Continuation Request
 
 extension ParserUnitTests {
-    func testContinueRequest_valid() {
+    func testContinuationRequest_valid() {
         let inputs: [(String, UInt)] = [
             ("+ Ready for additional command text\r\n", #line),
             ("+ \r\n", #line),
@@ -1256,7 +1256,7 @@ extension ParserUnitTests {
 
         for (input, line) in inputs {
             TestUtilities.withBuffer(input, terminator: " ") { (buffer) in
-                XCTAssertNoThrow(try GrammarParser.parseContinueRequest(buffer: &buffer, tracker: .testTracker), line: line)
+                XCTAssertNoThrow(try GrammarParser.parseContinuationRequest(buffer: &buffer, tracker: .testTracker), line: line)
             }
         }
     }

--- a/Tests/NIOIMAPCoreTests/Parser/ResponseParser+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/ResponseParser+Tests.swift
@@ -36,8 +36,8 @@ extension ResponseParser_Tests {
 
 extension ResponseParser_Tests {
     func testParseResponseStream() {
-        let inputs: [(String, [ResponseOrContinueRequest], UInt)] = [
-            ("+ OK Continue", [.continueRequest(.responseText(.init(text: "OK Continue")))], #line),
+        let inputs: [(String, [ResponseOrContinuationRequest], UInt)] = [
+            ("+ OK Continue", [.continuationRequest(.responseText(.init(text: "OK Continue")))], #line),
             ("1 OK NOOP Completed", [.response(.taggedResponse(.init(tag: "1", state: .ok(.init(text: "NOOP Completed")))))], #line),
             (
                 "* 999 FETCH (FLAGS (\\Seen))",
@@ -210,7 +210,7 @@ extension ResponseParser_Tests {
 
         for (input, expected, line) in inputs {
             var buffer = ByteBuffer(string: input + "\r\n")
-            var results = [ResponseOrContinueRequest]()
+            var results = [ResponseOrContinuationRequest]()
             var parser = ResponseParser()
             while buffer.readableBytes > 0 {
                 do {

--- a/Tests/NIOIMAPTests/B2MV+Tests.swift
+++ b/Tests/NIOIMAPTests/B2MV+Tests.swift
@@ -245,7 +245,7 @@ extension B2MV_Tests {
             ("tag BAD [PARSE] Complete", [.taggedResponse(.init(tag: "tag", state: .bad(.init(code: .parse, text: "Complete"))))]),
         ]
 
-        let inputs = inoutPairs.map { ($0.0 + CRLF, $0.1.map { ResponseOrContinueRequest.response($0) }) }
+        let inputs = inoutPairs.map { ($0.0 + CRLF, $0.1.map { ResponseOrContinuationRequest.response($0) }) }
         do {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 stringInputOutputPairs: inputs,

--- a/Tests/NIOIMAPTests/Coders/IMAPServerHandlerTests.swift
+++ b/Tests/NIOIMAPTests/Coders/IMAPServerHandlerTests.swift
@@ -29,7 +29,7 @@ class IMAPServerHandlerTests: XCTestCase {
         self.assertOutboundString("a OK yo\r\n")
     }
 
-    func testSimpleCommandWithContinueRequestWorks() {
+    func testSimpleCommandWithContinuationRequestWorks() {
         self.writeInbound("a LOGIN {4}\r\n")
         XCTAssertNoThrow(XCTAssertNil(try self.channel.readInbound(as: CommandStream.self)))
 
@@ -46,7 +46,7 @@ class IMAPServerHandlerTests: XCTestCase {
         self.assertOutboundString("a OK yo\r\n")
     }
 
-    func testSimpleCommandWithContinueRequestWorksEvenIfClientMisbehavesAndSendsWithoutWaiting() {
+    func testSimpleCommandWithContinuationRequestWorksEvenIfClientMisbehavesAndSendsWithoutWaiting() {
         self.writeInbound("a LOGIN {4}\r\nuser \"password\"\r\n")
         // Nothing happens until `read()`
         XCTAssertNoThrow(XCTAssertNil(try self.channel.readOutbound(as: ByteBuffer.self)))
@@ -59,8 +59,8 @@ class IMAPServerHandlerTests: XCTestCase {
         self.assertOutboundString("+ OK\r\n")
     }
 
-    func testSettingContinueRequestOnLiveHandler() {
-        self.handler.continueRequest = ContinueRequest.responseText(.init(text: "FoO"))
+    func testSettingContinuationRequestOnLiveHandler() {
+        self.handler.continuationRequest = ContinuationRequest.responseText(.init(text: "FoO"))
 
         self.writeInbound("a LOGIN {4}\r\n")
         XCTAssertNoThrow(XCTAssertNil(try self.channel.readInbound(as: CommandStream.self)))
@@ -78,8 +78,8 @@ class IMAPServerHandlerTests: XCTestCase {
         self.assertOutboundString("a OK yo\r\n")
     }
 
-    func testSettingContinueRequestInInit() {
-        self.handler = IMAPServerHandler(continueRequest: ContinueRequest.responseText(.init(text: "FoO")))
+    func testSettingContinuationRequestInInit() {
+        self.handler = IMAPServerHandler(continuationRequest: ContinuationRequest.responseText(.init(text: "FoO")))
         self.channel = EmbeddedChannel(handler: self.handler)
 
         self.writeInbound("a LOGIN {4}\r\n")

--- a/Tests/NIOIMAPTests/RealWorldTests.swift
+++ b/Tests/NIOIMAPTests/RealWorldTests.swift
@@ -33,7 +33,7 @@ extension RealWorldTests {
 
         """
 
-        let inoutPairs: [(String, [NIOIMAPCore.ResponseOrContinueRequest])] = [
+        let inoutPairs: [(String, [NIOIMAPCore.ResponseOrContinuationRequest])] = [
             (
                 input,
                 [


### PR DESCRIPTION
The text of RFC 3501 refers to this as “Command Continuation Request”, and even though the _formal syntax_ calls it `continue-req`, we should use the name from the text rather than the formal syntax.