### PR TITLE
Add @discardableResult to SetAlgebra implementations

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRangeSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRangeSet.swift
@@ -207,6 +207,7 @@ extension SequenceRangeSet: SetAlgebra {
         Self(rangeSet: ranges.symmetricDifference(other.ranges))
     }
 
+    @discardableResult
     public mutating func insert(_ newMember: SequenceNumber) -> (inserted: Bool, memberAfterInsert: SequenceNumber) {
         guard !contains(newMember) else { return (false, newMember) }
         let r: Range<SequenceNumberWrapper> = Range(newMember)
@@ -214,6 +215,7 @@ extension SequenceRangeSet: SetAlgebra {
         return (true, newMember)
     }
 
+    @discardableResult
     public mutating func remove(_ member: SequenceNumber) -> SequenceNumber? {
         guard contains(member) else { return nil }
         let r: Range<SequenceNumberWrapper> = Range(member)
@@ -221,6 +223,7 @@ extension SequenceRangeSet: SetAlgebra {
         return member
     }
 
+    @discardableResult
     public mutating func update(with newMember: SequenceNumber) -> SequenceNumber? {
         guard !contains(newMember) else { return newMember }
         let r: Range<SequenceNumberWrapper> = Range(newMember)

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDSet.swift
@@ -252,6 +252,7 @@ extension UIDSet: SetAlgebra {
         UIDSet(ranges.symmetricDifference(other.ranges))
     }
 
+    @discardableResult
     public mutating func insert(_ newMember: UID) -> (inserted: Bool, memberAfterInsert: UID) {
         guard !contains(newMember) else { return (false, newMember) }
         let r: Range<UIDShiftWrapper> = Range(newMember)
@@ -259,6 +260,7 @@ extension UIDSet: SetAlgebra {
         return (true, newMember)
     }
 
+    @discardableResult
     public mutating func remove(_ member: UID) -> UID? {
         guard contains(member) else { return nil }
         let r: Range<UIDShiftWrapper> = Range(member)
@@ -266,6 +268,7 @@ extension UIDSet: SetAlgebra {
         return member
     }
 
+    @discardableResult
     public mutating func update(with newMember: UID) -> UID? {
         guard !contains(newMember) else { return newMember }
         let r: Range<UIDShiftWrapper> = Range(newMember)


### PR DESCRIPTION
Add @discardableResult to SetAlgebra implementations

### Motivation:

These 3 methods should have `@discardableResult`
```
    public mutating func insert(_ newMember: Element) -> (inserted: Bool, memberAfterInsert: Element)
    public mutating func remove(_ member: Element) -> Element?
    public mutating func update(with newMember: Element) -> Element?
```
