### PR TITLE
Make UIDSet conform to Collection and SetAlgebra

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.7.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.2.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.44.11")),
+        .package(url: "https://github.com/apple/swift-standard-library-preview.git", .exact("0.0.1")),
     ],
     targets: [
         .target(
@@ -34,6 +35,7 @@ let package = Package(
             name: "NIOIMAPCore",
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
+                .product(name: "StandardLibraryPreview", package: "swift-standard-library-preview"),
             ]
         ),
         .testTarget(

--- a/Sources/NIOIMAPCore/Grammar/UID/UID.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UID.swift
@@ -14,6 +14,9 @@
 
 /// Unique Message Identifier
 ///
+/// Not that valid UIDs are 1 ... 4294967295 (UInt32.max).
+/// The maximum value is often rendered as `*` when encoded.
+///
 /// See RFC 3501 section 2.3.1.1.
 public struct UID: RawRepresentable, Hashable, Codable {
     /// The minimum `UID` is always *1*.

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDRange.swift
@@ -28,15 +28,21 @@ public struct UIDRange: Hashable, RawRepresentable {
 
 extension UIDRange {
     /// Creates a new `UIDRange`.
-    /// - parameter rawValue: A closed range with `UID`s as the upper and lower bound.
+    /// - parameter range: A closed range with `UID`s as the upper and lower bound.
     public init(_ range: ClosedRange<UID>) {
         self.init(rawValue: range)
     }
 
     /// Creates a new `UIDRange` from a partial range, using `.min` as the lower bound.
-    /// - parameter rawValue: A partial with a `UID` as the upper bound.
+    /// - parameter range: A partial with a `UID` as the upper bound.
     public init(_ range: PartialRangeThrough<UID>) {
         self.init(UID.min ... range.upperBound)
+    }
+
+    /// Creates a new `UIDRange`.
+    /// - parameter range: An open range with `UID`s as the upper and lower bound.
+    public init?(_: Range<UID>) {
+        fatalError("TODO")
     }
 
     /// Creates a new `UIDRange` from a partial range, using `.max` as the upper bound.

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDSet.swift
@@ -13,20 +13,81 @@
 //===----------------------------------------------------------------------===//
 
 import struct NIO.ByteBuffer
+import StandardLibraryPreview
 
 /// A set contains an array of `UIDRange` to represent a (potentially large) collection of messages.
+///
+/// UIDs are _not_ sorted.
 public struct UIDSet: Hashable {
     /// A non-empty array of UID ranges.
-    public var ranges: [UIDRange]
+    fileprivate var ranges: RangeSet<A>
 
-    /// Creates a new `UIDset`.
-    /// - parameter ranges: A non-empty array of ranges.
-    /// - returns: `nil` if `ranges` is empty, otherwise a new `UIDSet`.
-    public init?(_ ranges: [UIDRange]) {
-        guard !ranges.isEmpty else { return nil }
+    fileprivate init(_ ranges: RangeSet<A>) {
         self.ranges = ranges
     }
+
+    /// Creates a new `UIDSet` containing the UIDs in the given ranges.
+    public init<S: Sequence>(_ ranges: S) where S.Element == UIDRange {
+        self.init()
+        ranges.forEach {
+            self.ranges.insert(contentsOf: Range($0))
+        }
+    }
+
+    public init() {
+        self.ranges = RangeSet()
+    }
 }
+
+// MARK: -
+
+extension UIDSet {
+    /// UIDs shifted by 1, such that UID 1 -> 0, and UID.max -> UInt32.max - 1
+    /// This allows us to store UID.max + 1 inside a UInt32.
+    fileprivate struct A: RawRepresentable, Hashable {
+        var rawValue: UInt32
+    }
+}
+
+extension UIDSet.A: Strideable {
+    public init(_ uid: UID) {
+        // Since UID.min = 1, we can always do this:
+        self.rawValue = uid.rawValue - 1
+    }
+
+    func distance(to other: UIDSet.A) -> Int64 {
+        Int64(other.rawValue) - Int64(self.rawValue)
+    }
+
+    func advanced(by n: Int64) -> UIDSet.A {
+        UIDSet.A(rawValue: UInt32(Int64(rawValue) + n))
+    }
+}
+
+extension UID {
+    fileprivate init(_ a: UIDSet.A) {
+        precondition(a.rawValue < UInt32.max)
+        self.init(rawValue: a.rawValue + 1)!
+    }
+}
+
+extension Range where Element == UIDSet.A {
+    fileprivate init(_ r: UIDRange) {
+        self = UIDSet.A(r.rawValue.lowerBound) ..< UIDSet.A(r.rawValue.upperBound).advanced(by: 1)
+    }
+
+    fileprivate init(_ uid: UID) {
+        self = UIDSet.A(uid) ..< UIDSet.A(uid).advanced(by: 1)
+    }
+}
+
+extension UIDRange {
+    fileprivate init(_ r: Range<UIDSet.A>) {
+        self.init(UID(r.lowerBound) ... UID(r.upperBound.advanced(by: -1)))
+    }
+}
+
+// MARK: -
 
 extension UIDSet {
     /// Creates a `UIDSet` from a closed range.
@@ -50,7 +111,14 @@ extension UIDSet {
     /// Creates a set from a single range.
     /// - parameter range: The `UIDRange` to construct a set from.
     public init(_ range: UIDRange) {
-        self.ranges = [range]
+        let a: Range<A> = Range(range)
+        self.ranges = RangeSet(a)
+    }
+}
+
+extension UIDSet {
+    public init(_ uid: UID) {
+        self.ranges = RangeSet(A(uid) ..< (A(uid).advanced(by: 1)))
     }
 }
 
@@ -59,7 +127,10 @@ extension UIDSet {
 extension UIDSet: CustomStringConvertible {
     /// Creates a human-readable text representation of the set by joined ranges with a comma.
     public var description: String {
-        ranges.map { "\($0)" }.joined(separator: ",")
+        ranges
+            .ranges
+            .map { "\(UIDRange($0))" }
+            .joined(separator: ",")
     }
 }
 
@@ -69,21 +140,138 @@ extension UIDSet: ExpressibleByArrayLiteral {
     /// Creates a new UIDSet from a literal array of ranges.
     /// - parameter arrayLiteral: The elements to use, assumed to be non-empty.
     public init(arrayLiteral elements: UIDRange...) {
-        self.init(elements)!
+        self.init(elements)
     }
 }
 
 extension UIDSet {
     /// A set that contains a single range, that in turn contains all messages.
     public static let all = UIDSet(UIDRange.all)
+    /// A set that contains no UIDs.
+    public static let empty = UIDSet()
+}
+
+extension UIDSet: Collection {
+    public struct Index {
+        fileprivate var rangeIndex: RangeSet<A>.Ranges.Index
+        fileprivate var indexInRange: UID.Stride
+    }
+
+    public var startIndex: Index { Index(rangeIndex: ranges.ranges.startIndex, indexInRange: 0) }
+    public var endIndex: Index {
+        guard !ranges.ranges.isEmpty else { return Index(rangeIndex: ranges.ranges.endIndex, indexInRange: 0) }
+        return Index(rangeIndex: ranges.ranges.endIndex, indexInRange: UID.Stride(ranges.ranges.last!.count))
+    }
+
+    public func index(after i: Index) -> Index {
+        precondition(i.rangeIndex < ranges.ranges.endIndex)
+        let count = UID.Stride(ranges.ranges[i.rangeIndex].count)
+        if i.indexInRange.advanced(by: 1) < count {
+            return Index(rangeIndex: i.rangeIndex, indexInRange: i.indexInRange.advanced(by: 1))
+        }
+        let nextRange = ranges.ranges.index(after: i.rangeIndex)
+        guard nextRange < ranges.ranges.endIndex else { return endIndex }
+        return Index(rangeIndex: nextRange, indexInRange: 0)
+    }
+
+    public subscript(position: Index) -> UID {
+        UID(ranges.ranges[position.rangeIndex].lowerBound).advanced(by: position.indexInRange)
+    }
+
+    public var isEmpty: Bool {
+        ranges.isEmpty
+    }
+
+    /// The number of UIDs in the set.
+    public var count: Int {
+        ranges.ranges.reduce(into: 0) { $0 += $1.count }
+    }
+}
+
+extension UIDSet.Index: Comparable {
+    public static func < (lhs: UIDSet.Index, rhs: UIDSet.Index) -> Bool {
+        if lhs.rangeIndex == rhs.rangeIndex {
+            return lhs.indexInRange < rhs.indexInRange
+        } else {
+            return lhs.rangeIndex < rhs.rangeIndex
+        }
+    }
+
+    public static func > (lhs: UIDSet.Index, rhs: UIDSet.Index) -> Bool {
+        if lhs.rangeIndex == rhs.rangeIndex {
+            return lhs.indexInRange > rhs.indexInRange
+        } else {
+            return lhs.rangeIndex > rhs.rangeIndex
+        }
+    }
+
+    public static func == (lhs: UIDSet.Index, rhs: UIDSet.Index) -> Bool {
+        (lhs.rangeIndex == rhs.rangeIndex) && (lhs.indexInRange == rhs.indexInRange)
+    }
 }
 
 // MARK: - Encoding
 
 extension EncodeBuffer {
     @discardableResult mutating func writeUIDSet(_ set: UIDSet) -> Int {
-        self.writeArray(set.ranges, separator: ",", parenthesis: false) { (element, self) in
-            self.writeUIDRange(element)
+        self.writeArray(set.ranges.ranges, separator: ",", parenthesis: false) { (element, self) in
+            let r = UIDRange(element)
+            return self.writeUIDRange(r)
         }
+    }
+}
+
+// MARK: - Set Algebra
+
+extension UIDSet: SetAlgebra {
+    public typealias Element = UID
+
+    public func contains(_ member: UID) -> Bool {
+        ranges.contains(A(member))
+    }
+
+    public func union(_ other: Self) -> Self {
+        UIDSet(ranges.union(other.ranges))
+    }
+
+    public func intersection(_ other: Self) -> Self {
+        UIDSet(ranges.intersection(other.ranges))
+    }
+
+    public func symmetricDifference(_ other: UIDSet) -> UIDSet {
+        UIDSet(ranges.symmetricDifference(other.ranges))
+    }
+
+    public mutating func insert(_ newMember: UID) -> (inserted: Bool, memberAfterInsert: UID) {
+        guard !contains(newMember) else { return (false, newMember) }
+        let r: Range<A> = Range(newMember)
+        ranges.insert(contentsOf: r)
+        return (true, newMember)
+    }
+
+    public mutating func remove(_ member: UID) -> UID? {
+        guard contains(member) else { return nil }
+        let r: Range<A> = Range(member)
+        ranges.remove(contentsOf: r)
+        return member
+    }
+
+    public mutating func update(with newMember: UID) -> UID? {
+        guard !contains(newMember) else { return newMember }
+        let r: Range<A> = Range(newMember)
+        ranges.insert(contentsOf: r)
+        return nil
+    }
+
+    public mutating func formUnion(_ other: UIDSet) {
+        ranges.formUnion(other.ranges)
+    }
+
+    public mutating func formIntersection(_ other: UIDSet) {
+        ranges.formIntersection(other.ranges)
+    }
+
+    public mutating func formSymmetricDifference(_ other: UIDSet) {
+        ranges.formSymmetricDifference(other.ranges)
     }
 }

--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -4878,7 +4878,8 @@ extension GrammarParser {
                 try fixedString(",", buffer: &buffer, tracker: tracker)
                 return try parseUIDSet_element(buffer: &buffer, tracker: tracker)
             }
-            guard let s = UIDSet(output) else {
+            let s = UIDSet(output)
+            guard !s.isEmpty else {
                 throw ParserError(hint: "UID set is empty.")
             }
             return s

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDSetTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDSetTests.swift
@@ -18,21 +18,28 @@ import XCTest
 
 class UIDSetTests: EncodeTestClass {}
 
-// MARK: - CustomStringCovertible
+// MARK: - CustomStringConvertible
 
 extension UIDSetTests {
     func testCustomStringConvertible() {
-        XCTAssertEqual("\([1 ... 3, UIDRange(4), UIDRange(6)] as UIDSet)", "1:3,4,6")
+        XCTAssertEqual("\([1 ... 3, UIDRange(6), UIDRange(88)] as UIDSet)", "1:3,6,88")
         XCTAssertEqual("\([1 ... (.max)] as UIDSet)", "1:*")
         XCTAssertEqual("\([UIDRange(37)] as UIDSet)", "37")
         XCTAssertEqual("\([UIDRange(.max)] as UIDSet)", "*")
     }
 }
 
-// MARK: - UIDSetTests imapEncoded
+// MARK: - Encoding
 
 extension UIDSetTests {
     func testIMAPEncoded_one() {
+        let expected = "22"
+        let size = self.testBuffer.writeUIDSet(UIDSet(22 ... 22))
+        XCTAssertEqual(size, expected.utf8.count)
+        XCTAssertEqual(expected, self.testBufferString)
+    }
+
+    func testIMAPEncoded_oneRange() {
         let expected = "5:22"
         let size = self.testBuffer.writeUIDSet(UIDSet(5 ... 22))
         XCTAssertEqual(size, expected.utf8.count)
@@ -46,16 +53,178 @@ extension UIDSetTests {
         XCTAssertEqual(expected, self.testBufferString)
     }
 
-    func testIMAPEncoded_full() {
-        let expected = "1,2:3,4,5,6:*"
-        let size = self.testBuffer.writeUIDSet(UIDSet([
-            UIDRange(1),
-            UIDRange(2 ... 3),
-            UIDRange(4),
-            UIDRange(5),
-            UIDRange(6...),
-        ])!)
+    func testIMAPEncoded_almostAll() {
+        let expected = "1:4294967294"
+        let size = self.testBuffer.writeUIDSet(UIDSet(1 ... 4_294_967_294))
         XCTAssertEqual(size, expected.utf8.count)
         XCTAssertEqual(expected, self.testBufferString)
+    }
+
+    func testIMAPEncoded_full() {
+        let expected = "1,22:30,47,55,66:*"
+        let size = self.testBuffer.writeUIDSet(UIDSet([
+            UIDRange(1),
+            UIDRange(22 ... 30),
+            UIDRange(47),
+            UIDRange(55),
+            UIDRange(66...),
+        ]))
+        XCTAssertEqual(size, expected.utf8.count)
+        XCTAssertEqual(expected, self.testBufferString)
+    }
+}
+
+// MARK: - Set Algebra
+
+extension UIDSetTests {
+    func testContains() {
+        XCTAssertFalse(UIDSet(20 ... 22).contains(19))
+        XCTAssert(UIDSet(20 ... 22).contains(20))
+        XCTAssert(UIDSet(20 ... 22).contains(21))
+        XCTAssert(UIDSet(20 ... 22).contains(22))
+        XCTAssertFalse(UIDSet(20 ... 22).contains(23))
+        XCTAssertFalse(UIDSet(20 ... 22).contains(.max))
+
+        XCTAssert(UIDSet.all.contains(1))
+        XCTAssert(UIDSet.all.contains(.max))
+    }
+
+    func testUnion() {
+        XCTAssertEqual("\(UIDSet(20 as UID).union(UIDSet(30 as UID)))", "20,30")
+        XCTAssertEqual("\(UIDSet(20 as UID).union(UIDSet(21 as UID)))", "20:21")
+        XCTAssertEqual("\(UIDSet(20 ... 22).union(UIDSet(30 ... 39)))", "20:22,30:39")
+        XCTAssertEqual("\(UIDSet(20 ... 35).union(UIDSet(30 ... 39)))", "20:39")
+        XCTAssertEqual("\(UIDSet(20 ... 35).union(UIDSet(4 ... 39)))", "4:39")
+        XCTAssertEqual("\(UIDSet(4 ... 39).union(UIDSet(20 ... 35)))", "4:39")
+        XCTAssertEqual("\(UIDSet.all.union(UIDSet(20 ... 35)))", "1:*")
+        XCTAssertEqual("\(UIDSet(20 ... 35).union(UIDSet.all))", "1:*")
+        XCTAssertEqual("\(UIDSet(20 ... 21).union(UIDSet(4_294_967_294 as UID)))", "20:21,4294967294")
+    }
+
+    func testIntersection() {
+        XCTAssertEqual("\(UIDSet(20 as UID).intersection(UIDSet(30 as UID)))", "")
+        XCTAssertEqual("\(UIDSet(20 as UID).intersection(UIDSet(20 as UID)))", "20")
+        XCTAssertEqual("\(UIDSet(20 as UID).intersection(UIDSet(18 ... 22)))", "20")
+        XCTAssertEqual("\(UIDSet(20 ... 22).intersection(UIDSet(30 ... 39)))", "")
+        XCTAssertEqual("\(UIDSet(20 ... 35).intersection(UIDSet(30 ... 39)))", "30:35")
+        XCTAssertEqual("\(UIDSet.all.intersection(UIDSet(20 ... 35)))", "20:35")
+        XCTAssertEqual("\(UIDSet(20 ... 35).intersection(UIDSet.all))", "20:35")
+        XCTAssertEqual("\(UIDSet.all.intersection(UIDSet(2 ... 4_294_967_294)))", "2:4294967294")
+    }
+
+    func testSymmetricDifference() {
+        XCTAssertEqual("\(UIDSet(20 as UID).symmetricDifference(UIDSet(30 as UID)))", "20,30")
+        XCTAssertEqual("\(UIDSet(20 as UID).symmetricDifference(UIDSet(20 as UID)))", "")
+        XCTAssertEqual("\(UIDSet(20 ... 35).symmetricDifference(UIDSet(30 ... 39)))", "20:29,36:39")
+        XCTAssertEqual("\(UIDSet(20 ... 35).symmetricDifference(UIDSet.all))", "1:19,36:*")
+    }
+
+    func testInsert() {
+        var sut = UIDSet()
+        XCTAssertEqual(sut.testInsert(4), .inserted(4))
+        XCTAssertEqual(sut.testInsert(6), .inserted(6))
+        XCTAssertEqual(sut.testInsert(5), .inserted(5))
+        XCTAssertEqual("\(sut)", "4:6")
+        XCTAssertEqual(sut.count, 3)
+        XCTAssertEqual(sut.testInsert(6), .existing(6))
+        XCTAssertEqual(sut.testInsert(1), .inserted(1))
+        XCTAssertEqual("\(sut)", "1,4:6")
+        XCTAssertEqual(sut.count, 4)
+    }
+
+    func testRemove_1() {
+        var sut = UIDSet(4 ... 6)
+        XCTAssertNil(sut.remove(1))
+        XCTAssertEqual("\(sut)", "4:6")
+        XCTAssertEqual(sut.count, 3)
+        XCTAssertEqual(sut.remove(5), 5)
+        XCTAssertNil(sut.remove(5))
+        XCTAssertEqual("\(sut)", "4,6")
+        XCTAssertEqual(sut.count, 2)
+    }
+
+    func testRemove_2() {
+        var sut = UIDSet(1 ... 3)
+        XCTAssertEqual(sut.remove(1), 1)
+        XCTAssertEqual("\(sut)", "2:3")
+        XCTAssertEqual(sut.count, 2)
+    }
+
+    func testUpdate() {
+        var sut = UIDSet()
+        XCTAssertEqual(sut.update(with: 4), nil)
+        XCTAssertEqual(sut.update(with: 6), nil)
+        XCTAssertEqual(sut.update(with: 5), nil)
+        XCTAssertEqual("\(sut)", "4:6")
+        XCTAssertEqual(sut.count, 3)
+        XCTAssertEqual(sut.update(with: 6), 6)
+        XCTAssertEqual(sut.update(with: 1), nil)
+        XCTAssertEqual("\(sut)", "1,4:6")
+        XCTAssertEqual(sut.count, 4)
+    }
+
+    func testFormUnion() {
+        var sut = UIDSet(20 as UID)
+        sut.formUnion(UIDSet(30 as UID))
+        XCTAssertEqual("\(sut)", "20,30")
+    }
+
+    func testFormIntersection() {
+        var sut = UIDSet(20 ... 35)
+        sut.formIntersection(UIDSet(30 ... 40))
+        XCTAssertEqual("\(sut)", "30:35")
+    }
+
+    func testFormSymmetricDifference() {
+        var sut = UIDSet(20 ... 35)
+        sut.formSymmetricDifference(UIDSet(30 ... 40))
+        XCTAssertEqual("\(sut)", "20:29,36:40")
+    }
+
+    func testEmptyCollection() {
+        XCTAssertEqual(UIDSet().map { "\($0)" }, [])
+        XCTAssertEqual(UIDSet().count, 0)
+        XCTAssert(UIDSet().isEmpty)
+    }
+
+    func testSingleElementCollection() {
+        let sut = UIDSet(55 as UID)
+        XCTAssertEqual(sut.map { "\($0)" }, ["55"])
+        XCTAssertEqual(sut.count, 1)
+        XCTAssertFalse(sut.isEmpty)
+    }
+
+    func testSingleRangeCollection() {
+        let sut = UIDSet(55 ... 57)
+        XCTAssertEqual(sut.map { "\($0)" }, ["55", "56", "57"])
+        XCTAssertEqual(sut.count, 3)
+        XCTAssertFalse(sut.isEmpty)
+    }
+
+    func testCollection_A() {
+        let sut = UIDSet([UIDRange(55 ... 57), UIDRange(80)])
+        XCTAssertEqual(sut.map { "\($0)" }, ["55", "56", "57", "80"])
+        XCTAssertEqual(sut.count, 4)
+        XCTAssertFalse(sut.isEmpty)
+    }
+
+    func testCollection_B() {
+        let sut = UIDSet([UIDRange(8), UIDRange(55 ... 57)])
+        XCTAssertEqual(sut.map { "\($0)" }, ["8", "55", "56", "57"])
+        XCTAssertEqual(sut.count, 4)
+        XCTAssertFalse(sut.isEmpty)
+    }
+}
+
+/// Helper to make the result equatable
+private enum InsertResult: Equatable {
+    case inserted(UID)
+    case existing(UID)
+}
+
+extension SetAlgebra where Element == UID {
+    fileprivate mutating func testInsert(_ newMember: UID) -> InsertResult {
+        let r = insert(newMember)
+        return r.0 ? .inserted(r.1) : .existing(r.1)
     }
 }

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -4538,7 +4538,7 @@ extension ParserUnitTests {
         self.iterateTests(
             testFunction: GrammarParser.parseUIDSet,
             validInputs: [
-                ("1234", "\r\n", UIDSet(1234), #line),
+                ("1234", "\r\n", UIDSet(1234 as UID), #line),
                 ("12:34", "\r\n", UIDSet(UIDRange(12 ... 34)), #line),
                 ("1,2,34:56,78:910,11", "\r\n", UIDSet([
                     UIDRange(1),
@@ -4546,7 +4546,7 @@ extension ParserUnitTests {
                     UIDRange(34 ... 56),
                     UIDRange(78 ... 910),
                     UIDRange(11),
-                ])!, #line),
+                ]), #line),
                 ("*", "\r\n", UIDSet(UIDRange(.max)), #line),
                 ("1:*", "\r\n", .all, #line),
             ],


### PR DESCRIPTION
Makes `UIDSet` conform to `Collection` and `SetAlgebra`.

### Motivation:

Operating on a collection of UIDs is an extremely common operation when implementing either a client of a server. And among the very common operations are the `SetAlgebra` operations.

### Modifications:

This uses [SE-0270](https://github.com/apple/swift-evolution/blob/master/proposals/0270-rangeset-and-collection-operations.md) through the [Swift Standard Library Preview](https://github.com/apple/swift-standard-library-preview) to implement `SetAlgebra`.

`UIDSet` now stored the ranges of UIDs as a `RangeSet` (from SE-0270).

As an implementation detail, the ranges are _not_ ranges of `UID` but of an internal type — which is shifted by `1`. This allows representing `UID.max` for `ClosedRange`. This implementation detail is `fileprivate`, though. As is the fact that SE-0270 is being used to implement `UIDSet`.

### Result:

See the updated tests for `UIDSet`.

### Follow-Up:

1. Need to figure out what to do about encoding empty `UIDSet` as part of `Command.uidCopy` etc.
2. Need to make `SequenceSet` conform to `Collection` and `SetAlgebra`.
