### PR TITLE
Fix create encode (missing parenthesis)

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -332,7 +332,7 @@ extension CommandEncodeBuffer {
             self.buffer.writeMailbox(mailbox) +
             self.buffer.write(if: parameters.count > 0) {
                 self.buffer.writeSpace() +
-                    self.buffer.writeArray(parameters, separator: "", parenthesis: false) { (param, buffer) -> Int in
+                    self.buffer.writeArray(parameters, separator: "", parenthesis: true) { (param, buffer) -> Int in
                         buffer.writeCreateParameter(param)
                     }
             }

--- a/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
@@ -59,7 +59,7 @@ extension CommandType_Tests {
             (.urlFetch(["test1", "test2"]), CommandEncodingOptions(), ["URLFETCH test1 test2"], #line),
 
             (.create(.inbox, []), CommandEncodingOptions(), ["CREATE \"INBOX\""], #line),
-            (.create(.inbox, [.attributes([.archive, .drafts, .flagged])]), CommandEncodingOptions(), ["CREATE \"INBOX\" USE (\\archive \\drafts \\flagged)"], #line),
+            (.create(.inbox, [.attributes([.archive, .drafts, .flagged])]), CommandEncodingOptions(), ["CREATE \"INBOX\" (USE (\\archive \\drafts \\flagged))"], #line),
         ]
 
         for (test, options, expectedStrings, line) in inputs {


### PR DESCRIPTION
After reviewing the grammar, there's a pair of parenthesis missing from the encoder. The encoding tests have been fixed to reflect this.