### PR TITLE
Make StoreFlags Hashable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Flag/StoreFlags.swift
+++ b/Sources/NIOIMAPCore/Grammar/Flag/StoreFlags.swift
@@ -14,9 +14,9 @@
 
 import struct NIO.ByteBuffer
 
-public struct StoreFlags: Equatable {
+public struct StoreFlags: Hashable {
     /// What operation to perform on the flags.
-    public enum Operation: String, Equatable {
+    public enum Operation: String, Hashable {
         /// Add to the flags for the message.
         case add = "+"
         /// Remove from the flags for the message.


### PR DESCRIPTION
Make `StoreFlags` conform to `Hashable`.

### Motivation:

It's useful to put these in sets and use them as keys in dictionaries.

### Modifications:

Make these types `Hashable`:

 - `StoreFlags`
 - `StoreFlags.Operation`