### PR TITLE
Use a SequenceNumber for ResponseTextCode.unseen

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
@@ -74,7 +74,7 @@ public enum ResponseTextCode: Equatable {
     case uidValidity(UIDValidity)
 
     /// Indicates the number of the first message without the \Seen flag set.
-    case unseen(Int)
+    case unseen(SequenceNumber)
 
     /// A command was unable to complete because it attempted to perform
     /// an option in a namespace the user does not have access.
@@ -200,7 +200,7 @@ extension EncodeBuffer {
         case .uidValidity(let number):
             return self.writeString("UIDVALIDITY ") + self.writeUIDValidity(number)
         case .unseen(let number):
-            return self.writeString("UNSEEN \(number)")
+            return self.writeString("UNSEEN ") + self.writeSequenceNumber(number)
         case .other(let atom, let string):
             return self.writeResponseTextCode_other(atom: atom, string: string)
         case .namespace(let namesapce):

--- a/Sources/NIOIMAPCore/Parser/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/GrammarParser.swift
@@ -3897,7 +3897,7 @@ extension GrammarParser {
 
         func parseResponseTextCode_unseen(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
             try fixedString("UNSEEN ", buffer: &buffer, tracker: tracker)
-            return .unseen(try self.parseNZNumber(buffer: &buffer, tracker: tracker))
+            return .unseen(try self.parseSequenceNumber(buffer: &buffer, tracker: tracker))
         }
 
         func parseResponseTextCode_namespace(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {


### PR DESCRIPTION
This makes it clear that this is a sequence number and not a count.

### Modifications:

Change `Int` to `SequenceNumber`.