### PR TITLE
It's GSSAPI, not GSAPI

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Capability.swift
+++ b/Sources/NIOIMAPCore/Grammar/Capability.swift
@@ -54,7 +54,7 @@ extension Capability {
         public static let pToken = Self(unchecked: "PTOKEN")
         public static let weToken = Self(unchecked: "WETOKEN")
         public static let wsToken = Self(unchecked: "WSTOKEN")
-        public static let gsAPI = Self(unchecked: "GSAPI")
+        public static let gssAPI = Self(unchecked: "GSSAPI")
 
         public var rawValue: String
 


### PR DESCRIPTION
`Capability.AuthKind.gsAPI` should be `Capability.AuthKind.gssAPI` (two _s_ s).