### PR TITLE
Throw if creating a sub mailbox where path separator is nil

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
@@ -151,11 +151,10 @@ extension MailboxPath {
     /// - throws: `InvalidMailboxNameError` if the `displayName` contains a `pathSeparator`.
     /// - returns: A new `MailboxPath` containing the given name and separator.
     public func makeSubMailbox(displayName: String) throws -> MailboxPath {
-        
         guard let separator = self.pathSeparator else {
             throw InvalidPathSeparatorError(description: "Need a path separator to make a sub mailbox")
         }
-        
+
         // the new name should not contain a path separator
         if displayName.contains(separator) {
             throw InvalidMailboxNameError(description: "\(displayName) cannot contain the separator \(separator)")

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxName+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxName+Tests.swift
@@ -97,7 +97,7 @@ extension MailboxName_Tests {
             XCTAssertEqual(path.displayStringComponents(omittingEmptySubsequences: ommitEmpty), expected, line: line)
         }
     }
-    
+
     func testCreateSubmailboxWithoutPathSeparatorThrows() {
         let mailbox = try! MailboxPath(name: .inbox, pathSeparator: nil)
         XCTAssertThrowsError(try mailbox.makeSubMailbox(displayName: "sub")) { e in


### PR DESCRIPTION
Resolves #460 

You shouldn't be able to create a sub mailbox if the mailbox's path separator is `nil`. This PR fixes that by throwing an error.