### PR TITLE
Make MessageData.expunge take a SequenceNumber

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Message/MessageData.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/MessageData.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 /// A piece of data regarding a message, returned as an untagged server response.
 public enum MessageData: Equatable {
     /// The specified message sequence number has been permanently removed from the mailbox
-    case expunge(Int)
+    case expunge(SequenceNumber)
 
     /// RFC 7162 Condstore
     /// The VANISHED UID FETCH modifier instructs the server to report those
@@ -45,7 +45,7 @@ extension EncodeBuffer {
     @discardableResult mutating func writeMessageData(_ data: MessageData) -> Int {
         switch data {
         case .expunge(let number):
-            return self.writeString("\(number) EXPUNGE")
+            return self.writeSequenceNumber(number) + self.writeString(" EXPUNGE")
         case .vanished(let set):
             return self.writeString("VANISHED ") + self.writeSequenceSet(set)
         case .vanishedEarlier(let set):

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
@@ -27,7 +27,7 @@ extension GrammarParser {
     // message-data    = nz-number SP ("EXPUNGE" / ("FETCH" SP msg-att))
     static func parseMessageData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageData {
         func parseMessageData_expunge(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageData {
-            let number = try self.parseNZNumber(buffer: &buffer, tracker: tracker)
+            let number = try self.parseSequenceNumber(buffer: &buffer, tracker: tracker)
             try fixedString(" EXPUNGE", buffer: &buffer, tracker: tracker)
             return .expunge(number)
         }


### PR DESCRIPTION
Change `MessageData.expunge(Int)` to `MessageData.expunge(SequenceNumber)`.

### Motivation:

This is a sequence number, so we should use the `SequenceNumber` type to help catch any mistakes.