### PR TITLE
Add UIDSet.init(_: Range<UID>)

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/UID/UIDSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDSet.swift
@@ -108,6 +108,16 @@ extension UIDSet {
         self.init(UIDRange(range))
     }
 
+    /// Creates a `UIDSet` from a range.
+    /// - parameter range: The range to use.
+    public init(_ range: Range<UID>) {
+        if range.isEmpty {
+            self.init()
+        } else {
+            self.init(range.lowerBound ... range.upperBound.advanced(by: -1))
+        }
+    }
+
     /// Creates a set from a single range.
     /// - parameter range: The `UIDRange` to construct a set from.
     public init(_ range: UIDRange) {


### PR DESCRIPTION
Adds `UIDSet.init(_: Range<UID>)`.

### Motivation:

If you call `UIDSet(1 ..< 10_001)` today, it will create a `UIDSet` by iterating over the range and calling `insert` 10,000 times.  A dedicated initializer is much more efficient.