### PR TITLE
Rename response code code members

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseCodeCopy.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseCodeCopy.swift
@@ -15,7 +15,6 @@
 /// Matches the `UIDSet` of the messages in the source mailbox to the `UIDSet` of the
 /// copied messages in the destination mailbox.
 public struct ResponseCodeCopy: Equatable {
-
     /// The `UIDValidity` of the destination mailbox
     public var destinationUIDValidity: Int
 


### PR DESCRIPTION
Resolves #385 

The names `num`, `set1`, `set2`, aren't really very descriptive, so they've been renamed to describe what data they actually represent.