### PR TITLE
Make SearchKey Hashable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/AttributeFlag.swift
+++ b/Sources/NIOIMAPCore/Grammar/AttributeFlag.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// RFC 7162 Condstore
-public struct AttributeFlag: Equatable, RawRepresentable {
+public struct AttributeFlag: Hashable, RawRepresentable {
     public var rawValue: String
 
     /// "\\Answered"

--- a/Sources/NIOIMAPCore/Grammar/Date/Date.swift
+++ b/Sources/NIOIMAPCore/Grammar/Date/Date.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 /// Represents a date with the format `yyyy-MM-dd`.
 /// (RFC 3501)
-public struct Date: Equatable {
+public struct Date: Hashable {
     /// 4-digit year in the range (1900, 2500)
     public var year: Int
 

--- a/Sources/NIOIMAPCore/Grammar/Entry/EntryFlagName.swift
+++ b/Sources/NIOIMAPCore/Grammar/Entry/EntryFlagName.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct EntryFlagName: Equatable {
+public struct EntryFlagName: Hashable {
     public var flag: AttributeFlag
 
     public init(flag: AttributeFlag) {

--- a/Sources/NIOIMAPCore/Grammar/Entry/EntryKindRequest.swift
+++ b/Sources/NIOIMAPCore/Grammar/Entry/EntryKindRequest.swift
@@ -14,7 +14,7 @@
 
 import struct NIO.ByteBuffer
 
-public struct EntryKindRequest: Equatable {
+public struct EntryKindRequest: Hashable {
     var _backing: String
 
     public static var `private` = Self(_backing: "priv")

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchKey.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchKey.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// IMAPv4 `search-key`
-public indirect enum SearchKey: Equatable {
+public indirect enum SearchKey: Hashable {
     /// RFC 3501: All messages in the mailbox; the default initial key for ANDing.
     case all
 

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchModificationSequence.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchModificationSequence.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// RFC 7162
-public struct SearchModificationSequenceExtension: Equatable {
+public struct SearchModificationSequenceExtension: Hashable {
     public var name: EntryFlagName
     public var request: EntryKindRequest
 
@@ -24,7 +24,7 @@ public struct SearchModificationSequenceExtension: Equatable {
 }
 
 /// RFC 7162
-public struct SearchModificationSequence: Equatable {
+public struct SearchModificationSequence: Hashable {
     public var extensions: [SearchModificationSequenceExtension]
     public var sequenceValue: ModificationSequenceValue
 


### PR DESCRIPTION
Conform `SearchKey` to `Hashable`.

### Motivation:

It's helpful to use these in sets and as keys in dictionaries.

### Modifications:

Make these types `Hashable`:

 - `AttributeFlag`
 - `Date`
 - `EntryFlagName`
 - `EntryKindRequest`
 - `SearchKey`
 - `SearchModificationSequence`
 - `SearchModificationSequenceExtension`