### PR TITLE
Rename URL Rump mechanism

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -166,7 +166,7 @@ public enum Command: Equatable {
     /// Requests that the server generate a URLAUTH-
     /// authorized URL for each of the given URLs using the given URL
     /// authorization mechanism.
-    case genURLAuth([URLRumpMechanism])
+    case genURLAuth([RumpURLAndMechanism])
 
     /// Requests that the server return the text data
     /// associated with the specified IMAP URLs
@@ -278,7 +278,7 @@ extension CommandEncodeBuffer {
             }
     }
 
-    private mutating func writeCommandKind_genURLAuth(mechanisms: [URLRumpMechanism]) -> Int {
+    private mutating func writeCommandKind_genURLAuth(mechanisms: [RumpURLAndMechanism]) -> Int {
         self.buffer.writeString("GENURLAUTH") +
             self.buffer.writeArray(mechanisms, prefix: " ", parenthesis: false) { mechanism, buffer in
                 buffer.writeURLRumpMechanism(mechanism)

--- a/Sources/NIOIMAPCore/Grammar/RumpURLAndMechanism.swift
+++ b/Sources/NIOIMAPCore/Grammar/RumpURLAndMechanism.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// Pairs an IMAP "rump" URL with an authentication mechanism
-public struct URLRumpMechanism: Equatable {
+public struct RumpURLAndMechanism: Equatable {
     /// The IMAP URL excluding the access mechanism and access token.
     public var urlRump: ByteBuffer
 
@@ -34,7 +34,7 @@ public struct URLRumpMechanism: Equatable {
 // MARK: - Encoding
 
 extension EncodeBuffer {
-    @discardableResult mutating func writeURLRumpMechanism(_ data: URLRumpMechanism) -> Int {
+    @discardableResult mutating func writeURLRumpMechanism(_ data: RumpURLAndMechanism) -> Int {
         self.writeIMAPString(data.urlRump) +
             self.writeSpace() +
             self.writeUAuthMechanism(data.mechanism)

--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -788,7 +788,7 @@ extension GrammarParser {
 
         func parseCommandAuth_genURLAuth(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
             try fixedString("GENURLAUTH", buffer: &buffer, tracker: tracker)
-            let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> URLRumpMechanism in
+            let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> RumpURLAndMechanism in
                 try space(buffer: &buffer, tracker: tracker)
                 return try self.parseURLRumpMechanism(buffer: &buffer, tracker: tracker)
             })
@@ -2307,8 +2307,8 @@ extension GrammarParser {
         }
     }
 
-    static func parseURLRumpMechanism(buffer: inout ByteBuffer, tracker: StackTracker) throws -> URLRumpMechanism {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> URLRumpMechanism in
+    static func parseURLRumpMechanism(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RumpURLAndMechanism {
+        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> RumpURLAndMechanism in
             let rump = try self.parseAString(buffer: &buffer, tracker: tracker)
             try space(buffer: &buffer, tracker: tracker)
             let mechanism = try self.parseUAuthMechanism(buffer: &buffer, tracker: tracker)

--- a/Tests/NIOIMAPCoreTests/Grammar/URLRumpMechanism+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/URLRumpMechanism+Tests.swift
@@ -22,7 +22,7 @@ class URLRumpMechanism_Tests: EncodeTestClass {}
 
 extension URLRumpMechanism_Tests {
     func testEncode() {
-        let inputs: [(URLRumpMechanism, String, UInt)] = [
+        let inputs: [(RumpURLAndMechanism, String, UInt)] = [
             (.init(urlRump: "test", mechanism: .internal), "\"test\" INTERNAL", #line),
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeURLRumpMechanism($0) })


### PR DESCRIPTION
Resolves #382 

Stop using a terrible name - the new name `RumpURLAndMechanism` makes it more clear this is a pairing.