### PR TITLE
Encode missing space in CREATE command

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -330,12 +330,12 @@ extension CommandEncodeBuffer {
     private mutating func writeCommandKind_create(mailbox: MailboxName, parameters: [CreateParameter]) -> Int {
         self.buffer.writeString("CREATE ") +
             self.buffer.writeMailbox(mailbox) +
-        self.buffer.write(if: parameters.count > 0, {
-            self.buffer.writeSpace() +
-            self.buffer.writeArray(parameters, separator: "", parenthesis: false) { (param, buffer) -> Int in
-                buffer.writeCreateParameter(param)
+            self.buffer.write(if: parameters.count > 0) {
+                self.buffer.writeSpace() +
+                    self.buffer.writeArray(parameters, separator: "", parenthesis: false) { (param, buffer) -> Int in
+                        buffer.writeCreateParameter(param)
+                    }
             }
-        })
     }
 
     private mutating func writeCommandKind_delete(mailbox: MailboxName) -> Int {

--- a/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
@@ -57,9 +57,9 @@ extension CommandType_Tests {
 
             (.urlFetch(["test"]), CommandEncodingOptions(), ["URLFETCH test"], #line),
             (.urlFetch(["test1", "test2"]), CommandEncodingOptions(), ["URLFETCH test1 test2"], #line),
-            
+
             (.create(.inbox, []), CommandEncodingOptions(), ["CREATE \"INBOX\""], #line),
-            (.create(.inbox, [.attributes([.archive, .drafts, .flagged])]), CommandEncodingOptions(), ["CREATE \"INBOX\" USE (\\archive \\drafts \\flagged)"], #line)
+            (.create(.inbox, [.attributes([.archive, .drafts, .flagged])]), CommandEncodingOptions(), ["CREATE \"INBOX\" USE (\\archive \\drafts \\flagged)"], #line),
         ]
 
         for (test, options, expectedStrings, line) in inputs {


### PR DESCRIPTION
Add a missing space between the new mailbox name and the special use parameters.

### Motivation:

The encoding was incorrect, and bugs are bad.

### Modifications:

Add the missing space, and a test.

### Result:

The bug is dead.
