### PR TITLE
Add failable “exactly” initializers for UID, UIDValidity, and SequenceNumber

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceNumber.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceNumber.swift
@@ -49,6 +49,13 @@ extension SequenceNumber: ExpressibleByIntegerLiteral {
     }
 }
 
+extension SequenceNumber {
+    public init?<T>(exactly source: T) where T: BinaryInteger {
+        guard let rawValue = UInt32(exactly: source) else { return nil }
+        self.init(rawValue: rawValue)
+    }
+}
+
 // MARK: - Strideable
 
 extension SequenceNumber: Strideable {

--- a/Sources/NIOIMAPCore/Grammar/UID/UID.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UID.swift
@@ -61,8 +61,15 @@ extension UID: ExpressibleByIntegerLiteral {
     /// Create a `UID`, asserting with invalid values.
     /// - parameter value: A `UInt32` that must be non-zero.
     public init(_ value: UInt32) {
-        assert(value >= 0, "UID cannot be 0")
+        assert(value >= 1, "UID cannot be 0")
         self.init(rawValue: Int(value))!
+    }
+}
+
+extension UID {
+    public init?<T>(exactly source: T) where T: BinaryInteger {
+        guard let rawValue = UInt32(exactly: source) else { return nil }
+        self.init(rawValue: rawValue)
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDValidity.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDValidity.swift
@@ -43,8 +43,15 @@ extension UIDValidity: ExpressibleByIntegerLiteral {
     /// Create a `UIDValidity`, asserting with invalid values.
     /// - parameter value: A `UInt32` that must be non-zero.
     public init(_ value: UInt32) {
-        assert(value >= 0, "UIDValidity cannot be 0")
+        assert(value >= 1, "UIDValidity cannot be 0")
         self.init(rawValue: Int(value))!
+    }
+}
+
+extension UIDValidity {
+    public init?<T>(exactly source: T) where T: BinaryInteger {
+        guard let rawValue = UInt32(exactly: source) else { return nil }
+        self.init(rawValue: rawValue)
     }
 }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/Sequence/SequenceNumberTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Sequence/SequenceNumberTests.swift
@@ -25,6 +25,13 @@ extension SequenceNumberTests {
         let num: SequenceNumber = 5
         XCTAssertEqual(num, 5)
     }
+
+    func testValidRange() {
+        XCTAssertNil(SequenceNumber(exactly: 0))
+        XCTAssertEqual(SequenceNumber(exactly: 1)?.rawValue, 1)
+        XCTAssertEqual(SequenceNumber(exactly: 4_294_967_295)?.rawValue, 4_294_967_295)
+        XCTAssertNil(SequenceNumber(exactly: 4_294_967_296))
+    }
 }
 
 // MARK: - Comparable

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDTests.swift
@@ -25,6 +25,13 @@ extension UIDTests {
         let num: UID = 5
         XCTAssertEqual(num, 5)
     }
+
+    func testValidRange() {
+        XCTAssertNil(UID(exactly: 0))
+        XCTAssertEqual(UID(exactly: 1)?.rawValue, 1)
+        XCTAssertEqual(UID(exactly: 4_294_967_295)?.rawValue, 4_294_967_295)
+        XCTAssertNil(UID(exactly: 4_294_967_296))
+    }
 }
 
 // MARK: - Comparable

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDValidity+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDValidity+Tests.swift
@@ -27,4 +27,11 @@ extension UIDValidity_Tests {
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeUIDValidity($0) })
     }
+
+    func testValidRange() {
+        XCTAssertNil(UIDValidity(exactly: 0))
+        XCTAssertEqual(UIDValidity(exactly: 1)?.rawValue, 1)
+        XCTAssertEqual(UIDValidity(exactly: 4_294_967_295)?.rawValue, 4_294_967_295)
+        XCTAssertNil(UIDValidity(exactly: 4_294_967_296))
+    }
 }


### PR DESCRIPTION
Add
```swift
public init?<T>(exactly source: T) where T : BinaryInteger
```
similar to what `Int` etc. have.