### PR TITLE
Make internal date comparable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Date/InternalDate.swift
+++ b/Sources/NIOIMAPCore/Grammar/Date/InternalDate.swift
@@ -20,7 +20,7 @@
 /// See RFC 3501 section 2.3.3. “Internal Date Message Attribute”
 ///
 /// IMAPv4 `date-time`
-public struct InternalDate: Equatable {
+public struct InternalDate: Hashable {
     var rawValue: UInt64
 
     /// The components of the date, such as the day, month, year, etc.
@@ -128,7 +128,6 @@ extension InternalDate {
 }
 
 extension InternalDate: Comparable {
-    
     public static func < (lhs: InternalDate, rhs: InternalDate) -> Bool {
         let c1 = lhs.components, c2 = rhs.components
         if c1.year < c2.year {
@@ -154,7 +153,6 @@ extension InternalDate: Comparable {
         }
         return false
     }
-    
 }
 
 // MARK: - Internal

--- a/Tests/NIOIMAPCoreTests/Grammar/DateTests/InternalDateTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/DateTests/InternalDateTests.swift
@@ -61,52 +61,49 @@ extension InternalDateTests {
 }
 
 // MARK: - Comparable
+
 extension InternalDateTests {
-    
     func testLessThan() {
-        
         // test the same date
         var d1 = InternalDate(.init(year: 1994, month: 06, day: 25, hour: 01, minute: 02, second: 03, timeZoneMinutes: 0)!)
         var d2 = d1
         XCTAssertFalse(d1 < d2)
-        
+
         // test the same date, different time zone
         d1 = InternalDate(.init(year: 1994, month: 06, day: 25, hour: 01, minute: 02, second: 03, timeZoneMinutes: -100)!)
         d2 = InternalDate(.init(year: 1994, month: 06, day: 25, hour: 01, minute: 02, second: 03, timeZoneMinutes: 0)!)
         XCTAssertTrue(d1 < d2)
-        
+
         // test almost the same, different time zone
         d1 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         d2 = InternalDate(.init(year: 2001, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         XCTAssertTrue(d1 < d2)
-        
+
         // test almost the same, different year
         d1 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         d2 = InternalDate(.init(year: 2001, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         XCTAssertTrue(d1 < d2)
-        
+
         // test almost the same, different year
         d1 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         d2 = InternalDate(.init(year: 2000, month: 2, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         XCTAssertTrue(d1 < d2)
-        
+
         // test almost the same, different year
         d1 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         d2 = InternalDate(.init(year: 2000, month: 1, day: 3, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         XCTAssertTrue(d1 < d2)
-        
+
         d1 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         d2 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 4, minute: 4, second: 5, timeZoneMinutes: 0)!)
         XCTAssertTrue(d1 < d2)
-        
+
         d1 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         d2 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 5, second: 5, timeZoneMinutes: 0)!)
         XCTAssertTrue(d1 < d2)
-        
+
         d1 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 4, second: 5, timeZoneMinutes: 0)!)
         d2 = InternalDate(.init(year: 2000, month: 1, day: 2, hour: 3, minute: 4, second: 6, timeZoneMinutes: 0)!)
         XCTAssertTrue(d1 < d2)
-        
     }
-    
 }


### PR DESCRIPTION
`InternalDate: Comparable`.

Implemented and tested with fairly basic `if-then` logic.  It's possible to achieve using `rawValue`, but this code is easier to understand and (probably) just as fast.