### PR TITLE
restore separation of parser & parser library

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Append.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Append.swift
@@ -25,48 +25,48 @@ import struct NIO.ByteBufferView
 
 extension GrammarParser {
     // append          = "APPEND" SP mailbox 1*append-message
-    static func parseAppend(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CommandStream {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> CommandStream in
+    static func parseAppend(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CommandStream {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> CommandStream in
             let tag = try self.parseTag(buffer: &buffer, tracker: tracker)
-            try fixedString(" APPEND ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" APPEND ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
             return .append(.start(tag: tag, appendingTo: mailbox))
         }
     }
 
     // append-data = literal / literal8 / append-data-ext
-    static func parseAppendData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AppendData {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AppendData in
-            let withoutContentTransferEncoding = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try fixedString("~", buffer: &buffer, tracker: tracker)
+    static func parseAppendData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AppendData {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AppendData in
+            let withoutContentTransferEncoding = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try ParserLibrary.fixedString("~", buffer: &buffer, tracker: tracker)
             }.map { () in true } ?? false
-            try fixedString("{", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("{", buffer: &buffer, tracker: tracker)
             let length = try Self.parseNumber(buffer: &buffer, tracker: tracker)
-            _ = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try fixedString("+", buffer: &buffer, tracker: tracker)
+            _ = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try ParserLibrary.fixedString("+", buffer: &buffer, tracker: tracker)
             }.map { () in false } ?? true
-            try fixedString("}", buffer: &buffer, tracker: tracker)
-            try newline(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("}", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
             return .init(byteCount: length, withoutContentTransferEncoding: withoutContentTransferEncoding)
         }
     }
 
     // append-message = appents-opts SP append-data
-    static func parseAppendMessage(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AppendMessage {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> AppendMessage in
+    static func parseAppendMessage(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AppendMessage {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> AppendMessage in
             let options = try self.parseAppendOptions(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let data = try self.parseAppendData(buffer: &buffer, tracker: tracker)
             return .init(options: options, data: data)
         }
     }
 
     // Like appendMessage, but with CATENATE at the start instead of regular append data.
-    static func parseCatenateMessage(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AppendOptions {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> AppendOptions in
+    static func parseCatenateMessage(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AppendOptions {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> AppendOptions in
             let options = try self.parseAppendOptions(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
-            try fixedString("CATENATE (", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("CATENATE (", buffer: &buffer, tracker: tracker)
             return options
         }
     }
@@ -76,35 +76,35 @@ extension GrammarParser {
         case catenate(AppendOptions)
     }
 
-    static func parseAppendOrCatenateMessage(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AppendOrCatenateMessage {
-        func parseAppend(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AppendOrCatenateMessage {
+    static func parseAppendOrCatenateMessage(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AppendOrCatenateMessage {
+        func parseAppend(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AppendOrCatenateMessage {
             try .append(self.parseAppendMessage(buffer: &buffer, tracker: tracker))
         }
 
-        func parseCatenate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AppendOrCatenateMessage {
+        func parseCatenate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AppendOrCatenateMessage {
             try .catenate(self.parseCatenateMessage(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseCatenate,
             parseAppend,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // append-options = [SP flag-list] [SP date-time] *(SP append-ext)
-    static func parseAppendOptions(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AppendOptions {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            let flagList = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [Flag] in
-                try space(buffer: &buffer, tracker: tracker)
+    static func parseAppendOptions(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AppendOptions {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            let flagList = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [Flag] in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseFlagList(buffer: &buffer, tracker: tracker)
             } ?? []
-            let internalDate = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> InternalDate in
-                try space(buffer: &buffer, tracker: tracker)
+            let internalDate = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> InternalDate in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseInternalDate(buffer: &buffer, tracker: tracker)
             }
             var kvs = KeyValues<String, ParameterValue>()
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &kvs, tracker: tracker) { (buffer, tracker) -> KeyValue<String, ParameterValue> in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseTaggedExtension(buffer: &buffer, tracker: tracker)
             }
             return .init(flagList: flagList, internalDate: internalDate, extensions: kvs)
@@ -117,36 +117,36 @@ extension GrammarParser {
         case end
     }
 
-    static func parseCatenatePart(expectPrecedingSpace: Bool, buffer: inout ByteBuffer, tracker: StackTracker) throws -> CatenatePart {
-        func parseCatenateURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CatenatePart {
+    static func parseCatenatePart(expectPrecedingSpace: Bool, buffer: inout ParseBuffer, tracker: StackTracker) throws -> CatenatePart {
+        func parseCatenateURL(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CatenatePart {
             if expectPrecedingSpace {
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             }
-            try fixedString("URL ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("URL ", buffer: &buffer, tracker: tracker)
             let url = try self.parseAString(buffer: &buffer, tracker: tracker)
             return .url(url)
         }
 
-        func parseCatenateText(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CatenatePart {
+        func parseCatenateText(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CatenatePart {
             if expectPrecedingSpace {
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             }
-            try fixedString("TEXT {", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("TEXT {", buffer: &buffer, tracker: tracker)
             let length = try Self.parseNumber(buffer: &buffer, tracker: tracker)
-            _ = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try fixedString("+", buffer: &buffer, tracker: tracker)
+            _ = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try ParserLibrary.fixedString("+", buffer: &buffer, tracker: tracker)
             }.map { () in false } ?? true
-            try fixedString("}", buffer: &buffer, tracker: tracker)
-            try newline(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("}", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
             return .text(length)
         }
 
-        func parseCatenateEnd(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CatenatePart {
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+        func parseCatenateEnd(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CatenatePart {
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .end
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseCatenateURL,
             parseCatenateText,
             parseCatenateEnd,

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
@@ -26,11 +26,11 @@ import struct NIO.ByteBufferView
 extension GrammarParser {
     // command         = tag SP (command-any / command-auth / command-nonauth /
     //                   command-select) CRLF
-    static func parseCommand(buffer: inout ByteBuffer, tracker: StackTracker) throws -> TaggedCommand {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+    static func parseCommand(buffer: inout ParseBuffer, tracker: StackTracker) throws -> TaggedCommand {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             let tag = try self.parseTag(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
-            let type = try oneOf([
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
+            let type = try ParserLibrary.oneOf([
                 self.parseCommandAny,
                 self.parseCommandAuth,
                 self.parseCommandNonauth,
@@ -42,33 +42,33 @@ extension GrammarParser {
     }
 
     // command-any     = "CAPABILITY" / "LOGOUT" / "NOOP" / enable / x-command / id
-    static func parseCommandAny(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        func parseCommandAny_capability(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("CAPABILITY", buffer: &buffer, tracker: tracker)
+    static func parseCommandAny(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        func parseCommandAny_capability(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("CAPABILITY", buffer: &buffer, tracker: tracker)
             return .capability
         }
 
-        func parseCommandAny_logout(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("LOGOUT", buffer: &buffer, tracker: tracker)
+        func parseCommandAny_logout(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("LOGOUT", buffer: &buffer, tracker: tracker)
             return .logout
         }
 
-        func parseCommandAny_noop(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("NOOP", buffer: &buffer, tracker: tracker)
+        func parseCommandAny_noop(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("NOOP", buffer: &buffer, tracker: tracker)
             return .noop
         }
 
-        func parseCommandAny_id(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
+        func parseCommandAny_id(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
             let id = try self.parseID(buffer: &buffer, tracker: tracker)
             return .id(id)
         }
 
-        func parseCommandAny_enable(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
+        func parseCommandAny_enable(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
             let enable = try self.parseEnable(buffer: &buffer, tracker: tracker)
             return enable
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseCommandAny_noop,
             parseCommandAny_logout,
             parseCommandAny_capability,
@@ -83,33 +83,33 @@ extension GrammarParser {
     //                   idle
     // RFC 6237
     // command-auth =/  esearch
-    static func parseCommandAuth(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        func parseCommandAuth_getMetadata(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("GETMETADATA", buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
-            let options = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> [MetadataOption] in
+    static func parseCommandAuth(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        func parseCommandAuth_getMetadata(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("GETMETADATA", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
+            let options = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> [MetadataOption] in
                 let options = try self.parseMetadataOptions(buffer: &buffer, tracker: tracker)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return options
             }) ?? []
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let entries = try self.parseEntries(buffer: &buffer, tracker: tracker)
             return .getMetadata(options: options, mailbox: mailbox, entries: entries)
         }
 
-        func parseCommandAuth_setMetadata(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("SETMETADATA ", buffer: &buffer, tracker: tracker)
+        func parseCommandAuth_setMetadata(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("SETMETADATA ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let list = try self.parseEntryValues(buffer: &buffer, tracker: tracker)
             return .setMetadata(mailbox: mailbox, entries: list)
         }
 
-        func parseCommandAuth_resetKey(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("RESETKEY", buffer: &buffer, tracker: tracker)
-            let _mailbox = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> MailboxName in
-                try space(buffer: &buffer, tracker: tracker)
+        func parseCommandAuth_resetKey(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("RESETKEY", buffer: &buffer, tracker: tracker)
+            let _mailbox = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> MailboxName in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseMailbox(buffer: &buffer, tracker: tracker)
             })
 
@@ -119,31 +119,31 @@ extension GrammarParser {
             }
 
             let mechanisms = try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> URLAuthenticationMechanism in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseUAuthMechanism(buffer: &buffer, tracker: tracker)
             })
             return .resetKey(mailbox: mailbox, mechanisms: mechanisms)
         }
 
-        func parseCommandAuth_generateAuthorizedURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("GENURLAUTH", buffer: &buffer, tracker: tracker)
+        func parseCommandAuth_generateAuthorizedURL(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("GENURLAUTH", buffer: &buffer, tracker: tracker)
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> RumpURLAndMechanism in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseURLRumpMechanism(buffer: &buffer, tracker: tracker)
             })
             return .generateAuthorizedURL(array)
         }
 
-        func parseCommandAuth_urlFetch(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("URLFETCH", buffer: &buffer, tracker: tracker)
+        func parseCommandAuth_urlFetch(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("URLFETCH", buffer: &buffer, tracker: tracker)
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> ByteBuffer in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseAString(buffer: &buffer, tracker: tracker)
             })
             return .urlFetch(array)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             self.parseCreate,
             self.parseDelete,
             self.parseExamine,
@@ -166,13 +166,13 @@ extension GrammarParser {
     }
 
     // command-nonauth = login / authenticate / "STARTTLS"
-    static func parseCommandNonauth(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        func parseCommandNonauth_starttls(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("STARTTLS", buffer: &buffer, tracker: tracker)
+    static func parseCommandNonauth(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        func parseCommandNonauth_starttls(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("STARTTLS", buffer: &buffer, tracker: tracker)
             return .starttls
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             self.parseLogin,
             self.parseAuthenticate,
             parseCommandNonauth_starttls,
@@ -183,28 +183,28 @@ extension GrammarParser {
     //                   uid / search / move
     // RFC 6237
     // command-select =/  esearch
-    static func parseCommandSelect(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        func parseCommandSelect_check(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("CHECK", buffer: &buffer, tracker: tracker)
+    static func parseCommandSelect(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        func parseCommandSelect_check(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("CHECK", buffer: &buffer, tracker: tracker)
             return .check
         }
 
-        func parseCommandSelect_close(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("CLOSE", buffer: &buffer, tracker: tracker)
+        func parseCommandSelect_close(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("CLOSE", buffer: &buffer, tracker: tracker)
             return .close
         }
 
-        func parseCommandSelect_expunge(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("EXPUNGE", buffer: &buffer, tracker: tracker)
+        func parseCommandSelect_expunge(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("EXPUNGE", buffer: &buffer, tracker: tracker)
             return .expunge
         }
 
-        func parseCommandSelect_unselect(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("UNSELECT", buffer: &buffer, tracker: tracker)
+        func parseCommandSelect_unselect(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("UNSELECT", buffer: &buffer, tracker: tracker)
             return .unselect
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseCommandSelect_check,
             parseCommandSelect_close,
             parseCommandSelect_expunge,

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Date.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Date.swift
@@ -25,25 +25,25 @@ import struct NIO.ByteBufferView
 
 extension GrammarParser {
     // date            = date-text / DQUOTE date-text DQUOTE
-    static func parseDate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMAPDate {
-        func parseDateText_quoted(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMAPDate {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-                try fixedString("\"", buffer: &buffer, tracker: tracker)
+    static func parseDate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMAPDate {
+        func parseDateText_quoted(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMAPDate {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
                 let date = try self.parseDateText(buffer: &buffer, tracker: tracker)
-                try fixedString("\"", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
                 return date
             }
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseDateText,
             parseDateText_quoted,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // date-day        = 1*2DIGIT
-    static func parseDateDay(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-        let (num, size) = try ParserLibrary.parseUnsignedInteger(buffer: &buffer, tracker: tracker)
+    static func parseDateDay(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+        let (num, size) = try ParserLibrary.parseUnsignedInteger(buffer: &buffer, tracker: tracker, allowLeadingZeros: true)
         guard size <= 2 else {
             throw ParserError(hint: "Expected 1 or 2 bytes, got \(size)")
         }
@@ -51,13 +51,13 @@ extension GrammarParser {
     }
 
     // date-day-fixed  = (SP DIGIT) / 2DIGIT
-    static func parseDateDayFixed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-        func parseDateDayFixed_spaced(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-            try fixedString(" ", buffer: &buffer, tracker: tracker)
+    static func parseDateDayFixed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+        func parseDateDayFixed_spaced(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+            try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
             return try self.parseNDigits(buffer: &buffer, tracker: tracker, bytes: 1)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseDateDayFixed_spaced,
             parse2Digit,
         ], buffer: &buffer, tracker: tracker)
@@ -65,7 +65,7 @@ extension GrammarParser {
 
     // date-month      = "Jan" / "Feb" / "Mar" / "Apr" / "May" / "Jun" /
     //                   "Jul" / "Aug" / "Sep" / "Oct" / "Nov" / "Dec"
-    static func parseDateMonth(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
+    static func parseDateMonth(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
         let string = try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char -> Bool in
             isalnum(Int32(char)) != 0
         }
@@ -76,12 +76,12 @@ extension GrammarParser {
     }
 
     // date-text       = date-day "-" date-month "-" date-year
-    static func parseDateText(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMAPDate {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+    static func parseDateText(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMAPDate {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             let day = try self.parseDateDay(buffer: &buffer, tracker: tracker)
-            try fixedString("-", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
             let month = try self.parseDateMonth(buffer: &buffer, tracker: tracker)
-            try fixedString("-", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
             let year = try self.parse4Digit(buffer: &buffer, tracker: tracker)
             guard let date = IMAPDate(year: year, month: month, day: day) else {
                 throw ParserError(hint: "Invalid date components \(year) \(month) \(day)")
@@ -92,24 +92,24 @@ extension GrammarParser {
 
     // date-time       = DQUOTE date-day-fixed "-" date-month "-" date-year
     //                   SP time SP zone DQUOTE
-    static func parseInternalDate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> InternalDate {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+    static func parseInternalDate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> InternalDate {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             let day = try self.parseDateDayFixed(buffer: &buffer, tracker: tracker)
-            try fixedString("-", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
             let month = try self.parseDateMonth(buffer: &buffer, tracker: tracker)
-            try fixedString("-", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
             let year = try self.parse4Digit(buffer: &buffer, tracker: tracker)
-            try fixedString(" ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
 
             // time            = 2DIGIT ":" 2DIGIT ":" 2DIGIT
             let hour = try self.parse2Digit(buffer: &buffer, tracker: tracker)
-            try fixedString(":", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
             let minute = try self.parse2Digit(buffer: &buffer, tracker: tracker)
-            try fixedString(":", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
             let second = try self.parse2Digit(buffer: &buffer, tracker: tracker)
 
-            try fixedString(" ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
 
             func splitZoneMinutes(_ raw: Int) -> Int? {
                 guard raw >= 0 else { return nil }
@@ -120,8 +120,8 @@ extension GrammarParser {
             }
 
             // zone            = ("+" / "-") 4DIGIT
-            func parseZonePositive(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-                try fixedString("+", buffer: &buffer, tracker: tracker)
+            func parseZonePositive(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+                try ParserLibrary.fixedString("+", buffer: &buffer, tracker: tracker)
                 let num = try self.parse4Digit(buffer: &buffer, tracker: tracker)
                 guard let zone = splitZoneMinutes(num) else {
                     throw ParserError(hint: "Building TimeZone from \(num) failed")
@@ -129,8 +129,8 @@ extension GrammarParser {
                 return zone
             }
 
-            func parseZoneNegative(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-                try fixedString("-", buffer: &buffer, tracker: tracker)
+            func parseZoneNegative(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+                try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
                 let num = try self.parse4Digit(buffer: &buffer, tracker: tracker)
                 guard let zone = splitZoneMinutes(num) else {
                     throw ParserError(hint: "Building TimeZone from \(num) failed")
@@ -138,12 +138,12 @@ extension GrammarParser {
                 return -zone
             }
 
-            let zone = try oneOf([
+            let zone = try ParserLibrary.oneOf([
                 parseZonePositive,
                 parseZoneNegative,
             ], buffer: &buffer, tracker: tracker)
 
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             guard
                 let components = InternalDate.Components(year: year, month: month, day: day, hour: hour, minute: minute, second: second, timeZoneMinutes: zone)
             else {

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
@@ -51,21 +51,21 @@ extension GrammarParser {
     }
 
     // reusable for a lot of the env-* types
-    static func parseEnvelopeEmailAddresses(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [EmailAddress] {
-        try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parseEnvelopeEmailAddresses(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [EmailAddress] {
+        try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
         let addresses = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker) { buffer, tracker in
             try self.parseEmailAddress(buffer: &buffer, tracker: tracker)
         }
-        try fixedString(")", buffer: &buffer, tracker: tracker)
+        try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
         return addresses
     }
 
-    static func parseOptionalEnvelopeEmailAddresses(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [EmailAddressListElement] {
-        func parseOptionalEnvelopeEmailAddresses_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [EmailAddress] {
+    static func parseOptionalEnvelopeEmailAddresses(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [EmailAddressListElement] {
+        func parseOptionalEnvelopeEmailAddresses_nil(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [EmailAddress] {
             try self.parseNil(buffer: &buffer, tracker: tracker)
             return []
         }
-        let addresses = try oneOf([
+        let addresses = try ParserLibrary.oneOf([
             parseEnvelopeEmailAddresses,
             parseOptionalEnvelopeEmailAddresses_nil,
         ], buffer: &buffer, tracker: tracker)
@@ -75,22 +75,22 @@ extension GrammarParser {
 
     // address         = "(" addr-name SP addr-adl SP addr-mailbox SP
     //                   addr-host ")"
-    static func parseEmailAddress(buffer: inout ByteBuffer, tracker: StackTracker) throws -> EmailAddress {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EmailAddress in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parseEmailAddress(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EmailAddress {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EmailAddress in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             let name = try self.parseNString(buffer: &buffer, tracker: tracker)
-            try fixedString(" ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
             let adl = try self.parseNString(buffer: &buffer, tracker: tracker)
-            try fixedString(" ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseNString(buffer: &buffer, tracker: tracker)
-            try fixedString(" ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
             let host = try self.parseNString(buffer: &buffer, tracker: tracker)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return EmailAddress(personName: name, sourceRoot: adl, mailbox: mailbox, host: host)
         }
     }
 
-    static func parseMessageID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageID? {
+    static func parseMessageID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageID? {
         if let parsed = try self.parseNString(buffer: &buffer, tracker: tracker) {
             return .init(rawValue: String(buffer: parsed))
         }
@@ -100,29 +100,29 @@ extension GrammarParser {
     // envelope        = "(" env-date SP env-subject SP env-from SP
     //                   env-sender SP env-reply-to SP env-to SP env-cc SP
     //                   env-bcc SP env-in-reply-to SP env-message-id ")"
-    static func parseEnvelope(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Envelope {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Envelope in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parseEnvelope(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Envelope {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Envelope in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             let date = try self.parseNString(buffer: &buffer, tracker: tracker).flatMap { InternetMessageDate(String(buffer: $0)) }
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let subject = try self.parseNString(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let from = try self.parseOptionalEnvelopeEmailAddresses(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let sender = try self.parseOptionalEnvelopeEmailAddresses(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let replyTo = try self.parseOptionalEnvelopeEmailAddresses(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let to = try self.parseOptionalEnvelopeEmailAddresses(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let cc = try self.parseOptionalEnvelopeEmailAddresses(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let bcc = try self.parseOptionalEnvelopeEmailAddresses(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let inReplyTo = try self.parseMessageID(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let messageID = try self.parseMessageID(buffer: &buffer, tracker: tracker)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return Envelope(
                 date: date,
                 subject: subject,

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
@@ -26,49 +26,49 @@ import struct NIO.ByteBufferView
 extension GrammarParser {
     // fetch           = "FETCH" SP sequence-set SP ("ALL" / "FULL" / "FAST" /
     //                   fetch-att / "(" fetch-att *(SP fetch-att) ")") [fetch-modifiers]
-    static func parseFetch(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("FETCH ", buffer: &buffer, tracker: tracker)
+    static func parseFetch(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("FETCH ", buffer: &buffer, tracker: tracker)
             let sequence = try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let att = try parseFetch_type(buffer: &buffer, tracker: tracker)
-            let modifiers = try optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
+            let modifiers = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
             return .fetch(sequence, att, modifiers)
         }
     }
 
-    static func parseFetch_type(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
-        func parseFetch_type_all(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
-            try fixedString("ALL", buffer: &buffer, tracker: tracker)
+    static func parseFetch_type(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
+        func parseFetch_type_all(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
+            try ParserLibrary.fixedString("ALL", buffer: &buffer, tracker: tracker)
             return [.flags, .internalDate, .rfc822Size, .envelope]
         }
 
-        func parseFetch_type_fast(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
-            try fixedString("FAST", buffer: &buffer, tracker: tracker)
+        func parseFetch_type_fast(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
+            try ParserLibrary.fixedString("FAST", buffer: &buffer, tracker: tracker)
             return [.flags, .internalDate, .rfc822Size]
         }
 
-        func parseFetch_type_full(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
-            try fixedString("FULL", buffer: &buffer, tracker: tracker)
+        func parseFetch_type_full(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
+            try ParserLibrary.fixedString("FULL", buffer: &buffer, tracker: tracker)
             return [.flags, .internalDate, .rfc822Size, .envelope, .bodyStructure(extensions: false)]
         }
 
-        func parseFetch_type_singleAtt(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
+        func parseFetch_type_singleAtt(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
             [try self.parseFetchAttribute(buffer: &buffer, tracker: tracker)]
         }
 
-        func parseFetch_type_multiAtt(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+        func parseFetch_type_multiAtt(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [FetchAttribute] {
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             var array = [try self.parseFetchAttribute(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> FetchAttribute in
-                try fixedString(" ", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
                 return try self.parseFetchAttribute(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return array
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFetch_type_all,
             parseFetch_type_full,
             parseFetch_type_fast,
@@ -85,49 +85,49 @@ extension GrammarParser {
     //                   "BINARY" [".PEEK"] section-binary [partial] /
     //                   "BINARY.SIZE" section-binary
     // TODO: rev2
-    static func parseFetchAttribute(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-        func parseFetchAttribute_envelope(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("ENVELOPE", buffer: &buffer, tracker: tracker)
+    static func parseFetchAttribute(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+        func parseFetchAttribute_envelope(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("ENVELOPE", buffer: &buffer, tracker: tracker)
             return .envelope
         }
 
-        func parseFetchAttribute_flags(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("FLAGS", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_flags(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("FLAGS", buffer: &buffer, tracker: tracker)
             return .flags
         }
 
-        func parseFetchAttribute_internalDate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("INTERNALDATE", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_internalDate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("INTERNALDATE", buffer: &buffer, tracker: tracker)
             return .internalDate
         }
 
-        func parseFetchAttribute_UID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("UID", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_UID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("UID", buffer: &buffer, tracker: tracker)
             return .uid
         }
 
-        func parseFetchAttribute_rfc822(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            func parseFetchAttribute_rfc822Size(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-                try fixedString("RFC822.SIZE", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_rfc822(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            func parseFetchAttribute_rfc822Size(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+                try ParserLibrary.fixedString("RFC822.SIZE", buffer: &buffer, tracker: tracker)
                 return .rfc822Size
             }
 
-            func parseFetchAttribute_rfc822Header(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-                try fixedString("RFC822.HEADER", buffer: &buffer, tracker: tracker)
+            func parseFetchAttribute_rfc822Header(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+                try ParserLibrary.fixedString("RFC822.HEADER", buffer: &buffer, tracker: tracker)
                 return .rfc822Header
             }
 
-            func parseFetchAttribute_rfc822Text(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-                try fixedString("RFC822.TEXT", buffer: &buffer, tracker: tracker)
+            func parseFetchAttribute_rfc822Text(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+                try ParserLibrary.fixedString("RFC822.TEXT", buffer: &buffer, tracker: tracker)
                 return .rfc822Text
             }
 
-            func parseFetchAttribute_rfc822(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-                try fixedString("RFC822", buffer: &buffer, tracker: tracker)
+            func parseFetchAttribute_rfc822(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+                try ParserLibrary.fixedString("RFC822", buffer: &buffer, tracker: tracker)
                 return .rfc822
             }
 
-            return try oneOf([
+            return try ParserLibrary.oneOf([
                 parseFetchAttribute_rfc822Size,
                 parseFetchAttribute_rfc822Header,
                 parseFetchAttribute_rfc822Text,
@@ -135,11 +135,11 @@ extension GrammarParser {
             ], buffer: &buffer, tracker: tracker)
         }
 
-        func parseFetchAttribute_body(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("BODY", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_body(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("BODY", buffer: &buffer, tracker: tracker)
             let extensions: Bool = {
                 do {
-                    try fixedString("STRUCTURE", buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.fixedString("STRUCTURE", buffer: &buffer, tracker: tracker)
                     return true
                 } catch {
                     return false
@@ -148,33 +148,33 @@ extension GrammarParser {
             return .bodyStructure(extensions: extensions)
         }
 
-        func parseFetchAttribute_bodySection(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("BODY", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_bodySection(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("BODY", buffer: &buffer, tracker: tracker)
             let section = try self.parseSection(buffer: &buffer, tracker: tracker)
-            let chevronNumber = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ClosedRange<UInt32> in
+            let chevronNumber = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ClosedRange<UInt32> in
                 try self.parsePartial(buffer: &buffer, tracker: tracker)
             }
             return .bodySection(peek: false, section, chevronNumber)
         }
 
-        func parseFetchAttribute_bodyPeekSection(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("BODY.PEEK", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_bodyPeekSection(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("BODY.PEEK", buffer: &buffer, tracker: tracker)
             let section = try self.parseSection(buffer: &buffer, tracker: tracker)
-            let chevronNumber = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ClosedRange<UInt32> in
+            let chevronNumber = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ClosedRange<UInt32> in
                 try self.parsePartial(buffer: &buffer, tracker: tracker)
             }
             return .bodySection(peek: true, section, chevronNumber)
         }
 
-        func parseFetchAttribute_modificationSequence(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
+        func parseFetchAttribute_modificationSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
             .modificationSequenceValue(try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker))
         }
 
-        func parseFetchAttribute_binary(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            func parsePeek(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Bool {
+        func parseFetchAttribute_binary(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            func parsePeek(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Bool {
                 let save = buffer
                 do {
-                    try fixedString(".PEEK", buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.fixedString(".PEEK", buffer: &buffer, tracker: tracker)
                     return true
                 } catch {
                     buffer = save
@@ -182,40 +182,40 @@ extension GrammarParser {
                 }
             }
 
-            try fixedString("BINARY", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("BINARY", buffer: &buffer, tracker: tracker)
             let peek = try parsePeek(buffer: &buffer, tracker: tracker)
             let sectionBinary = try self.parseSectionBinary(buffer: &buffer, tracker: tracker)
-            let partial = try optional(buffer: &buffer, tracker: tracker, parser: self.parsePartial)
+            let partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parsePartial)
             return .binary(peek: peek, section: sectionBinary, partial: partial)
         }
 
-        func parseFetchAttribute_binarySize(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("BINARY.SIZE", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_binarySize(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("BINARY.SIZE", buffer: &buffer, tracker: tracker)
             let sectionBinary = try self.parseSectionBinary(buffer: &buffer, tracker: tracker)
             return .binarySize(section: sectionBinary)
         }
 
-        func parseFetchAttribute_gmailMessageID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("X-GM-MSGID", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_gmailMessageID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("X-GM-MSGID", buffer: &buffer, tracker: tracker)
             return .gmailMessageID
         }
 
-        func parseFetchAttribute_gmailThreadID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("X-GM-THRID", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_gmailThreadID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("X-GM-THRID", buffer: &buffer, tracker: tracker)
             return .gmailThreadID
         }
 
-        func parseFetchAttribute_gmailLabels(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("X-GM-LABELS", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_gmailLabels(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("X-GM-LABELS", buffer: &buffer, tracker: tracker)
             return .gmailLabels
         }
 
-        func parseFetchAttribute_modSeq(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchAttribute {
-            try fixedString("MODSEQ", buffer: &buffer, tracker: tracker)
+        func parseFetchAttribute_modSeq(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchAttribute {
+            try ParserLibrary.fixedString("MODSEQ", buffer: &buffer, tracker: tracker)
             return .modificationSequence
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFetchAttribute_envelope,
             parseFetchAttribute_flags,
             parseFetchAttribute_internalDate,
@@ -234,51 +234,51 @@ extension GrammarParser {
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseFetchModificationResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchModificationResponse {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> FetchModificationResponse in
-            try fixedString("MODSEQ (", buffer: &buffer, tracker: tracker)
+    static func parseFetchModificationResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchModificationResponse {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> FetchModificationResponse in
+            try ParserLibrary.fixedString("MODSEQ (", buffer: &buffer, tracker: tracker)
             let val = try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .init(modifierSequenceValue: val)
         }
     }
 
-    static func parseFetchStreamingResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StreamingKind {
-        func parseFetchStreamingResponse_rfc822Text(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StreamingKind {
-            try fixedString("RFC822.TEXT", buffer: &buffer, tracker: tracker)
+    static func parseFetchStreamingResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StreamingKind {
+        func parseFetchStreamingResponse_rfc822Text(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StreamingKind {
+            try ParserLibrary.fixedString("RFC822.TEXT", buffer: &buffer, tracker: tracker)
             return .rfc822Text
         }
 
-        func parseFetchStreamingResponse_rfc822Header(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StreamingKind {
-            try fixedString("RFC822.HEADER", buffer: &buffer, tracker: tracker)
+        func parseFetchStreamingResponse_rfc822Header(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StreamingKind {
+            try ParserLibrary.fixedString("RFC822.HEADER", buffer: &buffer, tracker: tracker)
             return .rfc822Header
         }
 
-        func parseFetchStreamingResponse_bodySectionText(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StreamingKind {
-            try fixedString("BODY", buffer: &buffer, tracker: tracker)
-            let section = try optional(buffer: &buffer, tracker: tracker, parser: self.parseSection) ?? .init()
-            let offset = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Int in
-                try fixedString("<", buffer: &buffer, tracker: tracker)
+        func parseFetchStreamingResponse_bodySectionText(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StreamingKind {
+            try ParserLibrary.fixedString("BODY", buffer: &buffer, tracker: tracker)
+            let section = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseSection) ?? .init()
+            let offset = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Int in
+                try ParserLibrary.fixedString("<", buffer: &buffer, tracker: tracker)
                 let num = try self.parseNumber(buffer: &buffer, tracker: tracker)
-                try fixedString(">", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(">", buffer: &buffer, tracker: tracker)
                 return num
             }
             return .body(section: section, offset: offset)
         }
 
-        func parseFetchStreamingResponse_binary(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StreamingKind {
-            try fixedString("BINARY", buffer: &buffer, tracker: tracker)
+        func parseFetchStreamingResponse_binary(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StreamingKind {
+            try ParserLibrary.fixedString("BINARY", buffer: &buffer, tracker: tracker)
             let section = try self.parseSectionBinary(buffer: &buffer, tracker: tracker)
-            let offset = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> Int in
-                try fixedString("<", buffer: &buffer, tracker: tracker)
+            let offset = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> Int in
+                try ParserLibrary.fixedString("<", buffer: &buffer, tracker: tracker)
                 let num = try self.parseNumber(buffer: &buffer, tracker: tracker)
-                try fixedString(">", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(">", buffer: &buffer, tracker: tracker)
                 return num
             })
             return .binary(section: section, offset: offset)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFetchStreamingResponse_rfc822Text,
             parseFetchStreamingResponse_rfc822Header,
             parseFetchStreamingResponse_bodySectionText,
@@ -286,26 +286,26 @@ extension GrammarParser {
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseFetchModifier(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchModifier {
-        func parseFetchModifier_changedSince(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchModifier {
+    static func parseFetchModifier(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchModifier {
+        func parseFetchModifier_changedSince(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchModifier {
             .changedSince(try self.parseChangedSinceModifier(buffer: &buffer, tracker: tracker))
         }
 
-        func parseFetchModifier_other(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FetchModifier {
+        func parseFetchModifier_other(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchModifier {
             .other(try self.parseParameter(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFetchModifier_changedSince,
             parseFetchModifier_other,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseFetchResponseStart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> _FetchResponse {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("* ", buffer: &buffer, tracker: tracker)
+    static func parseFetchResponseStart(buffer: inout ParseBuffer, tracker: StackTracker) throws -> _FetchResponse {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("* ", buffer: &buffer, tracker: tracker)
             let number = try self.parseSequenceNumber(buffer: &buffer, tracker: tracker)
-            try fixedString(" FETCH (", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" FETCH (", buffer: &buffer, tracker: tracker)
             return .start(number)
         }
     }
@@ -320,35 +320,35 @@ extension GrammarParser {
         case finish
     }
 
-    static func parseFetchResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> _FetchResponse {
-        func parseFetchResponse_simpleAttribute(buffer: inout ByteBuffer, tracker: StackTracker) throws -> _FetchResponse {
+    static func parseFetchResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> _FetchResponse {
+        func parseFetchResponse_simpleAttribute(buffer: inout ParseBuffer, tracker: StackTracker) throws -> _FetchResponse {
             let attribute = try self.parseMessageAttribute(buffer: &buffer, tracker: tracker)
             return .simpleAttribute(attribute)
         }
 
-        func parseFetchResponse_streamingBegin(buffer: inout ByteBuffer, tracker: StackTracker) throws -> _FetchResponse {
+        func parseFetchResponse_streamingBegin(buffer: inout ParseBuffer, tracker: StackTracker) throws -> _FetchResponse {
             let type = try self.parseFetchStreamingResponse(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let literalSize = try self.parseLiteralSize(buffer: &buffer, tracker: tracker)
             return .literalStreamingBegin(kind: type, byteCount: literalSize)
         }
 
-        func parseFetchResponse_streamingBeginQuoted(buffer: inout ByteBuffer, tracker: StackTracker) throws -> _FetchResponse {
+        func parseFetchResponse_streamingBeginQuoted(buffer: inout ParseBuffer, tracker: StackTracker) throws -> _FetchResponse {
             let type = try self.parseFetchStreamingResponse(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let save = buffer
             let quoted = try self.parseQuoted(buffer: &buffer, tracker: tracker)
             buffer = save
             return .quotedStreamingBegin(kind: type, byteCount: quoted.readableBytes)
         }
 
-        func parseFetchResponse_finish(buffer: inout ByteBuffer, tracker: StackTracker) throws -> _FetchResponse {
-            try fixedString(")", buffer: &buffer, tracker: tracker)
-            try newline(buffer: &buffer, tracker: tracker)
+        func parseFetchResponse_finish(buffer: inout ParseBuffer, tracker: StackTracker) throws -> _FetchResponse {
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
             return .finish
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFetchResponse_streamingBegin,
             parseFetchResponse_streamingBeginQuoted,
             parseFetchResponse_simpleAttribute,

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+List.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+List.swift
@@ -25,19 +25,19 @@ import struct NIO.ByteBufferView
 
 extension GrammarParser {
     // list            = "LIST" [SP list-select-opts] SP mailbox SP mbox-or-pat [SP list-return-opts]
-    static func parseList(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("LIST", buffer: &buffer, tracker: tracker)
-            let selectOptions = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ListSelectOptions in
-                try space(buffer: &buffer, tracker: tracker)
+    static func parseList(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("LIST", buffer: &buffer, tracker: tracker)
+            let selectOptions = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ListSelectOptions in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseListSelectOptions(buffer: &buffer, tracker: tracker)
             }
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let mailboxPatterns = try self.parseMailboxPatterns(buffer: &buffer, tracker: tracker)
-            let returnOptions = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [ReturnOption] in
-                try space(buffer: &buffer, tracker: tracker)
+            let returnOptions = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [ReturnOption] in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseListReturnOptions(buffer: &buffer, tracker: tracker)
             } ?? []
             return .list(selectOptions, reference: mailbox, mailboxPatterns, returnOptions)
@@ -45,44 +45,44 @@ extension GrammarParser {
     }
 
     // list-select-base-opt =  "SUBSCRIBED" / option-extension
-    static func parseListSelectBaseOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectBaseOption {
-        func parseListSelectBaseOption_subscribed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectBaseOption {
-            try fixedString("SUBSCRIBED", buffer: &buffer, tracker: tracker)
+    static func parseListSelectBaseOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectBaseOption {
+        func parseListSelectBaseOption_subscribed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectBaseOption {
+            try ParserLibrary.fixedString("SUBSCRIBED", buffer: &buffer, tracker: tracker)
             return .subscribed
         }
 
-        func parseListSelectBaseOption_optionExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectBaseOption {
+        func parseListSelectBaseOption_optionExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectBaseOption {
             .option(try self.parseOptionExtension(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseListSelectBaseOption_subscribed,
             parseListSelectBaseOption_optionExtension,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // list-select-base-opt-quoted =  DQUOTE list-select-base-opt DQUOTE
-    static func parseListSelectBaseOptionQuoted(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectBaseOption {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ListSelectBaseOption in
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+    static func parseListSelectBaseOptionQuoted(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectBaseOption {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ListSelectBaseOption in
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             let option = try self.parseListSelectBaseOption(buffer: &buffer, tracker: tracker)
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             return option
         }
     }
 
     // list-select-independent-opt =  "REMOTE" / option-extension
-    static func parseListSelectIndependentOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectIndependentOption {
-        func parseListSelectIndependentOption_subscribed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectIndependentOption {
-            try fixedString("REMOTE", buffer: &buffer, tracker: tracker)
+    static func parseListSelectIndependentOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectIndependentOption {
+        func parseListSelectIndependentOption_subscribed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectIndependentOption {
+            try ParserLibrary.fixedString("REMOTE", buffer: &buffer, tracker: tracker)
             return .remote
         }
 
-        func parseListSelectIndependentOption_optionExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectIndependentOption {
+        func parseListSelectIndependentOption_optionExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectIndependentOption {
             .option(try self.parseOptionExtension(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseListSelectIndependentOption_subscribed,
             parseListSelectIndependentOption_optionExtension,
         ], buffer: &buffer, tracker: tracker)
@@ -90,32 +90,32 @@ extension GrammarParser {
 
     // list-select-opt =  list-select-base-opt / list-select-independent-opt
     //                    / list-select-mod-opt
-    static func parseListSelectOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectOption {
-        func parseListSelectOption_subscribed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectOption {
-            try fixedString("SUBSCRIBED", buffer: &buffer, tracker: tracker)
+    static func parseListSelectOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectOption {
+        func parseListSelectOption_subscribed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectOption {
+            try ParserLibrary.fixedString("SUBSCRIBED", buffer: &buffer, tracker: tracker)
             return .subscribed
         }
 
-        func parseListSelectOption_remote(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectOption {
-            try fixedString("REMOTE", buffer: &buffer, tracker: tracker)
+        func parseListSelectOption_remote(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectOption {
+            try ParserLibrary.fixedString("REMOTE", buffer: &buffer, tracker: tracker)
             return .remote
         }
 
-        func parseListSelectOption_recursiveMatch(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectOption {
-            try fixedString("RECURSIVEMATCH", buffer: &buffer, tracker: tracker)
+        func parseListSelectOption_recursiveMatch(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectOption {
+            try ParserLibrary.fixedString("RECURSIVEMATCH", buffer: &buffer, tracker: tracker)
             return .recursiveMatch
         }
 
-        func parseListSelectOption_specialUse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectOption {
-            try fixedString("SPECIAL-USE", buffer: &buffer, tracker: tracker)
+        func parseListSelectOption_specialUse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectOption {
+            try ParserLibrary.fixedString("SPECIAL-USE", buffer: &buffer, tracker: tracker)
             return .specialUse
         }
 
-        func parseListSelectOption_optionExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectOption {
+        func parseListSelectOption_optionExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectOption {
             .option(try self.parseOptionExtension(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseListSelectOption_subscribed,
             parseListSelectOption_remote,
             parseListSelectOption_recursiveMatch,
@@ -130,65 +130,63 @@ extension GrammarParser {
     //                   / (list-select-independent-opt
     //                    *(SP list-select-independent-opt))
     //                      ] ")"
-    static func parseListSelectOptions(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ListSelectOptions {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parseListSelectOptions(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ListSelectOptions {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             var selectOptions = try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ListSelectOption in
                 let option = try self.parseListSelectOption(buffer: &buffer, tracker: tracker)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return option
             }
             let baseOption = try self.parseListSelectBaseOption(buffer: &buffer, tracker: tracker)
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &selectOptions, tracker: tracker) { (buffer, tracker) -> ListSelectOption in
                 let option = try self.parseListSelectOption(buffer: &buffer, tracker: tracker)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return option
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .init(baseOption: baseOption, options: selectOptions)
         }
     }
 
     // list-return-opt = "RETURN" SP "(" [return-option *(SP return-option)] ")"
-    static func parseListReturnOptions(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [ReturnOption] {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("RETURN (", buffer: &buffer, tracker: tracker)
-            let options = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [ReturnOption] in
+    static func parseListReturnOptions(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [ReturnOption] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("RETURN (", buffer: &buffer, tracker: tracker)
+            let options = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [ReturnOption] in
                 var array = [try self.parseReturnOption(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> ReturnOption in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try self.parseReturnOption(buffer: &buffer, tracker: tracker)
                 }
                 return array
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return options ?? []
         }
     }
 
     // list-mailbox    = 1*list-char / string
-    static func parseListMailbox(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
-        func parseListMailbox_string(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
+    static func parseListMailbox(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
+        func parseListMailbox_string(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
             try self.parseString(buffer: &buffer, tracker: tracker)
         }
 
-        func parseListMailbox_chars(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
+        func parseListMailbox_chars(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
             try ParserLibrary.parseOneOrMoreCharactersByteBuffer(buffer: &buffer, tracker: tracker) { char -> Bool in
                 char.isListChar
             }
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseListMailbox_string,
             parseListMailbox_chars,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // list-wildcards  = "%" / "*"
-    static func parseListWildcards(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
-        guard let char = buffer.readInteger(as: UInt8.self) else {
-            throw _IncompleteMessage()
-        }
+    static func parseListWildcards(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
+        let char = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
         guard char.isListWildcard else {
             throw ParserError()
         }

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
@@ -25,42 +25,42 @@ import struct NIO.ByteBufferView
 
 extension GrammarParser {
     // message-data    = nz-number SP ("EXPUNGE" / ("FETCH" SP msg-att))
-    static func parseMessageData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageData {
-        func parseMessageData_expunge(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageData {
+    static func parseMessageData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageData {
+        func parseMessageData_expunge(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageData {
             let number = try self.parseSequenceNumber(buffer: &buffer, tracker: tracker)
-            try fixedString(" EXPUNGE", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" EXPUNGE", buffer: &buffer, tracker: tracker)
             return .expunge(number)
         }
 
-        func parseMessageData_vanished(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageData {
-            try fixedString("VANISHED ", buffer: &buffer, tracker: tracker)
+        func parseMessageData_vanished(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageData {
+            try ParserLibrary.fixedString("VANISHED ", buffer: &buffer, tracker: tracker)
             return .vanished(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMessageData_vanishedEarlier(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageData {
-            try fixedString("VANISHED (EARLIER) ", buffer: &buffer, tracker: tracker)
+        func parseMessageData_vanishedEarlier(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageData {
+            try ParserLibrary.fixedString("VANISHED (EARLIER) ", buffer: &buffer, tracker: tracker)
             return .vanishedEarlier(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMessageData_generateAuthorizedURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageData {
-            try fixedString("GENURLAUTH", buffer: &buffer, tracker: tracker)
+        func parseMessageData_generateAuthorizedURL(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageData {
+            try ParserLibrary.fixedString("GENURLAUTH", buffer: &buffer, tracker: tracker)
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> ByteBuffer in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseAString(buffer: &buffer, tracker: tracker)
             })
             return .generateAuthorizedURL(array)
         }
 
-        func parseMessageData_fetchData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageData {
-            try fixedString("URLFETCH", buffer: &buffer, tracker: tracker)
+        func parseMessageData_fetchData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageData {
+            try ParserLibrary.fixedString("URLFETCH", buffer: &buffer, tracker: tracker)
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> URLFetchData in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseURLFetchData(buffer: &buffer, tracker: tracker)
             })
             return .urlFetch(array)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseMessageData_expunge,
             parseMessageData_vanished,
             parseMessageData_vanishedEarlier,
@@ -78,90 +78,90 @@ extension GrammarParser {
     //                   "UID" SP uniqueid
     // msg-att-dynamic = "FLAGS" SP "(" [flag-fetch *(SP flag-fetch)] ")"
     // ---- This function combines static and dynamic
-    static func parseMessageAttribute(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-        func parseMessageAttribute_flags(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> MessageAttribute in
-                try fixedString("FLAGS", buffer: &buffer, tracker: tracker)
-                try space(buffer: &buffer, tracker: tracker)
+    static func parseMessageAttribute(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+        func parseMessageAttribute_flags(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> MessageAttribute in
+                try ParserLibrary.fixedString("FLAGS", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 let flags = try self.parseFlagList(buffer: &buffer, tracker: tracker)
                 return .flags(flags)
             }
         }
 
-        func parseMessageAttribute_envelope(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("ENVELOPE ", buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_envelope(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("ENVELOPE ", buffer: &buffer, tracker: tracker)
             return .envelope(try self.parseEnvelope(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMessageAttribute_internalDate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("INTERNALDATE ", buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_internalDate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("INTERNALDATE ", buffer: &buffer, tracker: tracker)
             return .internalDate(try self.parseInternalDate(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMessageAttribute_rfc822Size(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("RFC822.SIZE ", buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_rfc822Size(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("RFC822.SIZE ", buffer: &buffer, tracker: tracker)
             return .rfc822Size(try self.parseNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMessageAttribute_body(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("BODY", buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_body(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("BODY", buffer: &buffer, tracker: tracker)
             let hasExtensionData: Bool = {
                 do {
-                    try fixedString("STRUCTURE", buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.fixedString("STRUCTURE", buffer: &buffer, tracker: tracker)
                     return true
                 } catch {
                     return false
                 }
             }()
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let body = try self.parseBody(buffer: &buffer, tracker: tracker)
             return .body(body, hasExtensionData: hasExtensionData)
         }
 
-        func parseMessageAttribute_uid(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("UID ", buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_uid(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("UID ", buffer: &buffer, tracker: tracker)
             return .uid(try self.parseUID(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMessageAttribute_binarySize(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("BINARY.SIZE", buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_binarySize(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("BINARY.SIZE", buffer: &buffer, tracker: tracker)
             let section = try self.parseSectionBinary(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let number = try self.parseNumber(buffer: &buffer, tracker: tracker)
             return .binarySize(section: section, size: number)
         }
 
-        func parseMessageAttribute_binary(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("BINARY", buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_binary(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("BINARY", buffer: &buffer, tracker: tracker)
             let section = try self.parseSectionBinary(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let string = try self.parseNString(buffer: &buffer, tracker: tracker)
             return .binary(section: section, data: string)
         }
 
-        func parseMessageAttribute_fetchModifierResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
+        func parseMessageAttribute_fetchModifierResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
             .fetchModificationResponse(try self.parseFetchModificationResponse(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMessageAttribute_gmailMessageID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("X-GM-MSGID", buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_gmailMessageID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("X-GM-MSGID", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let (id, _) = try ParserLibrary.parseUInt64(buffer: &buffer, tracker: tracker)
             return .gmailMessageID(id)
         }
 
-        func parseMessageAttribute_gmailThreadID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            try fixedString("X-GM-THRID", buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+        func parseMessageAttribute_gmailThreadID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
+            try ParserLibrary.fixedString("X-GM-THRID", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let (id, _) = try ParserLibrary.parseUInt64(buffer: &buffer, tracker: tracker)
             return .gmailThreadID(id)
         }
 
-        func parseMessageAttribute_gmailLabels(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MessageAttribute {
+        func parseMessageAttribute_gmailLabels(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
             var attributes: [GmailLabel] = []
-            try fixedString("X-GM-LABELS (", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("X-GM-LABELS (", buffer: &buffer, tracker: tracker)
 
-            let first: GmailLabel? = try optional(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            let first: GmailLabel? = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { buffer, tracker in
                 try parseGmailLabel(buffer: &buffer, tracker: tracker)
             }
 
@@ -169,16 +169,16 @@ extension GrammarParser {
                 attributes.append(first)
 
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &attributes, tracker: tracker) { buffer, tracker in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try parseGmailLabel(buffer: &buffer, tracker: tracker)
                 }
             }
 
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .gmailLabels(attributes)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseMessageAttribute_envelope,
             parseMessageAttribute_internalDate,
             parseMessageAttribute_rfc822Size,

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
@@ -25,78 +25,78 @@ import struct NIO.ByteBufferView
 
 extension GrammarParser {
     // response-data   = "*" SP response-payload CRLF
-    static func parseResponseData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("* ", buffer: &buffer, tracker: tracker)
+    static func parseResponseData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("* ", buffer: &buffer, tracker: tracker)
             let payload = try self.parseResponsePayload(buffer: &buffer, tracker: tracker)
-            try newline(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
             return payload
         }
     }
 
     // response-tagged = tag SP resp-cond-state CRLF
-    static func parseTaggedResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> TaggedResponse {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> TaggedResponse in
+    static func parseTaggedResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> TaggedResponse {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> TaggedResponse in
             let tag = try self.parseTag(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let state = try self.parseTaggedResponseState(buffer: &buffer, tracker: tracker)
-            try newline(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
             return TaggedResponse(tag: tag, state: state)
         }
     }
 
     // resp-code-apnd  = "APPENDUID" SP nz-number SP append-uid
-    static func parseResponseCodeAppend(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseCodeAppend {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ResponseCodeAppend in
-            try fixedString("APPENDUID ", buffer: &buffer, tracker: tracker)
+    static func parseResponseCodeAppend(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseCodeAppend {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ResponseCodeAppend in
+            try ParserLibrary.fixedString("APPENDUID ", buffer: &buffer, tracker: tracker)
             let number = try self.parseNZNumber(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let uid = try self.parseUID(buffer: &buffer, tracker: tracker)
             return ResponseCodeAppend(num: number, uid: uid)
         }
     }
 
     // resp-code-copy  = "COPYUID" SP nz-number SP uid-set SP uid-set
-    static func parseResponseCodeCopy(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseCodeCopy {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ResponseCodeCopy in
-            try fixedString("COPYUID ", buffer: &buffer, tracker: tracker)
+    static func parseResponseCodeCopy(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseCodeCopy {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ResponseCodeCopy in
+            try ParserLibrary.fixedString("COPYUID ", buffer: &buffer, tracker: tracker)
             let uidValidity = try self.parseNumber(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let sourceUIDRanges = try self.parseUIDRangeArray(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let destinationUIDRanges = try self.parseUIDRangeArray(buffer: &buffer, tracker: tracker)
             return ResponseCodeCopy(destinationUIDValidity: uidValidity, sourceUIDs: sourceUIDRanges, destinationUIDs: destinationUIDRanges)
         }
     }
 
     /// This is a combination of `resp-cond-state`, `resp-cond-bye`, and `greeting`.
-    static func parseUntaggedResponseStatus(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UntaggedStatus {
-        func parseTaggedResponseState_ok(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UntaggedStatus {
-            try fixedString("OK ", buffer: &buffer, tracker: tracker)
+    static func parseUntaggedResponseStatus(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UntaggedStatus {
+        func parseTaggedResponseState_ok(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UntaggedStatus {
+            try ParserLibrary.fixedString("OK ", buffer: &buffer, tracker: tracker)
             return .ok(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        func parseTaggedResponseState_no(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UntaggedStatus {
-            try fixedString("NO ", buffer: &buffer, tracker: tracker)
+        func parseTaggedResponseState_no(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UntaggedStatus {
+            try ParserLibrary.fixedString("NO ", buffer: &buffer, tracker: tracker)
             return .no(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        func parseTaggedResponseState_bad(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UntaggedStatus {
-            try fixedString("BAD ", buffer: &buffer, tracker: tracker)
+        func parseTaggedResponseState_bad(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UntaggedStatus {
+            try ParserLibrary.fixedString("BAD ", buffer: &buffer, tracker: tracker)
             return .bad(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        func parseTaggedResponseState_preAuth(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UntaggedStatus {
-            try fixedString("PREAUTH ", buffer: &buffer, tracker: tracker)
+        func parseTaggedResponseState_preAuth(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UntaggedStatus {
+            try ParserLibrary.fixedString("PREAUTH ", buffer: &buffer, tracker: tracker)
             return .preauth(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        func parseTaggedResponseState_bye(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UntaggedStatus {
-            try fixedString("BYE ", buffer: &buffer, tracker: tracker)
+        func parseTaggedResponseState_bye(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UntaggedStatus {
+            try ParserLibrary.fixedString("BYE ", buffer: &buffer, tracker: tracker)
             return .bye(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseTaggedResponseState_ok,
             parseTaggedResponseState_no,
             parseTaggedResponseState_bad,
@@ -106,23 +106,23 @@ extension GrammarParser {
     }
 
     // resp-cond-state = ("OK" / "NO" / "BAD") SP resp-text
-    static func parseTaggedResponseState(buffer: inout ByteBuffer, tracker: StackTracker) throws -> TaggedResponse.State {
-        func parseTaggedResponseState_ok(buffer: inout ByteBuffer, tracker: StackTracker) throws -> TaggedResponse.State {
-            try fixedString("OK ", buffer: &buffer, tracker: tracker)
+    static func parseTaggedResponseState(buffer: inout ParseBuffer, tracker: StackTracker) throws -> TaggedResponse.State {
+        func parseTaggedResponseState_ok(buffer: inout ParseBuffer, tracker: StackTracker) throws -> TaggedResponse.State {
+            try ParserLibrary.fixedString("OK ", buffer: &buffer, tracker: tracker)
             return .ok(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        func parseTaggedResponseState_no(buffer: inout ByteBuffer, tracker: StackTracker) throws -> TaggedResponse.State {
-            try fixedString("NO ", buffer: &buffer, tracker: tracker)
+        func parseTaggedResponseState_no(buffer: inout ParseBuffer, tracker: StackTracker) throws -> TaggedResponse.State {
+            try ParserLibrary.fixedString("NO ", buffer: &buffer, tracker: tracker)
             return .no(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        func parseTaggedResponseState_bad(buffer: inout ByteBuffer, tracker: StackTracker) throws -> TaggedResponse.State {
-            try fixedString("BAD ", buffer: &buffer, tracker: tracker)
+        func parseTaggedResponseState_bad(buffer: inout ParseBuffer, tracker: StackTracker) throws -> TaggedResponse.State {
+            try ParserLibrary.fixedString("BAD ", buffer: &buffer, tracker: tracker)
             return .bad(try self.parseResponseText(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseTaggedResponseState_ok,
             parseTaggedResponseState_no,
             parseTaggedResponseState_bad,
@@ -130,36 +130,36 @@ extension GrammarParser {
     }
 
     // response-payload = resp-cond-state / resp-cond-bye / mailbox-data / message-data / capability-data / id-response / enable-data
-    static func parseResponsePayload(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
-        func parseResponsePayload_conditionalState(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
+    static func parseResponsePayload(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
+        func parseResponsePayload_conditionalState(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
             .conditionalState(try self.parseUntaggedResponseStatus(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponsePayload_mailboxData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
+        func parseResponsePayload_mailboxData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
             .mailboxData(try self.parseMailboxData(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponsePayload_messageData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
+        func parseResponsePayload_messageData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
             .messageData(try self.parseMessageData(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponsePayload_capabilityData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
+        func parseResponsePayload_capabilityData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
             .capabilityData(try self.parseCapabilityData(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponsePayload_idResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
+        func parseResponsePayload_idResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
             .id(try self.parseIDResponse(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponsePayload_enableData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
+        func parseResponsePayload_enableData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
             .enableData(try self.parseEnableData(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponsePayload_metadata(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
+        func parseResponsePayload_metadata(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
             .metadata(try self.parseMetadataResponse(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseResponsePayload_conditionalState,
             parseResponsePayload_mailboxData,
             parseResponsePayload_messageData,
@@ -173,18 +173,18 @@ extension GrammarParser {
     }
 
     // resp-text       = ["[" resp-text-code "]" SP] text
-    static func parseResponseText(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseText {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ResponseText in
-            let code = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ResponseTextCode in
-                try fixedString("[", buffer: &buffer, tracker: tracker)
+    static func parseResponseText(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseText {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ResponseText in
+            let code = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ResponseTextCode in
+                try ParserLibrary.fixedString("[", buffer: &buffer, tracker: tracker)
                 let code = try self.parseResponseTextCode(buffer: &buffer, tracker: tracker)
-                try fixedString("]", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("]", buffer: &buffer, tracker: tracker)
                 return code
             }
 
             // because some servers might not send the text (looking at you, iCloud), they might
             // also not send a space after resp-text-code, so make parsing optional
-            try optional(buffer: &buffer, tracker: tracker, parser: space)
+            try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: ParserLibrary.space)
 
             // text requires minimum 1 char, but we want to be lenient here
             // and allow 0 characters to represent empty text
@@ -205,108 +205,108 @@ extension GrammarParser {
     //                   "UNSEEN" SP nz-number
     //                   atom [SP 1*<any TEXT-CHAR except "]">] /
     //                   "NOTSAVED"
-    static func parseResponseTextCode(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-        func parseResponseTextCode_alert(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("ALERT", buffer: &buffer, tracker: tracker)
+    static func parseResponseTextCode(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+        func parseResponseTextCode_alert(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("ALERT", buffer: &buffer, tracker: tracker)
             return .alert
         }
 
-        func parseResponseTextCode_noModifierSequence(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("NOMODSEQ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_noModifierSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("NOMODSEQ", buffer: &buffer, tracker: tracker)
             return .noModificationSequence
         }
 
-        func parseResponseTextCode_modified(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("MODIFIED ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_modified(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("MODIFIED ", buffer: &buffer, tracker: tracker)
             return .modificationSequence(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_highestModifiedSequence(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("HIGHESTMODSEQ ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_highestModifiedSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("HIGHESTMODSEQ ", buffer: &buffer, tracker: tracker)
             return .highestModificationSequence(try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_referral(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("REFERRAL ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_referral(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("REFERRAL ", buffer: &buffer, tracker: tracker)
             return .referral(try self.parseIMAPURL(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_badCharset(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("BADCHARSET", buffer: &buffer, tracker: tracker)
-            let charsets = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [String] in
-                try fixedString(" (", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_badCharset(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("BADCHARSET", buffer: &buffer, tracker: tracker)
+            let charsets = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [String] in
+                try ParserLibrary.fixedString(" (", buffer: &buffer, tracker: tracker)
                 var array = [try self.parseCharset(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> String in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try self.parseCharset(buffer: &buffer, tracker: tracker)
                 }
-                try fixedString(")", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
                 return array
             } ?? []
             return .badCharset(charsets)
         }
 
-        func parseResponseTextCode_capabilityData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+        func parseResponseTextCode_capabilityData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
             .capability(try self.parseCapabilityData(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_parse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("PARSE", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_parse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("PARSE", buffer: &buffer, tracker: tracker)
             return .parse
         }
 
-        func parseResponseTextCode_permanentFlags(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("PERMANENTFLAGS (", buffer: &buffer, tracker: tracker)
-            let array = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [PermanentFlag] in
+        func parseResponseTextCode_permanentFlags(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("PERMANENTFLAGS (", buffer: &buffer, tracker: tracker)
+            let array = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [PermanentFlag] in
                 var array = [try self.parseFlagPerm(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try self.parseFlagPerm(buffer: &buffer, tracker: tracker)
                 }
                 return array
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .permanentFlags(array ?? [])
         }
 
-        func parseResponseTextCode_readOnly(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("READ-ONLY", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_readOnly(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("READ-ONLY", buffer: &buffer, tracker: tracker)
             return .readOnly
         }
 
-        func parseResponseTextCode_readWrite(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("READ-WRITE", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_readWrite(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("READ-WRITE", buffer: &buffer, tracker: tracker)
             return .readWrite
         }
 
-        func parseResponseTextCode_tryCreate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("TRYCREATE", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_tryCreate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("TRYCREATE", buffer: &buffer, tracker: tracker)
             return .tryCreate
         }
 
-        func parseResponseTextCode_uidNext(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("UIDNEXT ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_uidNext(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("UIDNEXT ", buffer: &buffer, tracker: tracker)
             return .uidNext(try self.parseUID(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_uidValidity(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("UIDVALIDITY ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_uidValidity(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("UIDVALIDITY ", buffer: &buffer, tracker: tracker)
             return .uidValidity(try self.parseUIDValidity(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_unseen(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("UNSEEN ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_unseen(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("UNSEEN ", buffer: &buffer, tracker: tracker)
             return .unseen(try self.parseSequenceNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_namespace(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+        func parseResponseTextCode_namespace(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
             .namespace(try self.parseNamespaceResponse(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_atom(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+        func parseResponseTextCode_atom(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
             let atom = try self.parseAtom(buffer: &buffer, tracker: tracker)
-            let string = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> String in
-                try space(buffer: &buffer, tracker: tracker)
+            let string = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> String in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { (char) -> Bool in
                     char.isTextChar && char != UInt8(ascii: "]")
                 }
@@ -314,62 +314,62 @@ extension GrammarParser {
             return .other(atom, string)
         }
 
-        func parseResponseTextCode_uidNotSticky(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("UIDNOTSTICKY", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_uidNotSticky(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("UIDNOTSTICKY", buffer: &buffer, tracker: tracker)
             return .uidNotSticky
         }
 
-        func parseResponseTextCode_closed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("CLOSED", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_closed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("CLOSED", buffer: &buffer, tracker: tracker)
             return .closed
         }
 
-        func parseResponseTextCode_uidCopy(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+        func parseResponseTextCode_uidCopy(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
             .uidCopy(try self.parseResponseCodeCopy(buffer: &buffer, tracker: tracker))
         }
 
-        func parseResponseTextCode_uidAppend(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+        func parseResponseTextCode_uidAppend(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
             .uidAppend(try self.parseResponseCodeAppend(buffer: &buffer, tracker: tracker))
         }
 
         // RFC 5182
-        func parseResponseTextCode_notSaved(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("NOTSAVED", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_notSaved(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("NOTSAVED", buffer: &buffer, tracker: tracker)
             return .notSaved
         }
 
-        func parseResponseTextCode_metadataLongEntries(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("METADATA LONGENTRIES ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_metadataLongEntries(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("METADATA LONGENTRIES ", buffer: &buffer, tracker: tracker)
             let num = try self.parseNumber(buffer: &buffer, tracker: tracker)
             return .metadataLongEntries(num)
         }
 
-        func parseResponseTextCode_metadataMaxSize(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("METADATA MAXSIZE ", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_metadataMaxSize(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("METADATA MAXSIZE ", buffer: &buffer, tracker: tracker)
             let num = try self.parseNumber(buffer: &buffer, tracker: tracker)
             return .metadataMaxsize(num)
         }
 
-        func parseResponseTextCode_metadataTooMany(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("METADATA TOOMANY", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_metadataTooMany(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("METADATA TOOMANY", buffer: &buffer, tracker: tracker)
             return .metadataTooMany
         }
 
-        func parseResponseTextCode_metadataNoPrivate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("METADATA NOPRIVATE", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_metadataNoPrivate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("METADATA NOPRIVATE", buffer: &buffer, tracker: tracker)
             return .metadataNoPrivate
         }
 
-        func parseResponseTextCode_urlMechanisms(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponseTextCode {
-            try fixedString("URLMECH INTERNAL", buffer: &buffer, tracker: tracker)
+        func parseResponseTextCode_urlMechanisms(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
+            try ParserLibrary.fixedString("URLMECH INTERNAL", buffer: &buffer, tracker: tracker)
             let array = try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> MechanismBase64 in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseMechanismBase64(buffer: &buffer, tracker: tracker)
             })
             return .urlMechanisms(array)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseResponseTextCode_alert,
             parseResponseTextCode_noModifierSequence,
             parseResponseTextCode_modified,
@@ -401,51 +401,51 @@ extension GrammarParser {
     }
 
     // quota_response  ::= "QUOTA" SP astring SP quota_list
-    static func parseResponsePayload_quota(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ResponsePayload {
+    static func parseResponsePayload_quota(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponsePayload {
         // quota_resource  ::= atom SP number SP number
-        func parseQuotaResource(buffer: inout ByteBuffer, tracker: StackTracker) throws -> QuotaResource {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+        func parseQuotaResource(buffer: inout ParseBuffer, tracker: StackTracker) throws -> QuotaResource {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
                 let resourceName = try parseAtom(buffer: &buffer, tracker: tracker)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 let usage = try parseNumber(buffer: &buffer, tracker: tracker)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 let limit = try parseNumber(buffer: &buffer, tracker: tracker)
                 return QuotaResource(resourceName: resourceName, usage: usage, limit: limit)
             }
         }
 
         // quota_list      ::= "(" #quota_resource ")"
-        func parseQuotaList(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [QuotaResource] {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-                try fixedString("(", buffer: &buffer, tracker: tracker)
+        func parseQuotaList(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [QuotaResource] {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
                 var resources: [QuotaResource] = []
-                while let resource = try optional(buffer: &buffer, tracker: tracker, parser: parseQuotaResource) {
+                while let resource = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parseQuotaResource) {
                     resources.append(resource)
-                    if try optional(buffer: &buffer, tracker: tracker, parser: space) == nil {
+                    if try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: ParserLibrary.space) == nil {
                         break
                     }
                 }
-                try fixedString(")", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
                 return resources
             }
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("QUOTA ", buffer: &buffer, tracker: tracker)
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("QUOTA ", buffer: &buffer, tracker: tracker)
             let quotaRoot = try parseAString(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let resources = try parseQuotaList(buffer: &buffer, tracker: tracker)
             return .quota(.init(quotaRoot), resources)
         }
     }
 
     // quotaroot_response ::= "QUOTAROOT" SP astring *(SP astring)
-    static func parseResponsePayload_quotaRoot(buffer: inout ByteBuffer,
+    static func parseResponsePayload_quotaRoot(buffer: inout ParseBuffer,
                                                tracker: StackTracker) throws -> ResponsePayload {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("QUOTAROOT ", buffer: &buffer, tracker: tracker)
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("QUOTAROOT ", buffer: &buffer, tracker: tracker)
             let mailbox = try parseMailbox(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let quotaRoot = try parseAString(buffer: &buffer, tracker: tracker)
             return .quotaRoot(mailbox, .init(quotaRoot))
         }

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
@@ -25,11 +25,11 @@ import struct NIO.ByteBufferView
 
 extension GrammarParser {
     // search          = "SEARCH" [search-return-opts] SP search-program
-    static func parseSearch(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("SEARCH", buffer: &buffer, tracker: tracker)
-            let returnOpts = try optional(buffer: &buffer, tracker: tracker, parser: self.parseSearchReturnOptions) ?? []
-            try space(buffer: &buffer, tracker: tracker)
+    static func parseSearch(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("SEARCH", buffer: &buffer, tracker: tracker)
+            let returnOpts = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseSearchReturnOptions) ?? []
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let (charset, program) = try parseSearchProgram(buffer: &buffer, tracker: tracker)
             return .search(key: program, charset: charset, returnOptions: returnOpts)
         }
@@ -39,16 +39,16 @@ extension GrammarParser {
     //                         search-key *(SP search-key)
     //                         ;; CHARSET argument to SEARCH MUST be
     //                         ;; registered with IANA.
-    static func parseSearchProgram(buffer: inout ByteBuffer, tracker: StackTracker) throws -> (String?, SearchKey) {
-        let charset = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> String in
-            try fixedString("CHARSET ", buffer: &buffer, tracker: tracker)
+    static func parseSearchProgram(buffer: inout ParseBuffer, tracker: StackTracker) throws -> (String?, SearchKey) {
+        let charset = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> String in
+            try ParserLibrary.fixedString("CHARSET ", buffer: &buffer, tracker: tracker)
             let charset = try self.parseCharset(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             return charset
         }
         var array = [try self.parseSearchKey(buffer: &buffer, tracker: tracker)]
         try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> SearchKey in
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             return try self.parseSearchKey(buffer: &buffer, tracker: tracker)
         }
 
@@ -66,43 +66,43 @@ extension GrammarParser {
     //                      ("UIDVALIDITY" SP nz-number)
     //                      ; Each correlator MUST appear exactly once.
     // search-correlator =  SP "(" one-correlator *(SP one-correlator) ")"
-    static func parseSearchCorrelator(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchCorrelator {
+    static func parseSearchCorrelator(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchCorrelator {
         var tag: ByteBuffer?
         var mailbox: MailboxName?
         var uidValidity: UIDValidity?
 
-        func parseSearchCorrelator_tag(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-            try fixedString("TAG ", buffer: &buffer, tracker: tracker)
+        func parseSearchCorrelator_tag(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+            try ParserLibrary.fixedString("TAG ", buffer: &buffer, tracker: tracker)
             tag = try self.parseString(buffer: &buffer, tracker: tracker)
         }
 
-        func parseSearchCorrelator_mailbox(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-            try fixedString("MAILBOX ", buffer: &buffer, tracker: tracker)
+        func parseSearchCorrelator_mailbox(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+            try ParserLibrary.fixedString("MAILBOX ", buffer: &buffer, tracker: tracker)
             mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
         }
 
-        func parseSearchCorrelator_uidValidity(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-            try fixedString("UIDVALIDITY ", buffer: &buffer, tracker: tracker)
+        func parseSearchCorrelator_uidValidity(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+            try ParserLibrary.fixedString("UIDVALIDITY ", buffer: &buffer, tracker: tracker)
             uidValidity = try self.parseUIDValidity(buffer: &buffer, tracker: tracker)
         }
 
-        func parseSearchCorrelator_once(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-            try oneOf([
+        func parseSearchCorrelator_once(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+            try ParserLibrary.oneOf([
                 parseSearchCorrelator_tag,
                 parseSearchCorrelator_mailbox,
                 parseSearchCorrelator_uidValidity,
             ], buffer: &buffer, tracker: tracker)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString(" (", buffer: &buffer, tracker: tracker)
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString(" (", buffer: &buffer, tracker: tracker)
 
             try parseSearchCorrelator_once(buffer: &buffer, tracker: tracker)
             var result: SearchCorrelator
-            if try optional(buffer: &buffer, tracker: tracker, parser: space) != nil {
+            if try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: ParserLibrary.space) != nil {
                 // If we have 2, we must have the third.
                 try parseSearchCorrelator_once(buffer: &buffer, tracker: tracker)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 try parseSearchCorrelator_once(buffer: &buffer, tracker: tracker)
                 if let tag = tag, mailbox != nil, uidValidity != nil {
                     result = SearchCorrelator(tag: tag, mailbox: mailbox, uidValidity: uidValidity)
@@ -117,17 +117,17 @@ extension GrammarParser {
                 }
             }
 
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return result
         }
     }
 
     // search-critera = search-key *(search-key)
-    static func parseSearchCriteria(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [SearchKey] {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+    static func parseSearchCriteria(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [SearchKey] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             var array = [try self.parseSearchKey(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseSearchKey(buffer: &buffer, tracker: tracker)
             }
             return array
@@ -150,13 +150,13 @@ extension GrammarParser {
     //                   "SENTSINCE" SP date / "SMALLER" SP number /
     //                   "UID" SP sequence-set / "UNDRAFT" / sequence-set /
     //                   "(" search-key *(SP search-key) ")"
-    static func parseSearchKey(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-        func parseSearchKey_fixed(string: String, result: SearchKey, buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString(string, buffer: &buffer, tracker: tracker)
+    static func parseSearchKey(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+        func parseSearchKey_fixed(string: String, result: SearchKey, buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString(string, buffer: &buffer, tracker: tracker)
             return result
         }
 
-        func parseSearchKey_fixedOptions(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
+        func parseSearchKey_fixedOptions(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
             let inputs: [(String, SearchKey)] = [
                 ("ALL", .all),
                 ("ANSWERED", .answered),
@@ -184,134 +184,134 @@ extension GrammarParser {
             throw ParserError()
         }
 
-        func parseSearchKey_bcc(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("BCC ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_bcc(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("BCC ", buffer: &buffer, tracker: tracker)
             return .bcc(try self.parseAString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_before(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("BEFORE ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_before(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("BEFORE ", buffer: &buffer, tracker: tracker)
             return .before(try self.parseDate(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_body(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("BODY ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_body(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("BODY ", buffer: &buffer, tracker: tracker)
             return .body(try self.parseAString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_cc(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("CC ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_cc(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("CC ", buffer: &buffer, tracker: tracker)
             return .cc(try self.parseAString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_from(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("FROM ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_from(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("FROM ", buffer: &buffer, tracker: tracker)
             return .from(try self.parseAString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_keyword(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("KEYWORD ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_keyword(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("KEYWORD ", buffer: &buffer, tracker: tracker)
             return .keyword(try self.parseFlagKeyword(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_on(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("ON ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_on(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("ON ", buffer: &buffer, tracker: tracker)
             return .on(try self.parseDate(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_since(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("SINCE ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_since(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("SINCE ", buffer: &buffer, tracker: tracker)
             return .since(try self.parseDate(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_subject(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("SUBJECT ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_subject(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("SUBJECT ", buffer: &buffer, tracker: tracker)
             return .subject(try self.parseAString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_text(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("TEXT ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_text(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("TEXT ", buffer: &buffer, tracker: tracker)
             return .text(try self.parseAString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_to(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("TO ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_to(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("TO ", buffer: &buffer, tracker: tracker)
             return .to(try self.parseAString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_unkeyword(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("UNKEYWORD ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_unkeyword(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("UNKEYWORD ", buffer: &buffer, tracker: tracker)
             return .unkeyword(try self.parseFlagKeyword(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_filter(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("FILTER ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_filter(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("FILTER ", buffer: &buffer, tracker: tracker)
             return .filter(try self.parseFilterName(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_header(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("HEADER ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_header(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("HEADER ", buffer: &buffer, tracker: tracker)
             let header = try self.parseHeaderFieldName(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let string = try self.parseAString(buffer: &buffer, tracker: tracker)
             return .header(header, string)
         }
 
-        func parseSearchKey_larger(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("LARGER ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_larger(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("LARGER ", buffer: &buffer, tracker: tracker)
             return .messageSizeLarger(try self.parseNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_smaller(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("SMALLER ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_smaller(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("SMALLER ", buffer: &buffer, tracker: tracker)
             return .messageSizeSmaller(try self.parseNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_not(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("NOT ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_not(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("NOT ", buffer: &buffer, tracker: tracker)
             return .not(try self.parseSearchKey(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_or(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("OR ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_or(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("OR ", buffer: &buffer, tracker: tracker)
             let key1 = try self.parseSearchKey(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let key2 = try self.parseSearchKey(buffer: &buffer, tracker: tracker)
             return .or(key1, key2)
         }
 
-        func parseSearchKey_sentBefore(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("SENTBEFORE ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_sentBefore(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("SENTBEFORE ", buffer: &buffer, tracker: tracker)
             return .sentBefore(try self.parseDate(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_sentOn(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("SENTON ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_sentOn(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("SENTON ", buffer: &buffer, tracker: tracker)
             return .sentOn(try self.parseDate(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_sentSince(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("SENTSINCE ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_sentSince(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("SENTSINCE ", buffer: &buffer, tracker: tracker)
             return .sentSince(try self.parseDate(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_uid(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("UID ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_uid(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("UID ", buffer: &buffer, tracker: tracker)
             return .uid(try self.parseLastCommandSet(buffer: &buffer, tracker: tracker, setParser: self.parseUIDSetNonEmpty))
         }
 
-        func parseSearchKey_sequenceSet(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
+        func parseSearchKey_sequenceSet(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
             .sequenceNumbers(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_array(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_array(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             var array = [try self.parseSearchKey(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> SearchKey in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseSearchKey(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
 
             if array.count == 1 {
                 return array.first!
@@ -320,21 +320,21 @@ extension GrammarParser {
             }
         }
 
-        func parseSearchKey_older(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("OLDER ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_older(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("OLDER ", buffer: &buffer, tracker: tracker)
             return .older(try self.parseNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_younger(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
-            try fixedString("YOUNGER ", buffer: &buffer, tracker: tracker)
+        func parseSearchKey_younger(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
+            try ParserLibrary.fixedString("YOUNGER ", buffer: &buffer, tracker: tracker)
             return .younger(try self.parseNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchKey_modificationSequence(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchKey {
+        func parseSearchKey_modificationSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
             .modificationSequence(try self.parseSearchModificationSequence(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseSearchKey_older,
             parseSearchKey_fixedOptions,
             parseSearchKey_younger,
@@ -366,32 +366,32 @@ extension GrammarParser {
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseSearchModificationSequence(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchModificationSequence {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SearchModificationSequence in
-            try fixedString("MODSEQ", buffer: &buffer, tracker: tracker)
+    static func parseSearchModificationSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchModificationSequence {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SearchModificationSequence in
+            try ParserLibrary.fixedString("MODSEQ", buffer: &buffer, tracker: tracker)
             var extensions = KeyValues<EntryFlagName, EntryKindRequest>()
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &extensions, tracker: tracker, parser: self.parseSearchModificationSequenceExtension)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let val = try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker)
             return .init(extensions: extensions, sequenceValue: val)
         }
     }
 
-    static func parseSearchModificationSequenceExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValue<EntryFlagName, EntryKindRequest> {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> KeyValue<EntryFlagName, EntryKindRequest> in
-            try space(buffer: &buffer, tracker: tracker)
+    static func parseSearchModificationSequenceExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValue<EntryFlagName, EntryKindRequest> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> KeyValue<EntryFlagName, EntryKindRequest> in
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let flag = try self.parseEntryFlagName(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let request = try self.parseEntryKindRequest(buffer: &buffer, tracker: tracker)
             return .init(key: flag, value: request)
         }
     }
 
     // search-ret-data-ext = search-modifier-name SP search-return-value
-    static func parseSearchReturnDataExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValue<String, ParameterValue> {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<String, ParameterValue> in
+    static func parseSearchReturnDataExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValue<String, ParameterValue> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<String, ParameterValue> in
             let modifier = try self.parseParameterName(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let value = try self.parseParameterValue(buffer: &buffer, tracker: tracker)
             return .init(key: modifier, value: value)
         }
@@ -402,37 +402,37 @@ extension GrammarParser {
     //                     "ALL" SP sequence-set /
     //                     "COUNT" SP number /
     //                     search-ret-data-ext
-    static func parseSearchReturnData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnData {
-        func parseSearchReturnData_min(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnData {
-            try fixedString("MIN ", buffer: &buffer, tracker: tracker)
+    static func parseSearchReturnData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
+        func parseSearchReturnData_min(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
+            try ParserLibrary.fixedString("MIN ", buffer: &buffer, tracker: tracker)
             return .min(try self.parseNZNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchReturnData_max(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnData {
-            try fixedString("MAX ", buffer: &buffer, tracker: tracker)
+        func parseSearchReturnData_max(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
+            try ParserLibrary.fixedString("MAX ", buffer: &buffer, tracker: tracker)
             return .max(try self.parseNZNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchReturnData_all(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnData {
-            try fixedString("ALL ", buffer: &buffer, tracker: tracker)
+        func parseSearchReturnData_all(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
+            try ParserLibrary.fixedString("ALL ", buffer: &buffer, tracker: tracker)
             return .all(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchReturnData_count(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnData {
-            try fixedString("COUNT ", buffer: &buffer, tracker: tracker)
+        func parseSearchReturnData_count(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
+            try ParserLibrary.fixedString("COUNT ", buffer: &buffer, tracker: tracker)
             return .count(try self.parseNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchReturnData_modificationSequence(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnData {
-            try fixedString("MODSEQ ", buffer: &buffer, tracker: tracker)
+        func parseSearchReturnData_modificationSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
+            try ParserLibrary.fixedString("MODSEQ ", buffer: &buffer, tracker: tracker)
             return .modificationSequence(try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSearchReturnData_dataExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnData {
+        func parseSearchReturnData_dataExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
             .dataExtension(try self.parseSearchReturnDataExtension(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseSearchReturnData_min,
             parseSearchReturnData_max,
             parseSearchReturnData_all,
@@ -443,18 +443,18 @@ extension GrammarParser {
     }
 
     // search-return-opts   = SP "RETURN" SP "(" [search-return-opt *(SP search-return-opt)] ")"
-    static func parseSearchReturnOptions(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [SearchReturnOption] {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString(" RETURN (", buffer: &buffer, tracker: tracker)
-            let array = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [SearchReturnOption] in
+    static func parseSearchReturnOptions(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [SearchReturnOption] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString(" RETURN (", buffer: &buffer, tracker: tracker)
+            let array = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [SearchReturnOption] in
                 var array = [try self.parseSearchReturnOption(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> SearchReturnOption in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try self.parseSearchReturnOption(buffer: &buffer, tracker: tracker)
                 }
                 return array
             } ?? []
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return array
         }
     }
@@ -462,38 +462,38 @@ extension GrammarParser {
     // search-return-opt  = "MIN" / "MAX" / "ALL" / "COUNT" /
     //                      "SAVE" /
     //                      search-ret-opt-ext
-    static func parseSearchReturnOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnOption {
-        func parseSearchReturnOption_min(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnOption {
-            try fixedString("MIN", buffer: &buffer, tracker: tracker)
+    static func parseSearchReturnOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
+        func parseSearchReturnOption_min(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
+            try ParserLibrary.fixedString("MIN", buffer: &buffer, tracker: tracker)
             return .min
         }
 
-        func parseSearchReturnOption_max(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnOption {
-            try fixedString("MAX", buffer: &buffer, tracker: tracker)
+        func parseSearchReturnOption_max(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
+            try ParserLibrary.fixedString("MAX", buffer: &buffer, tracker: tracker)
             return .max
         }
 
-        func parseSearchReturnOption_all(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnOption {
-            try fixedString("ALL", buffer: &buffer, tracker: tracker)
+        func parseSearchReturnOption_all(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
+            try ParserLibrary.fixedString("ALL", buffer: &buffer, tracker: tracker)
             return .all
         }
 
-        func parseSearchReturnOption_count(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnOption {
-            try fixedString("COUNT", buffer: &buffer, tracker: tracker)
+        func parseSearchReturnOption_count(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
+            try ParserLibrary.fixedString("COUNT", buffer: &buffer, tracker: tracker)
             return .count
         }
 
-        func parseSearchReturnOption_save(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnOption {
-            try fixedString("SAVE", buffer: &buffer, tracker: tracker)
+        func parseSearchReturnOption_save(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
+            try ParserLibrary.fixedString("SAVE", buffer: &buffer, tracker: tracker)
             return .save
         }
 
-        func parseSearchReturnOption_extension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SearchReturnOption {
+        func parseSearchReturnOption_extension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
             let optionExtension = try self.parseSearchReturnOptionExtension(buffer: &buffer, tracker: tracker)
             return .optionExtension(optionExtension)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseSearchReturnOption_min,
             parseSearchReturnOption_max,
             parseSearchReturnOption_all,
@@ -504,22 +504,22 @@ extension GrammarParser {
     }
 
     // search-ret-opt-ext = search-modifier-name [SP search-mod-params]
-    static func parseSearchReturnOptionExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValue<String, ParameterValue?> {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<String, ParameterValue?> in
+    static func parseSearchReturnOptionExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValue<String, ParameterValue?> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<String, ParameterValue?> in
             let name = try self.parseParameterName(buffer: &buffer, tracker: tracker)
-            let params = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ParameterValue in
-                try space(buffer: &buffer, tracker: tracker)
+            let params = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ParameterValue in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseParameterValue(buffer: &buffer, tracker: tracker)
             }
             return .init(key: name, value: params)
         }
     }
 
-    static func parseSearchSortModificationSequence(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ModificationSequenceValue {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ModificationSequenceValue in
-            try fixedString("(MODSEQ ", buffer: &buffer, tracker: tracker)
+    static func parseSearchSortModificationSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ModificationSequenceValue {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ModificationSequenceValue in
+            try ParserLibrary.fixedString("(MODSEQ ", buffer: &buffer, tracker: tracker)
             let modSeq = try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return modSeq
         }
     }

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
@@ -25,27 +25,27 @@ import struct NIO.ByteBufferView
 
 extension GrammarParser {
     // Sequence Range
-    static func parseSequenceRange(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SequenceRange {
-        func parse_wildcard(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SequenceNumber {
-            try fixedString("*", buffer: &buffer, tracker: tracker)
+    static func parseSequenceRange(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SequenceRange {
+        func parse_wildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SequenceNumber {
+            try ParserLibrary.fixedString("*", buffer: &buffer, tracker: tracker)
             return .max
         }
 
-        func parse_SequenceOrWildcard(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SequenceNumber {
-            try oneOf([
+        func parse_SequenceOrWildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SequenceNumber {
+            try ParserLibrary.oneOf([
                 parse_wildcard,
                 GrammarParser.parseSequenceNumber,
             ], buffer: &buffer, tracker: tracker)
         }
 
-        func parse_colonAndSequenceOrWildcard(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SequenceNumber {
-            try fixedString(":", buffer: &buffer, tracker: tracker)
+        func parse_colonAndSequenceOrWildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SequenceNumber {
+            try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
             return try parse_SequenceOrWildcard(buffer: &buffer, tracker: tracker)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SequenceRange in
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SequenceRange in
             let id1 = try parse_SequenceOrWildcard(buffer: &buffer, tracker: tracker)
-            let id2 = try optional(buffer: &buffer, tracker: tracker, parser: parse_colonAndSequenceOrWildcard)
+            let id2 = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parse_colonAndSequenceOrWildcard)
             if let id2 = id2 {
                 return SequenceRange(id1 ... id2)
             } else if id1 == .max {
@@ -56,13 +56,13 @@ extension GrammarParser {
         }
     }
 
-    static func parseSequenceMatchData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SequenceMatchData {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parseSequenceMatchData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SequenceMatchData {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             let knownSequenceSet = try self.parseLastCommandSet(buffer: &buffer, tracker: tracker, setParser: self.parseUIDSetNonEmpty)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let knownUidSet = try self.parseLastCommandSet(buffer: &buffer, tracker: tracker, setParser: self.parseUIDSetNonEmpty)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return SequenceMatchData(knownSequenceSet: knownSequenceSet, knownUidSet: knownUidSet)
         }
     }
@@ -70,7 +70,7 @@ extension GrammarParser {
     // SequenceNumber
     // Note: the formal syntax is bogus here.
     // "*" is a sequence range, but not a sequence number.
-    static func parseSequenceNumber(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SequenceNumber {
+    static func parseSequenceNumber(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SequenceNumber {
         guard let seq = SequenceNumber(exactly: try self.parseNZNumber(buffer: &buffer, tracker: tracker)) else {
             throw ParserError(hint: "Sequence number out of range.")
         }
@@ -81,24 +81,24 @@ extension GrammarParser {
     // And from RFC 5182
     // sequence-set       =/ seq-last-command
     // seq-last-command   = "$"
-    static func parseSequenceSet(buffer: inout ByteBuffer, tracker: StackTracker) throws -> LastCommandSet<SequenceRangeSet> {
-        func parseSequenceSet_number(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SequenceRange {
+    static func parseSequenceSet(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<SequenceRangeSet> {
+        func parseSequenceSet_number(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SequenceRange {
             let num = try self.parseSequenceNumber(buffer: &buffer, tracker: tracker)
             return SequenceRange(num)
         }
 
-        func parseSequenceSet_element(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SequenceRange {
-            try oneOf([
+        func parseSequenceSet_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SequenceRange {
+            try ParserLibrary.oneOf([
                 self.parseSequenceRange,
                 parseSequenceSet_number,
             ], buffer: &buffer, tracker: tracker)
         }
 
-        func parseSequenceSet_base(buffer: inout ByteBuffer, tracker: StackTracker) throws -> LastCommandSet<SequenceRangeSet> {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+        func parseSequenceSet_base(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<SequenceRangeSet> {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
                 var output = [try parseSequenceSet_element(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &output, tracker: tracker) { buffer, tracker in
-                    try fixedString(",", buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.fixedString(",", buffer: &buffer, tracker: tracker)
                     return try parseSequenceSet_element(buffer: &buffer, tracker: tracker)
                 }
                 guard let s = SequenceRangeSet(output) else {
@@ -108,19 +108,19 @@ extension GrammarParser {
             }
         }
 
-        func parseSequenceSet_lastCommand(buffer: inout ByteBuffer, tracker: StackTracker) throws -> LastCommandSet<SequenceRangeSet> {
-            try fixedString("$", buffer: &buffer, tracker: tracker)
+        func parseSequenceSet_lastCommand(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<SequenceRangeSet> {
+            try ParserLibrary.fixedString("$", buffer: &buffer, tracker: tracker)
             return .lastCommand
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseSequenceSet_base,
             parseSequenceSet_lastCommand,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // mod-sequence-valzer = "0" / mod-sequence-value
-    static func parseModificationSequenceValue(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ModificationSequenceValue {
+    static func parseModificationSequenceValue(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ModificationSequenceValue {
         let number = UInt64(try self.parseNumber(buffer: &buffer, tracker: tracker))
         return ModificationSequenceValue(number)
     }

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
@@ -24,18 +24,18 @@ import struct NIO.ByteBuffer
 import struct NIO.ByteBufferView
 
 extension GrammarParser {
-    static func parseLastCommandSet<T: _IMAPEncodable>(buffer: inout ByteBuffer, tracker: StackTracker, setParser: SubParser<T>) throws -> LastCommandSet<T> {
-        func parseLastCommandSet_lastCommand(buffer: inout ByteBuffer, tracker: StackTracker) throws -> LastCommandSet<T> {
-            try fixedString("$", buffer: &buffer, tracker: tracker)
+    static func parseLastCommandSet<T: _IMAPEncodable>(buffer: inout ParseBuffer, tracker: StackTracker, setParser: SubParser<T>) throws -> LastCommandSet<T> {
+        func parseLastCommandSet_lastCommand(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<T> {
+            try ParserLibrary.fixedString("$", buffer: &buffer, tracker: tracker)
             return .lastCommand
         }
 
-        func parseLastCommandSet_set(buffer: inout ByteBuffer, tracker: StackTracker) throws -> LastCommandSet<T> {
+        func parseLastCommandSet_set(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<T> {
             .set(try setParser(&buffer, tracker))
         }
 
         return try withoutActuallyEscaping(parseLastCommandSet_set) { (parseLastCommandSet_set) in
-            try oneOf([
+            try ParserLibrary.oneOf([
                 parseLastCommandSet_lastCommand,
                 parseLastCommandSet_set,
             ], buffer: &buffer, tracker: tracker)
@@ -44,65 +44,65 @@ extension GrammarParser {
 
     // uid             = "UID" SP
     //                   (copy / move / fetch / search / store / uid-expunge)
-    static func parseUid(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        func parseUid_copy(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-                try fixedString("COPY ", buffer: &buffer, tracker: tracker)
+    static func parseUid(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        func parseUid_copy(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+                try ParserLibrary.fixedString("COPY ", buffer: &buffer, tracker: tracker)
                 let set = try self.parseLastCommandSet(buffer: &buffer, tracker: tracker, setParser: self.parseUIDSetNonEmpty)
-                try fixedString(" ", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
                 let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
                 return .uidCopy(set, mailbox)
             }
         }
 
-        func parseUid_move(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-                try fixedString("MOVE ", buffer: &buffer, tracker: tracker)
+        func parseUid_move(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+                try ParserLibrary.fixedString("MOVE ", buffer: &buffer, tracker: tracker)
                 let set = try self.parseLastCommandSet(buffer: &buffer, tracker: tracker, setParser: self.parseUIDSetNonEmpty)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
                 return .uidMove(set, mailbox)
             }
         }
 
-        func parseUid_fetch(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-                try fixedString("FETCH ", buffer: &buffer, tracker: tracker)
+        func parseUid_fetch(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+                try ParserLibrary.fixedString("FETCH ", buffer: &buffer, tracker: tracker)
                 let set = try self.parseLastCommandSet(buffer: &buffer, tracker: tracker, setParser: self.parseUIDSetNonEmpty)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 let att = try parseFetch_type(buffer: &buffer, tracker: tracker)
-                let modifiers = try optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
+                let modifiers = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
                 return .uidFetch(set, att, modifiers)
             }
         }
 
-        func parseUid_search(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
+        func parseUid_search(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
             guard case .search(let key, let charset, let returnOptions) = try self.parseSearch(buffer: &buffer, tracker: tracker) else {
                 fatalError("This should never happen")
             }
             return .uidSearch(key: key, charset: charset, returnOptions: returnOptions)
         }
 
-        func parseUid_store(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-                try fixedString("STORE ", buffer: &buffer, tracker: tracker)
+        func parseUid_store(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+                try ParserLibrary.fixedString("STORE ", buffer: &buffer, tracker: tracker)
                 let set = try self.parseLastCommandSet(buffer: &buffer, tracker: tracker, setParser: self.parseUIDSetNonEmpty)
-                let modifiers = try optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
-                try space(buffer: &buffer, tracker: tracker)
+                let modifiers = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 let flags = try self.parseStoreAttributeFlags(buffer: &buffer, tracker: tracker)
                 return .uidStore(set, modifiers, flags)
             }
         }
 
-        func parseUid_expunge(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try fixedString("EXPUNGE ", buffer: &buffer, tracker: tracker)
+        func parseUid_expunge(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.fixedString("EXPUNGE ", buffer: &buffer, tracker: tracker)
             let set = try self.parseLastCommandSet(buffer: &buffer, tracker: tracker, setParser: self.parseUIDSetNonEmpty)
             return .uidExpunge(set)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("UID ", buffer: &buffer, tracker: tracker)
-            return try oneOf([
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("UID ", buffer: &buffer, tracker: tracker)
+            return try ParserLibrary.oneOf([
                 parseUid_copy,
                 parseUid_move,
                 parseUid_fetch,
@@ -114,27 +114,27 @@ extension GrammarParser {
     }
 
     // uid-range       = (uniqueid ":" uniqueid)
-    static func parseUIDRange(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UIDRange {
-        func parse_wildcard(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UID {
-            try fixedString("*", buffer: &buffer, tracker: tracker)
+    static func parseUIDRange(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
+        func parse_wildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UID {
+            try ParserLibrary.fixedString("*", buffer: &buffer, tracker: tracker)
             return .max
         }
 
-        func parse_UIDOrWildcard(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UID {
-            try oneOf([
+        func parse_UIDOrWildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UID {
+            try ParserLibrary.oneOf([
                 parse_wildcard,
                 GrammarParser.parseUID,
             ], buffer: &buffer, tracker: tracker)
         }
 
-        func parse_colonAndUIDOrWildcard(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UID {
-            try fixedString(":", buffer: &buffer, tracker: tracker)
+        func parse_colonAndUIDOrWildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UID {
+            try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
             return try parse_UIDOrWildcard(buffer: &buffer, tracker: tracker)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> UIDRange in
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> UIDRange in
             let id1 = try parse_UIDOrWildcard(buffer: &buffer, tracker: tracker)
-            let id2 = try optional(buffer: &buffer, tracker: tracker, parser: parse_colonAndUIDOrWildcard)
+            let id2 = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parse_colonAndUIDOrWildcard)
             if let id2 = id2 {
                 return UIDRange(id1 ... id2)
             } else {
@@ -144,7 +144,7 @@ extension GrammarParser {
     }
 
     // uniqueid        = nz-number
-    static func parseUID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UID {
+    static func parseUID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UID {
         guard let uid = UID(exactly: try self.parseNZNumber(buffer: &buffer, tracker: tracker)) else {
             throw ParserError(hint: "UID out of range.")
         }
@@ -152,7 +152,7 @@ extension GrammarParser {
     }
 
     // uniqueid        = nz-number
-    static func parseUIDValidity(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UIDValidity {
+    static func parseUIDValidity(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDValidity {
         guard let validity = UIDValidity(exactly: try self.parseNZNumber(buffer: &buffer, tracker: tracker)) else {
             throw ParserError(hint: "Invalid UID validity.")
         }
@@ -160,23 +160,23 @@ extension GrammarParser {
     }
 
     // uid-set
-    static func parseUIDSet(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UIDSet {
-        func parseUIDSet_number(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UIDRange {
+    static func parseUIDSet(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDSet {
+        func parseUIDSet_number(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
             let num = try self.parseUID(buffer: &buffer, tracker: tracker)
             return UIDRange(num)
         }
 
-        func parseUIDSet_element(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UIDRange {
-            try oneOf([
+        func parseUIDSet_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
+            try ParserLibrary.oneOf([
                 self.parseUIDRange,
                 parseUIDSet_number,
             ], buffer: &buffer, tracker: tracker)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             var output = [try parseUIDSet_element(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &output, tracker: tracker) { buffer, tracker in
-                try fixedString(",", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(",", buffer: &buffer, tracker: tracker)
                 return try parseUIDSet_element(buffer: &buffer, tracker: tracker)
             }
             let s = UIDSet(output)
@@ -187,8 +187,8 @@ extension GrammarParser {
         }
     }
 
-    static func parseUIDSetNonEmpty(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UIDSetNonEmpty {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+    static func parseUIDSetNonEmpty(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDSetNonEmpty {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             guard let set = UIDSetNonEmpty(set: try self.parseUIDSet(buffer: &buffer, tracker: tracker)) else {
                 throw ParserError(hint: "Need at least one UID")
             }
@@ -196,23 +196,23 @@ extension GrammarParser {
         }
     }
 
-    static func parseUIDRangeArray(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UIDRange] {
-        func parseUIDArray_number(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UIDRange {
+    static func parseUIDRangeArray(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UIDRange] {
+        func parseUIDArray_number(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
             let num = try self.parseUID(buffer: &buffer, tracker: tracker)
             return UIDRange(num)
         }
 
-        func parseUIDArray_element(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UIDRange {
-            try oneOf([
+        func parseUIDArray_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
+            try ParserLibrary.oneOf([
                 self.parseUIDRange,
                 parseUIDArray_number,
             ], buffer: &buffer, tracker: tracker)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             var output = [try parseUIDArray_element(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &output, tracker: tracker) { buffer, tracker in
-                try fixedString(",", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(",", buffer: &buffer, tracker: tracker)
                 return try parseUIDArray_element(buffer: &buffer, tracker: tracker)
             }
 

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -21,32 +21,26 @@ let badOS = { fatalError("unsupported OS") }()
 #endif
 
 import struct NIO.ByteBuffer
-import struct NIO.ByteBufferView
-
-struct _IncompleteMessage: Error {
-    init() {}
-}
-
 enum GrammarParser {}
 
 // MARK: - Grammar Parsers
 
 extension GrammarParser {
     // astring         = 1*ASTRING-CHAR / string
-    static func parseAString(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
-        func parseOneOrMoreASTRINGCHAR(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
+    static func parseAString(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
+        func parseOneOrMoreASTRINGCHAR(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
             try ParserLibrary.parseOneOrMoreCharactersByteBuffer(buffer: &buffer, tracker: tracker) { char -> Bool in
                 char.isAStringChar
             }
         }
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             Self.parseString,
             parseOneOrMoreASTRINGCHAR,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // atom            = 1*ATOM-CHAR
-    static func parseAtom(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parseAtom(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
         try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char -> Bool in
             char.isAtomChar
         }
@@ -55,44 +49,44 @@ extension GrammarParser {
     // RFC 7162 Condstore
     // attr-flag           = "\\Answered" / "\\Flagged" / "\\Deleted" /
     //                          "\\Seen" / "\\Draft" / attr-flag-keyword / attr-flag-extension
-    static func parseAttributeFlag(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AttributeFlag {
-        func parseAttributeFlag_slashed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AttributeFlag {
-            try fixedString("\\\\", buffer: &buffer, tracker: tracker)
+    static func parseAttributeFlag(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AttributeFlag {
+        func parseAttributeFlag_slashed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AttributeFlag {
+            try ParserLibrary.fixedString("\\\\", buffer: &buffer, tracker: tracker)
             let atom = try self.parseAtom(buffer: &buffer, tracker: tracker)
             return .init("\\\\\(atom)")
         }
 
-        func parseAttributeFlag_unslashed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AttributeFlag {
+        func parseAttributeFlag_unslashed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AttributeFlag {
             let atom = try self.parseAtom(buffer: &buffer, tracker: tracker)
             return .init(atom)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseAttributeFlag_slashed,
             parseAttributeFlag_unslashed,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseAuthenticatedURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AuthenticatedURL {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AuthenticatedURL in
-            try fixedString("imap://", buffer: &buffer, tracker: tracker)
+    static func parseAuthenticatedURL(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AuthenticatedURL {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AuthenticatedURL in
+            try ParserLibrary.fixedString("imap://", buffer: &buffer, tracker: tracker)
             let server = try self.parseIMAPServer(buffer: &buffer, tracker: tracker)
-            try fixedString("/", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
             let messagePart = try self.parseIMessagePart(buffer: &buffer, tracker: tracker)
             return .init(server: server, messagePart: messagePart)
         }
     }
 
-    static func parseAuthIMAPURLFull(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FullAuthenticatedURL {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> FullAuthenticatedURL in
+    static func parseAuthIMAPURLFull(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FullAuthenticatedURL {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> FullAuthenticatedURL in
             let imapURL = try self.parseAuthenticatedURL(buffer: &buffer, tracker: tracker)
             let urlAuth = try self.parseIURLAuth(buffer: &buffer, tracker: tracker)
             return .init(imapURL: imapURL, authenticatedURL: urlAuth)
         }
     }
 
-    static func parseAuthIMAPURLRump(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RumpAuthenticatedURL {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> RumpAuthenticatedURL in
+    static func parseAuthIMAPURLRump(buffer: inout ParseBuffer, tracker: StackTracker) throws -> RumpAuthenticatedURL {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> RumpAuthenticatedURL in
             let imapURL = try self.parseAuthenticatedURL(buffer: &buffer, tracker: tracker)
             let rump = try self.parseIRumpAuthenticatedURL(buffer: &buffer, tracker: tracker)
             return .init(authenticatedURL: imapURL, authenticatedURLRump: rump)
@@ -100,38 +94,38 @@ extension GrammarParser {
     }
 
     // authenticate  = "AUTHENTICATE" SP auth-type [SP (base64 / "=")] *(CRLF base64)
-    static func parseAuthenticate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("AUTHENTICATE ", buffer: &buffer, tracker: tracker)
+    static func parseAuthenticate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("AUTHENTICATE ", buffer: &buffer, tracker: tracker)
             let authMethod = try self.parseAtom(buffer: &buffer, tracker: tracker)
-            let parseInitialClientResponse = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> InitialClientResponse in
-                try space(buffer: &buffer, tracker: tracker)
+            let parseInitialClientResponse = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> InitialClientResponse in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseInitialClientResponse(buffer: &buffer, tracker: tracker)
             })
             return .authenticate(method: authMethod, initialClientResponse: parseInitialClientResponse)
         }
     }
 
-    static func parseInitialClientResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> InitialClientResponse {
-        func parseInitialClientResponse_empty(buffer: inout ByteBuffer, tracker: StackTracker) throws -> InitialClientResponse {
-            try fixedString("=", buffer: &buffer, tracker: tracker)
+    static func parseInitialClientResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> InitialClientResponse {
+        func parseInitialClientResponse_empty(buffer: inout ParseBuffer, tracker: StackTracker) throws -> InitialClientResponse {
+            try ParserLibrary.fixedString("=", buffer: &buffer, tracker: tracker)
             return .empty
         }
 
-        func parseInitialClientResponse_data(buffer: inout ByteBuffer, tracker: StackTracker) throws -> InitialClientResponse {
+        func parseInitialClientResponse_data(buffer: inout ParseBuffer, tracker: StackTracker) throws -> InitialClientResponse {
             let base64 = try parseBase64(buffer: &buffer, tracker: tracker)
             return .init(base64)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseInitialClientResponse_empty,
             parseInitialClientResponse_data,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // base64          = *(4base64-char) [base64-terminal]
-    static func parseBase64(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
+    static func parseBase64(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
             let bytes = try ParserLibrary.parseZeroOrMoreCharactersByteBuffer(buffer: &buffer, tracker: tracker) { $0.isBase64Char || $0 == UInt8(ascii: "=") }
             let readableBytesView = bytes.readableBytesView
             if let firstEq = readableBytesView.firstIndex(of: UInt8(ascii: "=")) {
@@ -144,7 +138,7 @@ extension GrammarParser {
 
             do {
                 let decoded = try Base64.decode(bytes: bytes.readableBytesView)
-                return ByteBuffer(ByteBufferView(decoded))
+                return ByteBuffer(bytes: decoded)
             } catch {
                 throw ParserError(hint: "Invalid base64 \(error)")
             }
@@ -152,30 +146,30 @@ extension GrammarParser {
     }
 
     // capability      = ("AUTH=" auth-type) / atom / "MOVE" / "ENABLE" / "FILTERS"
-    static func parseCapability(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Capability {
+    static func parseCapability(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Capability {
         let string = try self.parseAtom(buffer: &buffer, tracker: tracker)
         return Capability(string)
     }
 
     // capability-data = "CAPABILITY" *(SP capability) SP "IMAP4rev1"
     //                   *(SP capability)
-    static func parseCapabilityData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [Capability] {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [Capability] in
-            try fixedString("CAPABILITY", buffer: &buffer, tracker: tracker)
+    static func parseCapabilityData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [Capability] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [Capability] in
+            try ParserLibrary.fixedString("CAPABILITY", buffer: &buffer, tracker: tracker)
             return try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseCapability(buffer: &buffer, tracker: tracker)
             }
         }
     }
 
     // charset          = atom / quoted
-    static func parseCharset(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
-        func parseCharset_atom(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parseCharset(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
+        func parseCharset_atom(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
             try parseAtom(buffer: &buffer, tracker: tracker)
         }
 
-        func parseCharset_quoted(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+        func parseCharset_quoted(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
             var buffer = try parseQuoted(buffer: &buffer, tracker: tracker)
             guard let string = buffer.readString(length: buffer.readableBytes) else {
                 throw ParserError(hint: "Couldn't read string from buffer")
@@ -183,23 +177,23 @@ extension GrammarParser {
             return string
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseCharset_atom,
             parseCharset_quoted,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseChangedSinceModifier(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ChangedSinceModifier {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ChangedSinceModifier in
-            try fixedString("CHANGEDSINCE ", buffer: &buffer, tracker: tracker)
+    static func parseChangedSinceModifier(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ChangedSinceModifier {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ChangedSinceModifier in
+            try ParserLibrary.fixedString("CHANGEDSINCE ", buffer: &buffer, tracker: tracker)
             let val = try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker)
             return .init(modificationSequence: val)
         }
     }
 
-    static func parseUnchangedSinceModifier(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UnchangedSinceModifier {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> UnchangedSinceModifier in
-            try fixedString("UNCHANGEDSINCE ", buffer: &buffer, tracker: tracker)
+    static func parseUnchangedSinceModifier(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UnchangedSinceModifier {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> UnchangedSinceModifier in
+            try ParserLibrary.fixedString("UNCHANGEDSINCE ", buffer: &buffer, tracker: tracker)
             let val = try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker)
             return .init(modificationSequence: val)
         }
@@ -208,31 +202,31 @@ extension GrammarParser {
     // childinfo-extended-item =  "CHILDINFO" SP "("
     //             list-select-base-opt-quoted
     //             *(SP list-select-base-opt-quoted) ")"
-    static func parseChildinfoExtendedItem(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [ListSelectBaseOption] {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [ListSelectBaseOption] in
-            try fixedString("CHILDINFO (", buffer: &buffer, tracker: tracker)
+    static func parseChildinfoExtendedItem(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [ListSelectBaseOption] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [ListSelectBaseOption] in
+            try ParserLibrary.fixedString("CHILDINFO (", buffer: &buffer, tracker: tracker)
             var array = [try self.parseListSelectBaseOptionQuoted(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> ListSelectBaseOption in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseListSelectBaseOptionQuoted(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return array
         }
     }
 
     // condstore-param = "CONDSTORE"
-    static func parseConditionalStoreParameter(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-        try fixedString("CONDSTORE", buffer: &buffer, tracker: tracker)
+    static func parseConditionalStoreParameter(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+        try ParserLibrary.fixedString("CONDSTORE", buffer: &buffer, tracker: tracker)
     }
 
     // continue-req    = "+" SP (resp-text / base64) CRLF
-    static func parseContinuationRequest(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ContinuationRequest {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ContinuationRequest in
-            try fixedString("+", buffer: &buffer, tracker: tracker)
+    static func parseContinuationRequest(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ContinuationRequest {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ContinuationRequest in
+            try ParserLibrary.fixedString("+", buffer: &buffer, tracker: tracker)
             // Allow no space and no additional text after "+":
             let req: ContinuationRequest
-            if try optional(buffer: &buffer, tracker: tracker, parser: space) != nil {
+            if try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: ParserLibrary.space) != nil {
                 if let base64 = try? self.parseBase64(buffer: &buffer, tracker: tracker), base64.readableBytes > 0 {
                     req = .data(base64)
                 } else {
@@ -241,121 +235,121 @@ extension GrammarParser {
             } else {
                 req = .responseText(ResponseText(code: nil, text: ""))
             }
-            try newline(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
             return req
         }
     }
 
     // copy            = "COPY" SP sequence-set SP mailbox
-    static func parseCopy(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("COPY ", buffer: &buffer, tracker: tracker)
+    static func parseCopy(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("COPY ", buffer: &buffer, tracker: tracker)
             let sequence = try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
-            try fixedString(" ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
             return .copy(sequence, mailbox)
         }
     }
 
     // create          = "CREATE" SP mailbox [create-params]
-    static func parseCreate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("CREATE ", buffer: &buffer, tracker: tracker)
+    static func parseCreate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("CREATE ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            let params = try optional(buffer: &buffer, tracker: tracker, parser: self.parseCreateParameters) ?? []
+            let params = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseCreateParameters) ?? []
             return .create(mailbox, params)
         }
     }
 
     // create-param = create-param-name [SP create-param-value]
 
-    static func parseCreateParameters(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [CreateParameter] {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString(" (", buffer: &buffer, tracker: tracker)
+    static func parseCreateParameters(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [CreateParameter] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString(" (", buffer: &buffer, tracker: tracker)
             var array = [try self.parseCreateParameter(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { buffer, tracker in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseCreateParameter(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return array
         }
     }
 
-    static func parseCreateParameter(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CreateParameter {
-        func parseCreateParameter_parameter(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CreateParameter {
+    static func parseCreateParameter(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CreateParameter {
+        func parseCreateParameter_parameter(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CreateParameter {
             .labelled(try self.parseParameter(buffer: &buffer, tracker: tracker))
         }
 
-        func parseCreateParameter_specialUse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> CreateParameter {
-            try fixedString("USE (", buffer: &buffer, tracker: tracker)
+        func parseCreateParameter_specialUse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CreateParameter {
+            try ParserLibrary.fixedString("USE (", buffer: &buffer, tracker: tracker)
             var array = [try self.parseUseAttribute(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseUseAttribute(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .attributes(array)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseCreateParameter_specialUse,
             parseCreateParameter_parameter,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseParameter(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValue<String, ParameterValue?> {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+    static func parseParameter(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValue<String, ParameterValue?> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             let name = try self.parseParameterName(buffer: &buffer, tracker: tracker)
-            let value = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ParameterValue in
-                try space(buffer: &buffer, tracker: tracker)
+            let value = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ParameterValue in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseParameterValue(buffer: &buffer, tracker: tracker)
             }
             return .init(key: name, value: value)
         }
     }
 
-    static func parseUseAttribute(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
-        func parseUseAttribute_fixed(expected: String, returning: UseAttribute, buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
-            try fixedString(expected, buffer: &buffer, tracker: tracker)
+    static func parseUseAttribute(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
+        func parseUseAttribute_fixed(expected: String, returning: UseAttribute, buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
+            try ParserLibrary.fixedString(expected, buffer: &buffer, tracker: tracker)
             return returning
         }
 
-        func parseUseAttribute_all(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
+        func parseUseAttribute_all(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
             try parseUseAttribute_fixed(expected: "\\All", returning: .all, buffer: &buffer, tracker: tracker)
         }
 
-        func parseUseAttribute_archive(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
+        func parseUseAttribute_archive(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
             try parseUseAttribute_fixed(expected: "\\Archive", returning: .archive, buffer: &buffer, tracker: tracker)
         }
 
-        func parseUseAttribute_drafts(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
+        func parseUseAttribute_drafts(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
             try parseUseAttribute_fixed(expected: "\\Drafts", returning: .drafts, buffer: &buffer, tracker: tracker)
         }
 
-        func parseUseAttribute_flagged(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
+        func parseUseAttribute_flagged(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
             try parseUseAttribute_fixed(expected: "\\Flagged", returning: .flagged, buffer: &buffer, tracker: tracker)
         }
 
-        func parseUseAttribute_junk(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
+        func parseUseAttribute_junk(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
             try parseUseAttribute_fixed(expected: "\\Junk", returning: .junk, buffer: &buffer, tracker: tracker)
         }
 
-        func parseUseAttribute_sent(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
+        func parseUseAttribute_sent(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
             try parseUseAttribute_fixed(expected: "\\Sent", returning: .sent, buffer: &buffer, tracker: tracker)
         }
 
-        func parseUseAttribute_trash(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
+        func parseUseAttribute_trash(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
             try parseUseAttribute_fixed(expected: "\\Trash", returning: .trash, buffer: &buffer, tracker: tracker)
         }
 
-        func parseUseAttribute_other(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UseAttribute {
-            try fixedString("\\", buffer: &buffer, tracker: tracker)
+        func parseUseAttribute_other(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UseAttribute {
+            try ParserLibrary.fixedString("\\", buffer: &buffer, tracker: tracker)
             let att = try self.parseAtom(buffer: &buffer, tracker: tracker)
             return .init("\\" + att)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseUseAttribute_all,
             parseUseAttribute_archive,
             parseUseAttribute_drafts,
@@ -368,76 +362,74 @@ extension GrammarParser {
     }
 
     // delete          = "DELETE" SP mailbox
-    static func parseDelete(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("DELETE ", buffer: &buffer, tracker: tracker)
+    static func parseDelete(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("DELETE ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
             return .delete(mailbox)
         }
     }
 
     // eitem-vendor-tag =  vendor-token "-" atom
-    static func parseEitemVendorTag(buffer: inout ByteBuffer, tracker: StackTracker) throws -> EItemVendorTag {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EItemVendorTag in
+    static func parseEitemVendorTag(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EItemVendorTag {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EItemVendorTag in
             let token = try self.parseVendorToken(buffer: &buffer, tracker: tracker)
-            try fixedString("-", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
             let atom = try self.parseAtom(buffer: &buffer, tracker: tracker)
             return EItemVendorTag(token: token, atom: atom)
         }
     }
 
     // enable          = "ENABLE" 1*(SP capability)
-    static func parseEnable(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("ENABLE", buffer: &buffer, tracker: tracker)
+    static func parseEnable(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("ENABLE", buffer: &buffer, tracker: tracker)
             let capabilities = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Capability in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseCapability(buffer: &buffer, tracker: tracker)
             }
             return .enable(capabilities)
         }
     }
 
-    static func parseEncodedAuthenticationType(buffer: inout ByteBuffer, tracker: StackTracker) throws -> EncodedAuthenticationType {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedAuthenticationType in
+    static func parseEncodedAuthenticationType(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EncodedAuthenticationType {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedAuthenticationType in
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: self.parseAChar).reduce([], +)
             return .init(authenticationType: String(decoding: array, as: Unicode.UTF8.self))
         }
     }
 
-    static func parseEncodedMailbox(buffer: inout ByteBuffer, tracker: StackTracker) throws -> EncodedMailbox {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedMailbox in
+    static func parseEncodedMailbox(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EncodedMailbox {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedMailbox in
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: self.parseBChar).reduce([], +)
             return .init(mailbox: String(decoding: array, as: Unicode.UTF8.self))
         }
     }
 
-    static func parseEncodedSearch(buffer: inout ByteBuffer, tracker: StackTracker) throws -> EncodedSearch {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedSearch in
+    static func parseEncodedSearch(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EncodedSearch {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedSearch in
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: self.parseBChar).reduce([], +)
             return .init(query: String(decoding: array, as: Unicode.UTF8.self))
         }
     }
 
-    static func parseEncodedSection(buffer: inout ByteBuffer, tracker: StackTracker) throws -> EncodedSection {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedSection in
+    static func parseEncodedSection(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EncodedSection {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedSection in
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: self.parseBChar).reduce([], +)
             return .init(section: String(decoding: array, as: Unicode.UTF8.self))
         }
     }
 
-    static func parseEncodedUser(buffer: inout ByteBuffer, tracker: StackTracker) throws -> EncodedUser {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedUser in
+    static func parseEncodedUser(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EncodedUser {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedUser in
             let array = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: self.parseAChar).reduce([], +)
             return .init(data: String(decoding: array, as: Unicode.UTF8.self))
         }
     }
 
-    static func parseEncodedURLAuth(buffer: inout ByteBuffer, tracker: StackTracker) throws -> EncodedAuthenticatedURL {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, _ -> EncodedAuthenticatedURL in
-            guard let bytes = buffer.readSlice(length: 32) else {
-                throw _IncompleteMessage()
-            }
+    static func parseEncodedURLAuth(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EncodedAuthenticatedURL {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, _ -> EncodedAuthenticatedURL in
+            let bytes = try ParserLibrary.parseBytes(buffer: &buffer, tracker: tracker, length: 32)
             guard bytes.readableBytesView.allSatisfy({ $0.isHexCharacter }) else {
                 throw ParserError(hint: "Found invalid character in \(String(buffer: bytes))")
             }
@@ -446,11 +438,11 @@ extension GrammarParser {
     }
 
     // enable-data     = "ENABLED" *(SP capability)
-    static func parseEnableData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [Capability] {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [Capability] in
-            try fixedString("ENABLED", buffer: &buffer, tracker: tracker)
+    static func parseEnableData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [Capability] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [Capability] in
+            try ParserLibrary.fixedString("ENABLED", buffer: &buffer, tracker: tracker)
             return try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Capability in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseCapability(buffer: &buffer, tracker: tracker)
             }
         }
@@ -458,16 +450,17 @@ extension GrammarParser {
 
     // esearch-response  = "ESEARCH" [search-correlator] [SP "UID"]
     //                     *(SP search-return-data)
-    static func parseExtendedSearchResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ExtendedSearchResponse {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("ESEARCH", buffer: &buffer, tracker: tracker)
-            let correlator = try optional(buffer: &buffer, tracker: tracker, parser: self.parseSearchCorrelator)
-            let uid = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try fixedString(" UID", buffer: &buffer, tracker: tracker)
+
+    static func parseExtendedSearchResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ExtendedSearchResponse {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("ESEARCH", buffer: &buffer, tracker: tracker)
+            let correlator = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseSearchCorrelator)
+            let uid = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try ParserLibrary.fixedString(" UID", buffer: &buffer, tracker: tracker)
                 return true
             } ?? false
             let searchReturnData = try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SearchReturnData in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseSearchReturnData(buffer: &buffer, tracker: tracker)
             }
             return ExtendedSearchResponse(correlator: correlator, uid: uid, returnData: searchReturnData)
@@ -475,45 +468,45 @@ extension GrammarParser {
     }
 
     // examine         = "EXAMINE" SP mailbox [select-params
-    static func parseExamine(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("EXAMINE ", buffer: &buffer, tracker: tracker)
+    static func parseExamine(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("EXAMINE ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            let params = try optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
+            let params = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
             return .examine(mailbox, params)
         }
     }
 
-    static func parseExpire(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Expire {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Expire in
-            try fixedString(";EXPIRE=", buffer: &buffer, tracker: tracker)
+    static func parseExpire(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Expire {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Expire in
+            try ParserLibrary.fixedString(";EXPIRE=", buffer: &buffer, tracker: tracker)
             let dateTime = try self.parseFullDateTime(buffer: &buffer, tracker: tracker)
             return .init(dateTime: dateTime)
         }
     }
 
-    static func parseAccess(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Access {
-        func parseAccess_submit(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Access {
-            try fixedString("submit+", buffer: &buffer, tracker: tracker)
+    static func parseAccess(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Access {
+        func parseAccess_submit(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Access {
+            try ParserLibrary.fixedString("submit+", buffer: &buffer, tracker: tracker)
             return .submit(try self.parseEncodedUser(buffer: &buffer, tracker: tracker))
         }
 
-        func parseAccess_user(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Access {
-            try fixedString("user+", buffer: &buffer, tracker: tracker)
+        func parseAccess_user(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Access {
+            try ParserLibrary.fixedString("user+", buffer: &buffer, tracker: tracker)
             return .user(try self.parseEncodedUser(buffer: &buffer, tracker: tracker))
         }
 
-        func parseAccess_authenticatedUser(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Access {
-            try fixedString("authuser", buffer: &buffer, tracker: tracker)
+        func parseAccess_authenticatedUser(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Access {
+            try ParserLibrary.fixedString("authuser", buffer: &buffer, tracker: tracker)
             return .authenticateUser
         }
 
-        func parseAccess_anonymous(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Access {
-            try fixedString("anonymous", buffer: &buffer, tracker: tracker)
+        func parseAccess_anonymous(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Access {
+            try ParserLibrary.fixedString("anonymous", buffer: &buffer, tracker: tracker)
             return .anonymous
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseAccess_submit,
             parseAccess_user,
             parseAccess_authenticatedUser,
@@ -522,7 +515,7 @@ extension GrammarParser {
     }
 
     // filter-name = 1*<any ATOM-CHAR except "/">
-    static func parseFilterName(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parseFilterName(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
         try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char -> Bool in
             char.isAtomChar && char != UInt8(ascii: "/")
         }
@@ -530,43 +523,43 @@ extension GrammarParser {
 
     // flag            = "\Answered" / "\Flagged" / "\Deleted" /
     //                   "\Seen" / "\Draft" / flag-keyword / flag-extension
-    static func parseFlag(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag {
-        func parseFlag_answered(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag {
-            try fixedString("\\Answered", buffer: &buffer, tracker: tracker)
+    static func parseFlag(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag {
+        func parseFlag_answered(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag {
+            try ParserLibrary.fixedString("\\Answered", buffer: &buffer, tracker: tracker)
             return .answered
         }
 
-        func parseFlag_flagged(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag {
-            try fixedString("\\Flagged", buffer: &buffer, tracker: tracker)
+        func parseFlag_flagged(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag {
+            try ParserLibrary.fixedString("\\Flagged", buffer: &buffer, tracker: tracker)
             return .flagged
         }
 
-        func parseFlag_deleted(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag {
-            try fixedString("\\Deleted", buffer: &buffer, tracker: tracker)
+        func parseFlag_deleted(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag {
+            try ParserLibrary.fixedString("\\Deleted", buffer: &buffer, tracker: tracker)
             return .deleted
         }
 
-        func parseFlag_seen(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag {
-            try fixedString("\\Seen", buffer: &buffer, tracker: tracker)
+        func parseFlag_seen(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag {
+            try ParserLibrary.fixedString("\\Seen", buffer: &buffer, tracker: tracker)
             return .seen
         }
 
-        func parseFlag_draft(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag {
-            try fixedString("\\Draft", buffer: &buffer, tracker: tracker)
+        func parseFlag_draft(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag {
+            try ParserLibrary.fixedString("\\Draft", buffer: &buffer, tracker: tracker)
             return .draft
         }
 
-        func parseFlag_keyword(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag {
+        func parseFlag_keyword(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag {
             let word = try self.parseFlagKeyword(buffer: &buffer, tracker: tracker)
             return .keyword(word)
         }
 
-        func parseFlag_extension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag {
+        func parseFlag_extension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag {
             let word = try self.parseFlagExtension(buffer: &buffer, tracker: tracker)
             return .extension(word)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFlag_seen,
             parseFlag_draft,
             parseFlag_answered,
@@ -578,130 +571,130 @@ extension GrammarParser {
     }
 
     // flag-extension  = "\" atom
-    static func parseFlagExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> String in
-            try fixedString("\\", buffer: &buffer, tracker: tracker)
+    static func parseFlagExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> String in
+            try ParserLibrary.fixedString("\\", buffer: &buffer, tracker: tracker)
             let string = try self.parseAtom(buffer: &buffer, tracker: tracker)
             return "\\\(string)"
         }
     }
 
     // flag-keyword    = "$MDNSent" / "$Forwarded" / atom
-    static func parseFlagKeyword(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Flag.Keyword {
+    static func parseFlagKeyword(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Flag.Keyword {
         let string = try self.parseAtom(buffer: &buffer, tracker: tracker)
         return Flag.Keyword(string)
     }
 
     // flag-list       = "(" [flag *(SP flag)] ")"
-    static func parseFlagList(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [Flag] {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
-            let flags = try optional(buffer: &buffer, tracker: tracker) { (buffer, _) -> [Flag] in
+    static func parseFlagList(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [Flag] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
+            let flags = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, _) -> [Flag] in
                 var output = [try self.parseFlag(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &output, tracker: tracker) { buffer, tracker in
-                    try fixedString(" ", buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
                     return try self.parseFlag(buffer: &buffer, tracker: tracker)
                 }
                 return output
             } ?? []
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return flags
         }
     }
 
     // flag-perm       = flag / "\*"
-    static func parseFlagPerm(buffer: inout ByteBuffer, tracker: StackTracker) throws -> PermanentFlag {
-        func parseFlagPerm_wildcard(buffer: inout ByteBuffer, tracker: StackTracker) throws -> PermanentFlag {
-            try fixedString("\\*", buffer: &buffer, tracker: tracker)
+    static func parseFlagPerm(buffer: inout ParseBuffer, tracker: StackTracker) throws -> PermanentFlag {
+        func parseFlagPerm_wildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> PermanentFlag {
+            try ParserLibrary.fixedString("\\*", buffer: &buffer, tracker: tracker)
             return .wildcard
         }
 
-        func parseFlagPerm_flag(buffer: inout ByteBuffer, tracker: StackTracker) throws -> PermanentFlag {
+        func parseFlagPerm_flag(buffer: inout ParseBuffer, tracker: StackTracker) throws -> PermanentFlag {
             .flag(try self.parseFlag(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFlagPerm_wildcard,
             parseFlagPerm_flag,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // header-fld-name = astring
-    static func parseHeaderFieldName(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parseHeaderFieldName(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
         var buffer = try self.parseAString(buffer: &buffer, tracker: tracker)
         return buffer.readString(length: buffer.readableBytes)!
     }
 
     // header-list     = "(" header-fld-name *(SP header-fld-name) ")"
-    static func parseHeaderList(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [String] {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [String] in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parseHeaderList(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [String] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [String] in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             var output = [try self.parseHeaderFieldName(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &output, tracker: tracker) { (buffer, tracker) -> String in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseHeaderFieldName(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return output
         }
     }
 
-    static func parseICommand(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ICommand {
-        func parseICommand_list(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ICommand {
+    static func parseICommand(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ICommand {
+        func parseICommand_list(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ICommand {
             .messageList(try self.parseIMessageList(buffer: &buffer, tracker: tracker))
         }
 
-        func parseICommand_part(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ICommand {
+        func parseICommand_part(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ICommand {
             let part = try self.parseIMessagePart(buffer: &buffer, tracker: tracker)
-            let auth = try optional(buffer: &buffer, tracker: tracker, parser: self.parseIURLAuth)
+            let auth = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseIURLAuth)
             return .messagePart(part: part, authenticatedURL: auth)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseICommand_part,
             parseICommand_list,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // id = "ID" SP id-params-list
-    static func parseID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("ID ", buffer: &buffer, tracker: tracker)
+    static func parseID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("ID ", buffer: &buffer, tracker: tracker)
             return try parseIDParamsList(buffer: &buffer, tracker: tracker)
         }
     }
 
-    static func parseINetworkPath(buffer: inout ByteBuffer, tracker: StackTracker) throws -> INetworkPath {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> INetworkPath in
-            try fixedString("//", buffer: &buffer, tracker: tracker)
+    static func parseINetworkPath(buffer: inout ParseBuffer, tracker: StackTracker) throws -> INetworkPath {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> INetworkPath in
+            try ParserLibrary.fixedString("//", buffer: &buffer, tracker: tracker)
             let server = try self.parseIMAPServer(buffer: &buffer, tracker: tracker)
             let query = try self.parseIPathQuery(buffer: &buffer, tracker: tracker)
             return .init(server: server, query: query)
         }
     }
 
-    static func parseIAbsolutePath(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IAbsolutePath {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> IAbsolutePath in
-            try fixedString("/", buffer: &buffer, tracker: tracker)
-            let command = try optional(buffer: &buffer, tracker: tracker, parser: self.parseICommand)
+    static func parseIAbsolutePath(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IAbsolutePath {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> IAbsolutePath in
+            try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
+            let command = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseICommand)
             return .init(command: command)
         }
     }
 
-    static func parseIAuthentication(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IAuthentication {
-        func parseIAuthentication_any(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IAuthentication {
-            try fixedString("*", buffer: &buffer, tracker: tracker)
+    static func parseIAuthentication(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IAuthentication {
+        func parseIAuthentication_any(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IAuthentication {
+            try ParserLibrary.fixedString("*", buffer: &buffer, tracker: tracker)
             return .any
         }
 
-        func parseIAuthentication_encoded(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IAuthentication {
+        func parseIAuthentication_encoded(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IAuthentication {
             let type = try self.parseEncodedAuthenticationType(buffer: &buffer, tracker: tracker)
             return .type(type)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString(";AUTH=", buffer: &buffer, tracker: tracker)
-            return try oneOf([
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString(";AUTH=", buffer: &buffer, tracker: tracker)
+            return try ParserLibrary.oneOf([
                 parseIAuthentication_any,
                 parseIAuthentication_encoded,
             ], buffer: &buffer, tracker: tracker)
@@ -709,133 +702,134 @@ extension GrammarParser {
     }
 
     // id-response = "ID" SP id-params-list
-    static func parseIDResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            try fixedString("ID ", buffer: &buffer, tracker: tracker)
+    static func parseIDResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            try ParserLibrary.fixedString("ID ", buffer: &buffer, tracker: tracker)
             return try parseIDParamsList(buffer: &buffer, tracker: tracker)
         }
     }
 
     // id-params-list = "(" *(string SP nstring) ")" / nil
-    static func parseIDParamsList(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
-        func parseIDParamsList_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
+    static func parseIDParamsList(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
+        func parseIDParamsList_nil(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
             try self.parseNil(buffer: &buffer, tracker: tracker)
             return [:]
         }
 
-        func parseIDParamsList_element(buffer: inout ByteBuffer, tracker: StackTracker) throws -> (String, ByteBuffer?) {
+        func parseIDParamsList_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> (String, ByteBuffer?) {
             let key = String(buffer: try self.parseString(buffer: &buffer, tracker: tracker))
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let value = try self.parseNString(buffer: &buffer, tracker: tracker)
             return (key, value)
         }
 
-        func parseIDParamsList_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+        func parseIDParamsList_some(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValues<String, ByteBuffer?> {
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             let (key, value) = try parseIDParamsList_element(buffer: &buffer, tracker: tracker)
             var dic: KeyValues<String, ByteBuffer?> = [key: value]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &dic, tracker: tracker) { (buffer, tracker) -> (String, ByteBuffer?) in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try parseIDParamsList_element(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return dic
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseIDParamsList_nil,
             parseIDParamsList_some,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // idle            = "IDLE" CRLF "DONE"
-    static func parseIdleStart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try fixedString("IDLE", buffer: &buffer, tracker: tracker)
+    static func parseIdleStart(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.fixedString("IDLE", buffer: &buffer, tracker: tracker)
         return .idleStart
     }
 
-    static func parseIdleDone(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-        try fixedString("DONE", buffer: &buffer, tracker: tracker)
-        try newline(buffer: &buffer, tracker: tracker)
+    static func parseIdleDone(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+        try ParserLibrary.fixedString("DONE", buffer: &buffer, tracker: tracker)
+        try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
     }
 
-    static func parseIPartial(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IPartial {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IPartial in
-            try fixedString("/;PARTIAL=", buffer: &buffer, tracker: tracker)
+    static func parseIPartial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IPartial {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IPartial in
+            try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
+            return try parseIPartialOnly(buffer: &buffer, tracker: tracker)
+        }
+    }
+
+    static func parseIPartialOnly(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IPartial {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IPartial in
+            try ParserLibrary.fixedString(";PARTIAL=", buffer: &buffer, tracker: tracker)
             return .init(range: try self.parsePartialRange(buffer: &buffer, tracker: tracker))
         }
     }
 
-    static func parseIPartialOnly(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IPartial {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IPartial in
-            try fixedString(";PARTIAL=", buffer: &buffer, tracker: tracker)
-            return .init(range: try self.parsePartialRange(buffer: &buffer, tracker: tracker))
-        }
-    }
-
-    static func parseIPathQuery(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IPathQuery {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IPathQuery in
-            try fixedString("/", buffer: &buffer, tracker: tracker)
-            let command = try optional(buffer: &buffer, tracker: tracker, parser: self.parseICommand)
+    static func parseIPathQuery(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IPathQuery {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IPathQuery in
+            try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
+            let command = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseICommand)
             return .init(command: command)
         }
     }
 
-    static func parseISection(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ISection {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ISection in
-            try fixedString("/;SECTION=", buffer: &buffer, tracker: tracker)
+    static func parseISection(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ISection {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ISection in
+            try ParserLibrary.fixedString("/;SECTION=", buffer: &buffer, tracker: tracker)
             return .init(encodedSection: try self.parseEncodedSection(buffer: &buffer, tracker: tracker))
         }
     }
 
-    static func parseISectionOnly(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ISection {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ISection in
-            try fixedString(";SECTION=", buffer: &buffer, tracker: tracker)
+    static func parseISectionOnly(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ISection {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ISection in
+            try ParserLibrary.fixedString(";SECTION=", buffer: &buffer, tracker: tracker)
             return .init(encodedSection: try self.parseEncodedSection(buffer: &buffer, tracker: tracker))
         }
     }
 
-    static func parseIMAPServer(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMAPServer {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMAPServer in
-            let info = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> UserInfo in
+    static func parseIMAPServer(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMAPServer {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMAPServer in
+            let info = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> UserInfo in
                 let info = try self.parseUserInfo(buffer: &buffer, tracker: tracker)
-                try fixedString("@", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("@", buffer: &buffer, tracker: tracker)
                 return info
             })
             let host = try self.parseHost(buffer: &buffer, tracker: tracker)
-            let port = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> Int in
-                try fixedString(":", buffer: &buffer, tracker: tracker)
+            let port = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> Int in
+                try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
                 return try self.parseNumber(buffer: &buffer, tracker: tracker)
             })
             return .init(userInfo: info, host: host, port: port)
         }
     }
 
-    static func parseHost(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parseHost(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
         // TODO: Enforce IPv6 rules RFC 3986 URI-GEN
-        func parseHost_ipv6(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+        func parseHost_ipv6(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
             try self.parseAtom(buffer: &buffer, tracker: tracker)
         }
 
         // TODO: Enforce IPv6 rules RFC 3986 URI-GEN
-        func parseHost_future(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+        func parseHost_future(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
             try self.parseAtom(buffer: &buffer, tracker: tracker)
         }
 
-        func parseHost_literal(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
-            try fixedString("[", buffer: &buffer, tracker: tracker)
-            let address = try oneOf([
+        func parseHost_literal(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
+            try ParserLibrary.fixedString("[", buffer: &buffer, tracker: tracker)
+            let address = try ParserLibrary.oneOf([
                 parseHost_ipv6,
                 parseHost_future,
             ], buffer: &buffer, tracker: tracker)
-            try fixedString("]", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("]", buffer: &buffer, tracker: tracker)
             return address
         }
 
-        func parseHost_regularName(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+        func parseHost_regularName(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
             var newBuffer = ByteBuffer()
             while true {
                 do {
+                    // FIXME: This is very inefficient
                     let chars = try self.parseUChar(buffer: &buffer, tracker: tracker)
                     newBuffer.writeBytes(chars)
                 } catch is ParserError {
@@ -846,73 +840,73 @@ extension GrammarParser {
         }
 
         // TODO: This isn't great, but it is functional. Perhaps make it actually enforce IPv4 rules
-        func parseHost_ipv4(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+        func parseHost_ipv4(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
             let num1 = try self.parseNumber(buffer: &buffer, tracker: tracker)
-            try fixedString(".", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(".", buffer: &buffer, tracker: tracker)
             let num2 = try self.parseNumber(buffer: &buffer, tracker: tracker)
-            try fixedString(".", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(".", buffer: &buffer, tracker: tracker)
             let num3 = try self.parseNumber(buffer: &buffer, tracker: tracker)
-            try fixedString(".", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(".", buffer: &buffer, tracker: tracker)
             let num4 = try self.parseNumber(buffer: &buffer, tracker: tracker)
             return "\(num1).\(num2).\(num3).\(num4)"
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseHost_literal,
             parseHost_regularName,
             parseHost_ipv4,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseIMailboxReference(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMailboxReference {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMailboxReference in
+    static func parseIMailboxReference(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMailboxReference {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMailboxReference in
             let mailbox = try self.parseEncodedMailbox(buffer: &buffer, tracker: tracker)
-            let uidValidity = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> UIDValidity in
-                try fixedString(";UIDVALIDITY=", buffer: &buffer, tracker: tracker)
+            let uidValidity = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> UIDValidity in
+                try ParserLibrary.fixedString(";UIDVALIDITY=", buffer: &buffer, tracker: tracker)
                 return try self.parseUIDValidity(buffer: &buffer, tracker: tracker)
             })
             return .init(encodeMailbox: mailbox, uidValidity: uidValidity)
         }
     }
 
-    static func parseIMessageList(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMessageList {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMessageList in
+    static func parseIMessageList(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMessageList {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMessageList in
             let mailboxRef = try self.parseIMailboxReference(buffer: &buffer, tracker: tracker)
-            let query = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> EncodedSearch in
-                try fixedString("?", buffer: &buffer, tracker: tracker)
+            let query = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> EncodedSearch in
+                try ParserLibrary.fixedString("?", buffer: &buffer, tracker: tracker)
                 return try self.parseEncodedSearch(buffer: &buffer, tracker: tracker)
             })
             return .init(mailboxReference: mailboxRef, encodedSearch: query)
         }
     }
 
-    static func parseIMAPURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMAPURL {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMAPURL in
-            try fixedString("imap://", buffer: &buffer, tracker: tracker)
+    static func parseIMAPURL(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMAPURL {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMAPURL in
+            try ParserLibrary.fixedString("imap://", buffer: &buffer, tracker: tracker)
             let server = try self.parseIMAPServer(buffer: &buffer, tracker: tracker)
             let query = try self.parseIPathQuery(buffer: &buffer, tracker: tracker)
             return .init(server: server, query: query)
         }
     }
 
-    static func parseRelativeIMAPURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
-        func parseRelativeIMAPURL_absolute(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
+    static func parseRelativeIMAPURL(buffer: inout ParseBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
+        func parseRelativeIMAPURL_absolute(buffer: inout ParseBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
             .absolutePath(try self.parseIAbsolutePath(buffer: &buffer, tracker: tracker))
         }
 
-        func parseRelativeIMAPURL_network(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
+        func parseRelativeIMAPURL_network(buffer: inout ParseBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
             .networkPath(try self.parseINetworkPath(buffer: &buffer, tracker: tracker))
         }
 
-        func parseRelativeIMAPURL_relative(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
+        func parseRelativeIMAPURL_relative(buffer: inout ParseBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
             .relativePath(try self.parseIRelativePath(buffer: &buffer, tracker: tracker))
         }
 
-        func parseRelativeIMAPURL_empty(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
+        func parseRelativeIMAPURL_empty(buffer: inout ParseBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
             .empty
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseRelativeIMAPURL_network,
             parseRelativeIMAPURL_absolute,
             parseRelativeIMAPURL_relative,
@@ -920,128 +914,124 @@ extension GrammarParser {
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseIRelativePath(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IRelativePath {
-        func parseIRelativePath_list(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IRelativePath {
+    static func parseIRelativePath(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IRelativePath {
+        func parseIRelativePath_list(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IRelativePath {
             .list(try self.parseIMessageList(buffer: &buffer, tracker: tracker))
         }
 
-        func parseIRelativePath_messageOrPartial(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IRelativePath {
+        func parseIRelativePath_messageOrPartial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IRelativePath {
             .messageOrPartial(try self.parseIMessageOrPartial(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseIRelativePath_list,
             parseIRelativePath_messageOrPartial,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseIMessagePart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMessagePart {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMessagePart in
+    static func parseIMessagePart(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMessagePart {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMessagePart in
             var ref = try self.parseIMailboxReference(buffer: &buffer, tracker: tracker)
 
             var uid = try IUID(uid: 1)
             if ref.uidValidity == nil, ref.encodedMailbox.mailbox.last == Character(.init(UInt8(ascii: "/"))) {
-                try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
                     ref.encodedMailbox.mailbox = String(ref.encodedMailbox.mailbox.dropLast())
-                    var newBuffer = ByteBuffer(ByteBufferView([UInt8(ascii: "/")]))
-                    newBuffer.writeBuffer(&buffer)
-                    uid = try self.parseIUID(buffer: &newBuffer, tracker: tracker)
-                    buffer = newBuffer
+
+                    uid = try self.parseIUIDOnly(buffer: &buffer, tracker: tracker)
                 }
             } else {
                 uid = try self.parseIUID(buffer: &buffer, tracker: tracker)
             }
 
-            var section = try optional(buffer: &buffer, tracker: tracker, parser: self.parseISection)
+            var section = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseISection)
             var partial: IPartial?
             if section?.encodedSection.section.last == Character(.init(UInt8(ascii: "/"))) {
-                try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
                     section!.encodedSection.section = String(section!.encodedSection.section.dropLast())
-                    var newBuffer = ByteBuffer(ByteBufferView([UInt8(ascii: "/")]))
-                    newBuffer.writeBuffer(&buffer)
-                    partial = try optional(buffer: &newBuffer, tracker: tracker, parser: self.parseIPartial)
-                    buffer = newBuffer
+
+                    partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartialOnly)
                 }
             } else {
-                partial = try optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartial)
+                partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartial)
             }
             return .init(mailboxReference: ref, iUID: uid, iSection: section, iPartial: partial)
         }
     }
 
-    static func parseIMessageOrPartial(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
-        func parseIMessageOrPartial_partialOnly(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
+    static func parseIMessageOrPartial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
+        func parseIMessageOrPartial_partialOnly(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
             let partial = try self.parseIPartialOnly(buffer: &buffer, tracker: tracker)
             return .partialOnly(partial)
         }
 
-        func parseIMessageOrPartial_sectionPartial(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
+        func parseIMessageOrPartial_sectionPartial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
             var section = try self.parseISectionOnly(buffer: &buffer, tracker: tracker)
             if section.encodedSection.section.last == Character(.init(UInt8(ascii: "/"))) {
                 section.encodedSection.section = String(section.encodedSection.section.dropLast())
                 do {
-                    let partial = try optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartialOnly)
+                    let partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartialOnly)
                     return .sectionPartial(section: section, partial: partial)
                 } catch is ParserError {
                     section.encodedSection.section.append("/")
                     return .sectionPartial(section: section, partial: nil)
                 }
             }
-            let partial = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> IPartial in
-                try fixedString("/", buffer: &buffer, tracker: tracker)
+            let partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> IPartial in
+                try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
                 return try self.parseIPartialOnly(buffer: &buffer, tracker: tracker)
             })
             return .sectionPartial(section: section, partial: partial)
         }
 
-        func parseIMessageOrPartial_uidSectionPartial(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
+        func parseIMessageOrPartial_uidSectionPartial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
             let uid = try self.parseIUIDOnly(buffer: &buffer, tracker: tracker)
-            var section = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> ISection in
-                try fixedString("/", buffer: &buffer, tracker: tracker)
+            var section = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> ISection in
+                try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
                 return try self.parseISectionOnly(buffer: &buffer, tracker: tracker)
             })
             if section?.encodedSection.section.last == Character(.init(UInt8(ascii: "/"))) {
                 section!.encodedSection.section = String(section!.encodedSection.section.dropLast())
                 do {
-                    let partial = try optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartialOnly)
+                    let partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartialOnly)
                     return .uidSectionPartial(uid: uid, section: section, partial: partial)
                 } catch is ParserError {
                     section?.encodedSection.section.append("/")
                     return .uidSectionPartial(uid: uid, section: section, partial: nil)
                 }
             }
-            let partial = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> IPartial in
-                try fixedString("/", buffer: &buffer, tracker: tracker)
+            let partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> IPartial in
+                try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
                 return try self.parseIPartialOnly(buffer: &buffer, tracker: tracker)
             })
             return .uidSectionPartial(uid: uid, section: section, partial: partial)
         }
 
-        func parseIMessageOrPartial_refUidSectionPartial(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
+        func parseIMessageOrPartial_refUidSectionPartial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMessageOrPartial {
             let ref = try self.parseIMailboxReference(buffer: &buffer, tracker: tracker)
             let uid = try self.parseIUIDOnly(buffer: &buffer, tracker: tracker)
-            var section = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> ISection in
-                try fixedString("/", buffer: &buffer, tracker: tracker)
+            var section = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> ISection in
+                try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
                 return try self.parseISectionOnly(buffer: &buffer, tracker: tracker)
             })
             if section?.encodedSection.section.last == Character(.init(UInt8(ascii: "/"))) {
                 section!.encodedSection.section = String(section!.encodedSection.section.dropLast())
                 do {
-                    let partial = try optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartialOnly)
+                    let partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseIPartialOnly)
                     return .refUidSectionPartial(ref: ref, uid: uid, section: section, partial: partial)
                 } catch is ParserError {
                     section?.encodedSection.section.append("/")
                     return .refUidSectionPartial(ref: ref, uid: uid, section: section, partial: nil)
                 }
             }
-            let partial = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> IPartial in
-                try fixedString("/", buffer: &buffer, tracker: tracker)
+            let partial = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> IPartial in
+                try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
                 return try self.parseIPartialOnly(buffer: &buffer, tracker: tracker)
             })
             return .refUidSectionPartial(ref: ref, uid: uid, section: section, partial: partial)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseIMessageOrPartial_refUidSectionPartial,
             parseIMessageOrPartial_uidSectionPartial,
             parseIMessageOrPartial_sectionPartial,
@@ -1049,21 +1039,17 @@ extension GrammarParser {
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseUChar(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UInt8] {
-        func parseUChar_unreserved(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UInt8] {
-            guard let num = buffer.readInteger(as: UInt8.self) else {
-                throw _IncompleteMessage()
-            }
+    static func parseUChar(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UInt8] {
+        func parseUChar_unreserved(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UInt8] {
+            let num = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
             guard num.isUnreserved else {
                 throw ParserError(hint: "Expected unreserved char, got \(num)")
             }
             return [num]
         }
 
-        func parseUChar_subDelimsSH(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UInt8] {
-            guard let num = buffer.readInteger(as: UInt8.self) else {
-                throw _IncompleteMessage()
-            }
+        func parseUChar_subDelimsSH(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UInt8] {
+            let num = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
             guard num.isSubDelimsSh else {
                 throw ParserError(hint: "Expected sub-delims-sh char, got \(num)")
             }
@@ -1072,14 +1058,11 @@ extension GrammarParser {
 
         // "%" HEXDIGIT HEXDIGIT
         // e.g. %1F
-        func parseUChar_pctEncoded(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UInt8] {
-            try fixedString("%", buffer: &buffer, tracker: tracker)
-            guard
-                var h1 = buffer.readInteger(as: UInt8.self),
-                var h2 = buffer.readInteger(as: UInt8.self)
-            else {
-                throw _IncompleteMessage()
-            }
+        func parseUChar_pctEncoded(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UInt8] {
+            // FIXME: Better parser for this
+            try ParserLibrary.fixedString("%", buffer: &buffer, tracker: tracker)
+            var h1 = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
+            var h2 = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
 
             guard h1.isHexCharacter, h2.isHexCharacter else {
                 throw ParserError(hint: "Expected 2 hex digits, got \(h1) and \(h2)")
@@ -1095,18 +1078,16 @@ extension GrammarParser {
             return [UInt8(ascii: "%"), h1, h2]
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseUChar_unreserved,
             parseUChar_subDelimsSH,
             parseUChar_pctEncoded,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseAChar(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UInt8] {
-        func parseAChar_other(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UInt8] {
-            guard let char = buffer.readInteger(as: UInt8.self) else {
-                throw _IncompleteMessage()
-            }
+    static func parseAChar(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UInt8] {
+        func parseAChar_other(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UInt8] {
+            let char = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
             switch char {
             case UInt8(ascii: "&"), UInt8(ascii: "="):
                 return [char]
@@ -1115,17 +1096,15 @@ extension GrammarParser {
             }
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseUChar,
             parseAChar_other,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseBChar(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UInt8] {
-        func parseBChar_other(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [UInt8] {
-            guard let char = buffer.readInteger(as: UInt8.self) else {
-                throw _IncompleteMessage()
-            }
+    static func parseBChar(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UInt8] {
+        func parseBChar_other(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UInt8] {
+            let char = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
             switch char {
             case UInt8(ascii: ":"), UInt8(ascii: "@"), UInt8(ascii: "/"):
                 return [char]
@@ -1134,75 +1113,75 @@ extension GrammarParser {
             }
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseAChar,
             parseBChar_other,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseIUID(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IUID {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("/;UID=", buffer: &buffer, tracker: tracker)
+    static func parseIUID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IUID {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("/", buffer: &buffer, tracker: tracker)
+            return try parseIUIDOnly(buffer: &buffer, tracker: tracker)
+        }
+    }
+
+    static func parseIUIDOnly(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IUID {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString(";UID=", buffer: &buffer, tracker: tracker)
             return try IUID(uid: try self.parseNZNumber(buffer: &buffer, tracker: tracker))
         }
     }
 
-    static func parseIUIDOnly(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IUID {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString(";UID=", buffer: &buffer, tracker: tracker)
-            return try IUID(uid: try self.parseNZNumber(buffer: &buffer, tracker: tracker))
-        }
-    }
-
-    static func parseIURLAuth(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IAuthenticatedURL {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IAuthenticatedURL in
+    static func parseIURLAuth(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IAuthenticatedURL {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IAuthenticatedURL in
             let rump = try self.parseIRumpAuthenticatedURL(buffer: &buffer, tracker: tracker)
             let verifier = try self.parseAuthenticatedURLVerifier(buffer: &buffer, tracker: tracker)
             return .init(authenticatedURL: rump, verifier: verifier)
         }
     }
 
-    static func parseURLRumpMechanism(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RumpURLAndMechanism {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> RumpURLAndMechanism in
+    static func parseURLRumpMechanism(buffer: inout ParseBuffer, tracker: StackTracker) throws -> RumpURLAndMechanism {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> RumpURLAndMechanism in
             let rump = try self.parseAString(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let mechanism = try self.parseUAuthMechanism(buffer: &buffer, tracker: tracker)
             return .init(urlRump: rump, mechanism: mechanism)
         }
     }
 
-    static func parseURLFetchData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> URLFetchData {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> URLFetchData in
+    static func parseURLFetchData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> URLFetchData {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> URLFetchData in
             let url = try self.parseAString(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let data = try self.parseNString(buffer: &buffer, tracker: tracker)
             return .init(url: url, data: data)
         }
     }
 
-    static func parseIRumpAuthenticatedURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IRumpAuthenticatedURL {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IRumpAuthenticatedURL in
-            let expiry = try optional(buffer: &buffer, tracker: tracker, parser: self.parseExpire)
-            try fixedString(";URLAUTH=", buffer: &buffer, tracker: tracker)
+    static func parseIRumpAuthenticatedURL(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IRumpAuthenticatedURL {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IRumpAuthenticatedURL in
+            let expiry = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseExpire)
+            try ParserLibrary.fixedString(";URLAUTH=", buffer: &buffer, tracker: tracker)
             let access = try self.parseAccess(buffer: &buffer, tracker: tracker)
             return .init(expire: expiry, access: access)
         }
     }
 
-    static func parseAuthenticatedURLVerifier(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AuthenticatedURLVerifier {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AuthenticatedURLVerifier in
-            try fixedString(":", buffer: &buffer, tracker: tracker)
+    static func parseAuthenticatedURLVerifier(buffer: inout ParseBuffer, tracker: StackTracker) throws -> AuthenticatedURLVerifier {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AuthenticatedURLVerifier in
+            try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
             let authMechanism = try self.parseUAuthMechanism(buffer: &buffer, tracker: tracker)
-            try fixedString(":", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
             let urlAuth = try self.parseEncodedURLAuth(buffer: &buffer, tracker: tracker)
             return .init(urlAuthMechanism: authMechanism, encodedAuthenticationURL: urlAuth)
         }
     }
 
-    static func parseUserInfo(buffer: inout ByteBuffer, tracker: StackTracker) throws -> UserInfo {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> UserInfo in
-            let encodedUser = try optional(buffer: &buffer, tracker: tracker, parser: self.parseEncodedUser)
-            let authenticationMechanism = try optional(buffer: &buffer, tracker: tracker, parser: self.parseIAuthentication)
+    static func parseUserInfo(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UserInfo {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> UserInfo in
+            let encodedUser = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseEncodedUser)
+            let authenticationMechanism = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseIAuthentication)
             guard (encodedUser != nil || authenticationMechanism != nil) else {
                 throw ParserError(hint: "Need one of encoded user or iauth")
             }
@@ -1210,111 +1189,105 @@ extension GrammarParser {
         }
     }
 
-    static func parseFullDateTime(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FullDateTime {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+    static func parseFullDateTime(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FullDateTime {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             let date = try self.parseFullDate(buffer: &buffer, tracker: tracker)
-            try fixedString("T", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("T", buffer: &buffer, tracker: tracker)
             let time = try self.parseFullTime(buffer: &buffer, tracker: tracker)
             return .init(date: date, time: time)
         }
     }
 
-    static func parseFullDate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FullDate {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+    static func parseFullDate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FullDate {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             let year = try parse4Digit(buffer: &buffer, tracker: tracker)
-            try fixedString("-", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
             let month = try parse2Digit(buffer: &buffer, tracker: tracker)
-            try fixedString("-", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
             let day = try parse2Digit(buffer: &buffer, tracker: tracker)
             return .init(year: year, month: month, day: day)
         }
     }
 
-    static func parseFullTime(buffer: inout ByteBuffer, tracker: StackTracker) throws -> FullTime {
+    static func parseFullTime(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FullTime {
         let hour = try parse2Digit(buffer: &buffer, tracker: tracker)
-        try fixedString(":", buffer: &buffer, tracker: tracker)
+        try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
         let minute = try parse2Digit(buffer: &buffer, tracker: tracker)
-        try fixedString(":", buffer: &buffer, tracker: tracker)
+        try ParserLibrary.fixedString(":", buffer: &buffer, tracker: tracker)
         let second = try parse2Digit(buffer: &buffer, tracker: tracker)
-        let fraction = try optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> Int in
-            try fixedString(".", buffer: &buffer, tracker: tracker)
+        let fraction = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> Int in
+            try ParserLibrary.fixedString(".", buffer: &buffer, tracker: tracker)
             return try self.parseNumber(buffer: &buffer, tracker: tracker)
         })
         return .init(hour: hour, minute: minute, second: second, fraction: fraction)
     }
 
-    static func parseLiteralSize(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Int in
-            try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try fixedString("~", buffer: &buffer, tracker: tracker)
+    static func parseLiteralSize(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Int in
+            try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try ParserLibrary.fixedString("~", buffer: &buffer, tracker: tracker)
             }
-            try fixedString("{", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("{", buffer: &buffer, tracker: tracker)
             let length = try Self.parseNumber(buffer: &buffer, tracker: tracker)
-            try fixedString("}", buffer: &buffer, tracker: tracker)
-            try newline(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("}", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
             return length
         }
     }
 
     // literal         = "{" number ["+"] "}" CRLF *CHAR8
-    static func parseLiteral(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
-            try fixedString("{", buffer: &buffer, tracker: tracker)
+    static func parseLiteral(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
+            try ParserLibrary.fixedString("{", buffer: &buffer, tracker: tracker)
             let length = try Self.parseNumber(buffer: &buffer, tracker: tracker)
-            try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try fixedString("+", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try ParserLibrary.fixedString("+", buffer: &buffer, tracker: tracker)
             }
-            try fixedString("}", buffer: &buffer, tracker: tracker)
-            try newline(buffer: &buffer, tracker: tracker)
-            if let bytes = buffer.readSlice(length: length) {
-                if bytes.readableBytesView.contains(0) {
-                    throw ParserError(hint: "Found NUL byte in literal")
-                }
-                return bytes
-            } else {
-                throw _IncompleteMessage()
+            try ParserLibrary.fixedString("}", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
+            let bytes = try ParserLibrary.parseBytes(buffer: &buffer, tracker: tracker, length: length)
+            if bytes.readableBytesView.contains(0) {
+                throw ParserError(hint: "Found NUL byte in literal")
             }
+            return bytes
         }
     }
 
     // literal8         = "~{" number ["+"] "}" CRLF *CHAR8
-    static func parseLiteral8(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
-            try fixedString("~{", buffer: &buffer, tracker: tracker)
+    static func parseLiteral8(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
+            try ParserLibrary.fixedString("~{", buffer: &buffer, tracker: tracker)
             let length = try Self.parseNumber(buffer: &buffer, tracker: tracker)
-            try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try fixedString("+", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try ParserLibrary.fixedString("+", buffer: &buffer, tracker: tracker)
             }
-            try fixedString("}", buffer: &buffer, tracker: tracker)
-            try newline(buffer: &buffer, tracker: tracker)
-            if let bytes = buffer.readSlice(length: length) {
-                if bytes.readableBytesView.contains(0) {
-                    throw ParserError(hint: "Found NUL byte in literal")
-                }
-                return bytes
-            } else {
-                throw _IncompleteMessage()
+            try ParserLibrary.fixedString("}", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
+            let bytes = try ParserLibrary.parseBytes(buffer: &buffer, tracker: tracker, length: length)
+            if bytes.readableBytesView.contains(0) {
+                throw ParserError(hint: "Found NUL byte in literal")
             }
+            return bytes
         }
     }
 
     // login           = "LOGIN" SP userid SP password
-    static func parseLogin(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("LOGIN ", buffer: &buffer, tracker: tracker)
+    static func parseLogin(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("LOGIN ", buffer: &buffer, tracker: tracker)
             let userid = try Self.parseUserId(buffer: &buffer, tracker: tracker)
-            try fixedString(" ", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
             let password = try Self.parsePassword(buffer: &buffer, tracker: tracker)
             return .login(username: userid, password: password)
         }
     }
 
     // lsub = "LSUB" SP mailbox SP list-mailbox
-    static func parseLSUB(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Command in
-            try fixedString("LSUB ", buffer: &buffer, tracker: tracker)
+    static func parseLSUB(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Command in
+            try ParserLibrary.fixedString("LSUB ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let listMailbox = try self.parseListMailbox(buffer: &buffer, tracker: tracker)
             return .lsub(reference: mailbox, pattern: listMailbox)
         }
@@ -1323,41 +1296,41 @@ extension GrammarParser {
     // media-basic     = ((DQUOTE ("APPLICATION" / "AUDIO" / "IMAGE" /
     //                   "MESSAGE" / "VIDEO") DQUOTE) / string) SP
     //                   media-subtype
-    static func parseMediaBasic(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.Basic {
-        func parseMediaBasic_Kind_defined(_ option: String, result: Media.BasicKind, buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.BasicKind {
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
-            try fixedString(option, buffer: &buffer, tracker: tracker)
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+    static func parseMediaBasic(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.Basic {
+        func parseMediaBasic_Kind_defined(_ option: String, result: Media.BasicKind, buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.BasicKind {
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(option, buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             return result
         }
 
-        func parseMediaBasic_Kind_application(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.BasicKind {
+        func parseMediaBasic_Kind_application(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.BasicKind {
             try parseMediaBasic_Kind_defined("APPLICATION", result: .application, buffer: &buffer, tracker: tracker)
         }
 
-        func parseMediaBasic_Kind_audio(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.BasicKind {
+        func parseMediaBasic_Kind_audio(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.BasicKind {
             try parseMediaBasic_Kind_defined("AUDIO", result: .audio, buffer: &buffer, tracker: tracker)
         }
 
-        func parseMediaBasic_Kind_image(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.BasicKind {
+        func parseMediaBasic_Kind_image(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.BasicKind {
             try parseMediaBasic_Kind_defined("IMAGE", result: .image, buffer: &buffer, tracker: tracker)
         }
 
-        func parseMediaBasic_Kind_message(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.BasicKind {
+        func parseMediaBasic_Kind_message(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.BasicKind {
             try parseMediaBasic_Kind_defined("MESSAGE", result: .message, buffer: &buffer, tracker: tracker)
         }
 
-        func parseMediaBasic_Kind_video(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.BasicKind {
+        func parseMediaBasic_Kind_video(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.BasicKind {
             try parseMediaBasic_Kind_defined("VIDEO", result: .video, buffer: &buffer, tracker: tracker)
         }
 
-        func parseMediaBasic_Kind_other(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.BasicKind {
+        func parseMediaBasic_Kind_other(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.BasicKind {
             let buffer = try self.parseString(buffer: &buffer, tracker: tracker)
             return .init(String(buffer: buffer))
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Media.Basic in
-            let basicType = try oneOf([
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Media.Basic in
+            let basicType = try ParserLibrary.oneOf([
                 parseMediaBasic_Kind_application,
                 parseMediaBasic_Kind_audio,
                 parseMediaBasic_Kind_image,
@@ -1365,7 +1338,7 @@ extension GrammarParser {
                 parseMediaBasic_Kind_video,
                 parseMediaBasic_Kind_other,
             ], buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let subtype = try self.parseMediaSubtype(buffer: &buffer, tracker: tracker)
             return Media.Basic(kind: basicType, subtype: subtype)
         }
@@ -1373,213 +1346,211 @@ extension GrammarParser {
 
     // media-message   = DQUOTE "MESSAGE" DQUOTE SP
     //                   DQUOTE ("RFC822" / "GLOBAL") DQUOTE
-    static func parseMediaMessage(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.Message {
-        func parseMediaMessage_rfc(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Media.Message {
-            try fixedString("RFC822", buffer: &buffer, tracker: tracker)
+    static func parseMediaMessage(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.Message {
+        func parseMediaMessage_rfc(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Media.Message {
+            try ParserLibrary.fixedString("RFC822", buffer: &buffer, tracker: tracker)
             return .rfc822
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Media.Message in
-            try fixedString("\"MESSAGE\" \"", buffer: &buffer, tracker: tracker)
-            let message = try oneOf([
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Media.Message in
+            try ParserLibrary.fixedString("\"MESSAGE\" \"", buffer: &buffer, tracker: tracker)
+            let message = try ParserLibrary.oneOf([
                 parseMediaMessage_rfc,
             ], buffer: &buffer, tracker: tracker)
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             return message
         }
     }
 
     // media-subtype   = string
-    static func parseMediaSubtype(buffer: inout ByteBuffer, tracker: StackTracker) throws -> BodyStructure.MediaSubtype {
+    static func parseMediaSubtype(buffer: inout ParseBuffer, tracker: StackTracker) throws -> BodyStructure.MediaSubtype {
         let buffer = try self.parseString(buffer: &buffer, tracker: tracker)
         let string = String(buffer: buffer)
         return .init(string)
     }
 
     // media-text      = DQUOTE "TEXT" DQUOTE SP media-subtype
-    static func parseMediaText(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> String in
-            try fixedString("\"TEXT\" ", buffer: &buffer, tracker: tracker)
+    static func parseMediaText(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> String in
+            try ParserLibrary.fixedString("\"TEXT\" ", buffer: &buffer, tracker: tracker)
             let subtype = try self.parseString(buffer: &buffer, tracker: tracker)
             return String(buffer: subtype)
         }
     }
 
-    static func parseMetadataOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataOption {
-        func parseMetadataOption_maxSize(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataOption {
-            try fixedString("MAXSIZE ", buffer: &buffer, tracker: tracker)
+    static func parseMetadataOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataOption {
+        func parseMetadataOption_maxSize(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataOption {
+            try ParserLibrary.fixedString("MAXSIZE ", buffer: &buffer, tracker: tracker)
             return .maxSize(try self.parseNumber(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMetadataOption_scope(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataOption {
+        func parseMetadataOption_scope(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataOption {
             .scope(try self.parseScopeOption(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMetadataOption_param(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataOption {
+        func parseMetadataOption_param(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataOption {
             .other(try self.parseParameter(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseMetadataOption_maxSize,
             parseMetadataOption_scope,
             parseMetadataOption_param,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseMetadataOptions(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [MetadataOption] {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parseMetadataOptions(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [MetadataOption] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             var array = [try self.parseMetadataOption(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker, parser: { buffer, tracker in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseMetadataOption(buffer: &buffer, tracker: tracker)
             })
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return array
         }
     }
 
-    static func parseMetadataResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataResponse {
-        func parseMetadataResponse_values(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataResponse {
-            try fixedString("METADATA ", buffer: &buffer, tracker: tracker)
+    static func parseMetadataResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataResponse {
+        func parseMetadataResponse_values(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataResponse {
+            try ParserLibrary.fixedString("METADATA ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let values = try self.parseEntryValues(buffer: &buffer, tracker: tracker)
             return .values(values: values, mailbox: mailbox)
         }
 
-        func parseMetadataResponse_list(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataResponse {
-            try fixedString("METADATA ", buffer: &buffer, tracker: tracker)
+        func parseMetadataResponse_list(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataResponse {
+            try ParserLibrary.fixedString("METADATA ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let list = try self.parseEntryList(buffer: &buffer, tracker: tracker)
             return .list(list: list, mailbox: mailbox)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseMetadataResponse_values,
             parseMetadataResponse_list,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseMetadataValue(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataValue {
-        func parseMetadataValue_nstring(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataValue {
+    static func parseMetadataValue(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataValue {
+        func parseMetadataValue_nstring(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataValue {
             .init(try self.parseNString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMetadataValue_literal8(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MetadataValue {
+        func parseMetadataValue_literal8(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MetadataValue {
             .init(try self.parseLiteral8(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseMetadataValue_nstring,
             parseMetadataValue_literal8,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // move            = "MOVE" SP sequence-set SP mailbox
-    static func parseMove(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("MOVE ", buffer: &buffer, tracker: tracker)
+    static func parseMove(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("MOVE ", buffer: &buffer, tracker: tracker)
             let set = try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
             return .move(set, mailbox)
         }
     }
 
-    static func parseMechanismBase64(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MechanismBase64 {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> MechanismBase64 in
+    static func parseMechanismBase64(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MechanismBase64 {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> MechanismBase64 in
             let mechanism = try self.parseUAuthMechanism(buffer: &buffer, tracker: tracker)
-            let base64 = try optional(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
-                try fixedString("=", buffer: &buffer, tracker: tracker)
+            let base64 = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
+                try ParserLibrary.fixedString("=", buffer: &buffer, tracker: tracker)
                 return try self.parseBase64(buffer: &buffer, tracker: tracker)
             }
             return .init(mechanism: mechanism, base64: base64)
         }
     }
 
-    static func parseGmailLabel(buffer: inout ByteBuffer, tracker: StackTracker) throws -> GmailLabel {
-        func parseGmailLabel_backslash(buffer: inout ByteBuffer, tracker: StackTracker) throws -> GmailLabel {
-            try fixedString("\\", buffer: &buffer, tracker: tracker)
+    static func parseGmailLabel(buffer: inout ParseBuffer, tracker: StackTracker) throws -> GmailLabel {
+        func parseGmailLabel_backslash(buffer: inout ParseBuffer, tracker: StackTracker) throws -> GmailLabel {
+            try ParserLibrary.fixedString("\\", buffer: &buffer, tracker: tracker)
             let att = try self.parseAtom(buffer: &buffer, tracker: tracker)
-            return .init(ByteBuffer(ByteBufferView("\\\(att)".utf8)))
+            return .init(ByteBuffer(string: "\\\(att)"))
         }
 
-        func parseGmailLabel_string(buffer: inout ByteBuffer, tracker: StackTracker) throws -> GmailLabel {
+        func parseGmailLabel_string(buffer: inout ParseBuffer, tracker: StackTracker) throws -> GmailLabel {
             let raw = try parseAString(buffer: &buffer, tracker: tracker)
             return .init(raw)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseGmailLabel_backslash,
             parseGmailLabel_string,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // Namespace         = nil / "(" 1*Namespace-Descr ")"
-    static func parseNamespace(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NamespaceDescription] {
-        func parseNamespace_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NamespaceDescription] {
+    static func parseNamespace(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [NamespaceDescription] {
+        func parseNamespace_nil(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [NamespaceDescription] {
             try self.parseNil(buffer: &buffer, tracker: tracker)
             return []
         }
 
-        func parseNamespace_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [NamespaceDescription] {
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+        func parseNamespace_some(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [NamespaceDescription] {
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             let descriptions = try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: tracker, parser: self.parseNamespaceDescription)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return descriptions
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseNamespace_nil,
             parseNamespace_some,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // Namespace-Command = "NAMESPACE"
-    static func parseNamespaceCommand(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try fixedString("NAMESPACE", buffer: &buffer, tracker: tracker)
+    static func parseNamespaceCommand(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.fixedString("NAMESPACE", buffer: &buffer, tracker: tracker)
         return .namespace
     }
 
     // Namespace-Descr   = "(" string SP
     //                        (DQUOTE QUOTED-CHAR DQUOTE / nil)
     //                         [Namespace-Response-Extensions] ")"
-    static func parseNamespaceDescription(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NamespaceDescription {
-        func parseNamespaceDescr_quotedChar(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Character? {
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
-            guard let char = buffer.readBytes(length: 1)?.first else {
-                throw _IncompleteMessage()
-            }
+    static func parseNamespaceDescription(buffer: inout ParseBuffer, tracker: StackTracker) throws -> NamespaceDescription {
+        func parseNamespaceDescr_quotedChar(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Character? {
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
+            let char = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
             guard char.isQuotedChar else {
                 throw ParserError(hint: "Invalid character")
             }
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             return Character(.init(char))
         }
 
-        func parseNamespaceDescr_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Character? {
+        func parseNamespaceDescr_nil(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Character? {
             try self.parseNil(buffer: &buffer, tracker: tracker)
             return nil
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NamespaceDescription in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NamespaceDescription in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             let string = try self.parseString(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
-            let char = try oneOf([
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
+            let char = try ParserLibrary.oneOf([
                 parseNamespaceDescr_quotedChar,
                 parseNamespaceDescr_nil,
             ], buffer: &buffer, tracker: tracker)
             let extensions = try self.parseNamespaceResponseExtensions(buffer: &buffer, tracker: tracker)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .init(string: string, char: char, responseExtensions: extensions)
         }
     }
 
     // Namespace-Response-Extensions = *(Namespace-Response-Extension)
-    static func parseNamespaceResponseExtensions(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValues<ByteBuffer, [ByteBuffer]> {
+    static func parseNamespaceResponseExtensions(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValues<ByteBuffer, [ByteBuffer]> {
         var kvs = KeyValues<ByteBuffer, [ByteBuffer]>()
         try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &kvs, tracker: tracker) { (buffer, tracker) -> KeyValue<ByteBuffer, [ByteBuffer]> in
             try self.parseNamespaceResponseExtension(buffer: &buffer, tracker: tracker)
@@ -1589,91 +1560,87 @@ extension GrammarParser {
 
     // Namespace-Response-Extension = SP string SP
     //                   "(" string *(SP string) ")"
-    static func parseNamespaceResponseExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValue<ByteBuffer, [ByteBuffer]> {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<ByteBuffer, [ByteBuffer]> in
-            try space(buffer: &buffer, tracker: tracker)
+    static func parseNamespaceResponseExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValue<ByteBuffer, [ByteBuffer]> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<ByteBuffer, [ByteBuffer]> in
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let s1 = try self.parseString(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             var array = [try self.parseString(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> ByteBuffer in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseString(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .init(key: s1, value: array)
         }
     }
 
     // Namespace-Response = "*" SP "NAMESPACE" SP Namespace
     //                       SP Namespace SP Namespace
-    static func parseNamespaceResponse(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NamespaceResponse {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NamespaceResponse in
-            try fixedString("NAMESPACE ", buffer: &buffer, tracker: tracker)
+    static func parseNamespaceResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> NamespaceResponse {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NamespaceResponse in
+            try ParserLibrary.fixedString("NAMESPACE ", buffer: &buffer, tracker: tracker)
             let n1 = try self.parseNamespace(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let n2 = try self.parseNamespace(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let n3 = try self.parseNamespace(buffer: &buffer, tracker: tracker)
             return NamespaceResponse(userNamespace: n1, otherUserNamespace: n2, sharedNamespace: n3)
         }
     }
 
     // nil             = "NIL"
-    static func parseNil(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-        try fixedString("nil", buffer: &buffer, tracker: tracker)
+    static func parseNil(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+        try ParserLibrary.fixedString("nil", buffer: &buffer, tracker: tracker)
     }
 
     // nstring         = string / nil
-    static func parseNString(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer? {
-        func parseNString_nil(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer? {
-            try fixedString("NIL", buffer: &buffer, tracker: tracker)
+    static func parseNString(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer? {
+        func parseNString_nil(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer? {
+            try ParserLibrary.fixedString("NIL", buffer: &buffer, tracker: tracker)
             return nil
         }
 
-        func parseNString_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer? {
+        func parseNString_some(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer? {
             try self.parseString(buffer: &buffer, tracker: tracker)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseNString_nil,
             parseNString_some,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // number          = 1*DIGIT
-    static func parseNumber(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-        let (num, _) = try ParserLibrary.parseUnsignedInteger(buffer: &buffer, tracker: tracker)
+    static func parseNumber(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+        let (num, _) = try ParserLibrary.parseUnsignedInteger(buffer: &buffer, tracker: tracker, allowLeadingZeros: true)
         return num
     }
 
     // nz-number       = digit-nz *DIGIT
-    static func parseNZNumber(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-        if case .some(UInt8(ascii: "0")) = buffer.readableBytesView.first {
-            throw ParserError(hint: "Number began with 0 ")
-        }
-        let (num, _) = try ParserLibrary.parseUnsignedInteger(buffer: &buffer, tracker: tracker)
-        return num
+    static func parseNZNumber(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+        try ParserLibrary.parseUnsignedInteger(buffer: &buffer, tracker: tracker).number
     }
 
     // option-extension = (option-standard-tag / option-vendor-tag)
     //                    [SP option-value]
-    static func parseOptionExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValue<OptionExtensionKind, OptionValueComp?> {
-        func parseOptionExtensionKind_standard(buffer: inout ByteBuffer, tracker: StackTracker) throws -> OptionExtensionKind {
+    static func parseOptionExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValue<OptionExtensionKind, OptionValueComp?> {
+        func parseOptionExtensionKind_standard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OptionExtensionKind {
             .standard(try self.parseAtom(buffer: &buffer, tracker: tracker))
         }
 
-        func parseOptionExtensionKind_vendor(buffer: inout ByteBuffer, tracker: StackTracker) throws -> OptionExtensionKind {
+        func parseOptionExtensionKind_vendor(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OptionExtensionKind {
             .vendor(try self.parseOptionVendorTag(buffer: &buffer, tracker: tracker))
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<OptionExtensionKind, OptionValueComp?> in
-            let type = try oneOf([
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<OptionExtensionKind, OptionValueComp?> in
+            let type = try ParserLibrary.oneOf([
                 parseOptionExtensionKind_standard,
                 parseOptionExtensionKind_vendor,
             ], buffer: &buffer, tracker: tracker)
-            let value = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> OptionValueComp in
-                try space(buffer: &buffer, tracker: tracker)
+            let value = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> OptionValueComp in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseOptionValue(buffer: &buffer, tracker: tracker)
             }
             return .init(key: type, value: value)
@@ -1683,28 +1650,28 @@ extension GrammarParser {
     // option-val-comp =  astring /
     //                    option-val-comp *(SP option-val-comp) /
     //                    "(" option-val-comp ")"
-    static func parseOptionValueComp(buffer: inout ByteBuffer, tracker: StackTracker) throws -> OptionValueComp {
-        func parseOptionValueComp_string(buffer: inout ByteBuffer, tracker: StackTracker) throws -> OptionValueComp {
+    static func parseOptionValueComp(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OptionValueComp {
+        func parseOptionValueComp_string(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OptionValueComp {
             .string(try self.parseAString(buffer: &buffer, tracker: tracker))
         }
 
-        func parseOptionValueComp_single(buffer: inout ByteBuffer, tracker: StackTracker) throws -> OptionValueComp {
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+        func parseOptionValueComp_single(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OptionValueComp {
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             let comp = try self.parseOptionValueComp(buffer: &buffer, tracker: tracker)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .array([comp])
         }
 
-        func parseOptionValueComp_array(buffer: inout ByteBuffer, tracker: StackTracker) throws -> OptionValueComp {
+        func parseOptionValueComp_array(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OptionValueComp {
             var array = [try self.parseOptionValueComp(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> OptionValueComp in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseOptionValueComp(buffer: &buffer, tracker: tracker)
             }
             return .array(array)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseOptionValueComp_string,
             parseOptionValueComp_single,
             parseOptionValueComp_array,
@@ -1712,38 +1679,38 @@ extension GrammarParser {
     }
 
     // option-value =  "(" option-val-comp ")"
-    static func parseOptionValue(buffer: inout ByteBuffer, tracker: StackTracker) throws -> OptionValueComp {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> OptionValueComp in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parseOptionValue(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OptionValueComp {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> OptionValueComp in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             let comp = try self.parseOptionValueComp(buffer: &buffer, tracker: tracker)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return comp
         }
     }
 
     // option-vendor-tag =  vendor-token "-" atom
-    static func parseOptionVendorTag(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValue<String, String> {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<String, String> in
+    static func parseOptionVendorTag(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValue<String, String> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> KeyValue<String, String> in
             let token = try self.parseVendorToken(buffer: &buffer, tracker: tracker)
-            try fixedString("-", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("-", buffer: &buffer, tracker: tracker)
             let atom = try self.parseAtom(buffer: &buffer, tracker: tracker)
             return .init(key: token, value: atom)
         }
     }
 
     // partial         = "<" number "." nz-number ">"
-    static func parsePartial(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ClosedRange<UInt32> {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ClosedRange<UInt32> in
-            try fixedString("<", buffer: &buffer, tracker: tracker)
+    static func parsePartial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ClosedRange<UInt32> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ClosedRange<UInt32> in
+            try ParserLibrary.fixedString("<", buffer: &buffer, tracker: tracker)
             guard let num1 = UInt32(exactly: try self.parseNumber(buffer: &buffer, tracker: tracker)) else {
                 throw ParserError(hint: "Partial range start is invalid.")
             }
-            try fixedString(".", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(".", buffer: &buffer, tracker: tracker)
             guard let num2 = UInt32(exactly: try self.parseNZNumber(buffer: &buffer, tracker: tracker)) else {
                 throw ParserError(hint: "Partial range count is invalid.")
             }
             guard num2 > 0 else { throw ParserError(hint: "Partial range is invalid: <\(num1).\(num2)>.") }
-            try fixedString(">", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(">", buffer: &buffer, tracker: tracker)
             let upper1 = num1.addingReportingOverflow(num2)
             guard !upper1.overflow else { throw ParserError(hint: "Range is invalid: <\(num1).\(num2)>.") }
             let upper2 = upper1.partialValue.subtractingReportingOverflow(1)
@@ -1752,85 +1719,85 @@ extension GrammarParser {
         }
     }
 
-    static func parsePartialRange(buffer: inout ByteBuffer, tracker: StackTracker) throws -> PartialRange {
-        func parsePartialRange_length(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
-            try fixedString(".", buffer: &buffer, tracker: tracker)
+    static func parsePartialRange(buffer: inout ParseBuffer, tracker: StackTracker) throws -> PartialRange {
+        func parsePartialRange_length(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+            try ParserLibrary.fixedString(".", buffer: &buffer, tracker: tracker)
             return try self.parseNumber(buffer: &buffer, tracker: tracker)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> PartialRange in
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> PartialRange in
             let offset = try self.parseNumber(buffer: &buffer, tracker: tracker)
-            let length = try optional(buffer: &buffer, tracker: tracker, parser: parsePartialRange_length)
+            let length = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parsePartialRange_length)
             return .init(offset: offset, length: length)
         }
     }
 
     // password        = astring
-    static func parsePassword(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parsePassword(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
         var buffer = try Self.parseAString(buffer: &buffer, tracker: tracker)
         return buffer.readString(length: buffer.readableBytes)!
     }
 
     // patterns        = "(" list-mailbox *(SP list-mailbox) ")"
-    static func parsePatterns(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [ByteBuffer] {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [ByteBuffer] in
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+    static func parsePatterns(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [ByteBuffer] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [ByteBuffer] in
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             var array = [try self.parseListMailbox(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> ByteBuffer in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseListMailbox(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return array
         }
     }
 
     // quoted          = DQUOTE *QUOTED-CHAR DQUOTE
-    static func parseQuoted(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+    static func parseQuoted(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ByteBuffer in
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             let data = try ParserLibrary.parseZeroOrMoreCharactersByteBuffer(buffer: &buffer, tracker: tracker) { char in
                 char.isQuotedChar
             }
-            try fixedString("\"", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("\"", buffer: &buffer, tracker: tracker)
             return data
         }
     }
 
     // rename          = "RENAME" SP mailbox SP mailbox [rename-params]
-    static func parseRename(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("RENAME ", buffer: &buffer, tracker: tracker)
+    static func parseRename(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("RENAME ", buffer: &buffer, tracker: tracker)
             let from = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            try fixedString(" ", caseSensitive: false, buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" ", caseSensitive: false, buffer: &buffer, tracker: tracker)
             let to = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            let params = try optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
+            let params = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]
             return .rename(from: from, to: to, params: params)
         }
     }
 
     // return-option   =  "SUBSCRIBED" / "CHILDREN" / status-option /
     //                    option-extension
-    static func parseReturnOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ReturnOption {
-        func parseReturnOption_subscribed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ReturnOption {
-            try fixedString("SUBSCRIBED", buffer: &buffer, tracker: tracker)
+    static func parseReturnOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ReturnOption {
+        func parseReturnOption_subscribed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ReturnOption {
+            try ParserLibrary.fixedString("SUBSCRIBED", buffer: &buffer, tracker: tracker)
             return .subscribed
         }
 
-        func parseReturnOption_children(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ReturnOption {
-            try fixedString("CHILDREN", buffer: &buffer, tracker: tracker)
+        func parseReturnOption_children(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ReturnOption {
+            try ParserLibrary.fixedString("CHILDREN", buffer: &buffer, tracker: tracker)
             return .children
         }
 
-        func parseReturnOption_statusOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ReturnOption {
+        func parseReturnOption_statusOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ReturnOption {
             .statusOption(try self.parseStatusOption(buffer: &buffer, tracker: tracker))
         }
 
-        func parseReturnOption_optionExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ReturnOption {
+        func parseReturnOption_optionExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ReturnOption {
             .optionExtension(try self.parseOptionExtension(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseReturnOption_subscribed,
             parseReturnOption_children,
             parseReturnOption_statusOption,
@@ -1838,25 +1805,25 @@ extension GrammarParser {
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseScopeOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ScopeOption {
-        func parseScopeOption_zero(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ScopeOption {
-            try fixedString("0", buffer: &buffer, tracker: tracker)
+    static func parseScopeOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ScopeOption {
+        func parseScopeOption_zero(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ScopeOption {
+            try ParserLibrary.fixedString("0", buffer: &buffer, tracker: tracker)
             return .zero
         }
 
-        func parseScopeOption_one(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ScopeOption {
-            try fixedString("1", buffer: &buffer, tracker: tracker)
+        func parseScopeOption_one(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ScopeOption {
+            try ParserLibrary.fixedString("1", buffer: &buffer, tracker: tracker)
             return .one
         }
 
-        func parseScopeOption_infinity(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ScopeOption {
-            try fixedString("infinity", buffer: &buffer, tracker: tracker)
+        func parseScopeOption_infinity(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ScopeOption {
+            try ParserLibrary.fixedString("infinity", buffer: &buffer, tracker: tracker)
             return .infinity
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("DEPTH ", buffer: &buffer, tracker: tracker)
-            return try oneOf([
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("DEPTH ", buffer: &buffer, tracker: tracker)
+            return try ParserLibrary.oneOf([
                 parseScopeOption_zero,
                 parseScopeOption_one,
                 parseScopeOption_infinity,
@@ -1865,44 +1832,44 @@ extension GrammarParser {
     }
 
     // section         = "[" [section-spec] "]"
-    static func parseSection(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
-        func parseSection_none(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SectionSpecifier in
-                try fixedString("[]", buffer: &buffer, tracker: tracker)
+    static func parseSection(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {
+        func parseSection_none(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SectionSpecifier in
+                try ParserLibrary.fixedString("[]", buffer: &buffer, tracker: tracker)
                 return .complete
             }
         }
 
-        func parseSection_some(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
-            try fixedString("[", buffer: &buffer, tracker: tracker)
+        func parseSection_some(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {
+            try ParserLibrary.fixedString("[", buffer: &buffer, tracker: tracker)
             let spec = try self.parseSectionSpecifier(buffer: &buffer, tracker: tracker)
-            try fixedString("]", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("]", buffer: &buffer, tracker: tracker)
             return spec
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseSection_none,
             parseSection_some,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // section-binary  = "[" [section-part] "]"
-    static func parseSectionBinary(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Part {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SectionSpecifier.Part in
-            try fixedString("[", buffer: &buffer, tracker: tracker)
-            let part = try optional(buffer: &buffer, tracker: tracker, parser: self.parseSectionPart)
-            try fixedString("]", buffer: &buffer, tracker: tracker)
+    static func parseSectionBinary(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Part {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SectionSpecifier.Part in
+            try ParserLibrary.fixedString("[", buffer: &buffer, tracker: tracker)
+            let part = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseSectionPart)
+            try ParserLibrary.fixedString("]", buffer: &buffer, tracker: tracker)
             return part ?? .init([])
         }
     }
 
     // section-part    = nz-number *("." nz-number)
-    static func parseSectionPart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Part {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SectionSpecifier.Part in
+    static func parseSectionPart(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Part {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> SectionSpecifier.Part in
             var output = [try self.parseNZNumber(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &output, tracker: tracker) { (buffer, tracker) -> Int in
-                try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Int in
-                    try fixedString(".", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> Int in
+                    try ParserLibrary.fixedString(".", buffer: &buffer, tracker: tracker)
                     return try self.parseNZNumber(buffer: &buffer, tracker: tracker)
                 }
             }
@@ -1911,59 +1878,59 @@ extension GrammarParser {
     }
 
     // section-spec    = section-msgtext / (section-part ["." section-text])
-    static func parseSectionSpecifier(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
-        func parseSectionSpecifier_noPart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
+    static func parseSectionSpecifier(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {
+        func parseSectionSpecifier_noPart(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {
             let kind = try self.parseSectionSpecifierKind(buffer: &buffer, tracker: tracker)
             return .init(kind: kind)
         }
 
-        func parseSectionSpecifier_withPart(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier {
+        func parseSectionSpecifier_withPart(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {
             let part = try self.parseSectionPart(buffer: &buffer, tracker: tracker)
-            let kind = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SectionSpecifier.Kind in
-                try fixedString(".", buffer: &buffer, tracker: tracker)
+            let kind = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SectionSpecifier.Kind in
+                try ParserLibrary.fixedString(".", buffer: &buffer, tracker: tracker)
                 return try self.parseSectionSpecifierKind(buffer: &buffer, tracker: tracker)
             } ?? .complete
             return .init(part: part, kind: kind)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseSectionSpecifier_withPart,
             parseSectionSpecifier_noPart,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // section-text    = section-msgtext / "MIME"
-    static func parseSectionSpecifierKind(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
-        func parseSectionSpecifierKind_mime(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
-            try fixedString("MIME", buffer: &buffer, tracker: tracker)
+    static func parseSectionSpecifierKind(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
+        func parseSectionSpecifierKind_mime(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
+            try ParserLibrary.fixedString("MIME", buffer: &buffer, tracker: tracker)
             return .MIMEHeader
         }
 
-        func parseSectionSpecifierKind_header(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
-            try fixedString("HEADER", buffer: &buffer, tracker: tracker)
+        func parseSectionSpecifierKind_header(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
+            try ParserLibrary.fixedString("HEADER", buffer: &buffer, tracker: tracker)
             return .header
         }
 
-        func parseSectionSpecifierKind_headerFields(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
-            try fixedString("HEADER.FIELDS ", buffer: &buffer, tracker: tracker)
+        func parseSectionSpecifierKind_headerFields(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
+            try ParserLibrary.fixedString("HEADER.FIELDS ", buffer: &buffer, tracker: tracker)
             return .headerFields(try self.parseHeaderList(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSectionSpecifierKind_notHeaderFields(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
-            try fixedString("HEADER.FIELDS.NOT ", buffer: &buffer, tracker: tracker)
+        func parseSectionSpecifierKind_notHeaderFields(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
+            try ParserLibrary.fixedString("HEADER.FIELDS.NOT ", buffer: &buffer, tracker: tracker)
             return .headerFieldsNot(try self.parseHeaderList(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSectionSpecifierKind_text(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
-            try fixedString("TEXT", buffer: &buffer, tracker: tracker)
+        func parseSectionSpecifierKind_text(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
+            try ParserLibrary.fixedString("TEXT", buffer: &buffer, tracker: tracker)
             return .text
         }
 
-        func parseSectionSpecifierKind_complete(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
+        func parseSectionSpecifierKind_complete(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier.Kind {
             .complete
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseSectionSpecifierKind_mime,
             parseSectionSpecifierKind_headerFields,
             parseSectionSpecifierKind_notHeaderFields,
@@ -1974,89 +1941,89 @@ extension GrammarParser {
     }
 
     // select          = "SELECT" SP mailbox [select-params]
-    static func parseSelect(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("SELECT ", buffer: &buffer, tracker: tracker)
+    static func parseSelect(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("SELECT ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            let params = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [SelectParameter] in
-                try space(buffer: &buffer, tracker: tracker)
-                try fixedString("(", buffer: &buffer, tracker: tracker)
+            let params = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [SelectParameter] in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
                 var array = [try self.parseSelectParameter(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker, parser: { (buffer, tracker) in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try self.parseSelectParameter(buffer: &buffer, tracker: tracker)
                 })
-                try fixedString(")", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
                 return array
             }
             return .select(mailbox, params ?? [])
         }
     }
 
-    static func parseSelectParameter(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SelectParameter {
-        func parseSelectParameter_basic(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SelectParameter {
+    static func parseSelectParameter(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SelectParameter {
+        func parseSelectParameter_basic(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SelectParameter {
             .basic(try self.parseParameter(buffer: &buffer, tracker: tracker))
         }
 
-        func parseSelectParameter_condstore(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SelectParameter {
-            try fixedString("CONDSTORE", buffer: &buffer, tracker: tracker)
+        func parseSelectParameter_condstore(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SelectParameter {
+            try ParserLibrary.fixedString("CONDSTORE", buffer: &buffer, tracker: tracker)
             return .condstore
         }
 
-        func parseSelectParameter_qresync(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SelectParameter {
-            try fixedString("QRESYNC (", buffer: &buffer, tracker: tracker)
+        func parseSelectParameter_qresync(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SelectParameter {
+            try ParserLibrary.fixedString("QRESYNC (", buffer: &buffer, tracker: tracker)
             let uidValidity = try self.parseNZNumber(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let modSeqVal = try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker)
-            let knownUids = try optional(buffer: &buffer, tracker: tracker, parser: { (buffer, tracker) -> LastCommandSet<SequenceRangeSet> in
-                try space(buffer: &buffer, tracker: tracker)
+            let knownUids = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { (buffer, tracker) -> LastCommandSet<SequenceRangeSet> in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseKnownUids(buffer: &buffer, tracker: tracker)
             })
-            let seqMatchData = try optional(buffer: &buffer, tracker: tracker, parser: { (buffer, tracker) -> SequenceMatchData in
-                try space(buffer: &buffer, tracker: tracker)
+            let seqMatchData = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: { (buffer, tracker) -> SequenceMatchData in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseSequenceMatchData(buffer: &buffer, tracker: tracker)
             })
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .qresync(.init(uidValiditiy: uidValidity, modificationSequenceValue: modSeqVal, knownUids: knownUids, sequenceMatchData: seqMatchData))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseSelectParameter_qresync,
             parseSelectParameter_condstore,
             parseSelectParameter_basic,
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseKnownUids(buffer: inout ByteBuffer, tracker: StackTracker) throws -> LastCommandSet<SequenceRangeSet> {
+    static func parseKnownUids(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<SequenceRangeSet> {
         try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
     }
 
     // select-params = SP "(" select-param *(SP select-param ")"
-    static func parseParameters(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValues<String, ParameterValue?> {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> KeyValues<String, ParameterValue?> in
-            try fixedString(" (", buffer: &buffer, tracker: tracker)
+    static func parseParameters(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValues<String, ParameterValue?> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> KeyValues<String, ParameterValue?> in
+            try ParserLibrary.fixedString(" (", buffer: &buffer, tracker: tracker)
             var kvs = KeyValues<String, ParameterValue?>()
             kvs.append(try self.parseParameter(buffer: &buffer, tracker: tracker))
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &kvs, tracker: tracker) { (buffer, tracker) -> KeyValue<String, ParameterValue?> in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseParameter(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return kvs
         }
     }
 
-    static func parseSortData(buffer: inout ByteBuffer, tracker: StackTracker) throws -> SortData? {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SortData? in
-            try fixedString("SORT", buffer: &buffer, tracker: tracker)
-            let _components = try optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ([Int], ModificationSequenceValue) in
-                try space(buffer: &buffer, tracker: tracker)
+    static func parseSortData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SortData? {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SortData? in
+            try ParserLibrary.fixedString("SORT", buffer: &buffer, tracker: tracker)
+            let _components = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ([Int], ModificationSequenceValue) in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 var array = [try self.parseNZNumber(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker, parser: { (buffer, tracker) in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try self.parseNZNumber(buffer: &buffer, tracker: tracker)
                 })
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 let seq = try self.parseSearchSortModificationSequence(buffer: &buffer, tracker: tracker)
                 return (array, seq)
             }
@@ -2070,24 +2037,24 @@ extension GrammarParser {
 
     // status          = "STATUS" SP mailbox SP
     //                   "(" status-att *(SP status-att) ")"
-    static func parseStatus(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("STATUS ", buffer: &buffer, tracker: tracker)
+    static func parseStatus(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("STATUS ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
-            try fixedString(" (", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" (", buffer: &buffer, tracker: tracker)
             var atts = [try self.parseStatusAttribute(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &atts, tracker: tracker) { buffer, tracker -> MailboxAttribute in
-                try fixedString(" ", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(" ", buffer: &buffer, tracker: tracker)
                 return try self.parseStatusAttribute(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .status(mailbox, atts)
         }
     }
 
     // status-att      = "MESSAGES" / "UIDNEXT" / "UIDVALIDITY" /
     //                   "UNSEEN" / "DELETED" / "SIZE"
-    static func parseStatusAttribute(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxAttribute {
+    static func parseStatusAttribute(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxAttribute {
         let string = try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { c -> Bool in
             isalpha(Int32(c)) != 0
         }
@@ -2098,51 +2065,51 @@ extension GrammarParser {
     }
 
     // status-option = "STATUS" SP "(" status-att *(SP status-att) ")"
-    static func parseStatusOption(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [MailboxAttribute] {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [MailboxAttribute] in
-            try fixedString("STATUS (", buffer: &buffer, tracker: tracker)
+    static func parseStatusOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [MailboxAttribute] {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> [MailboxAttribute] in
+            try ParserLibrary.fixedString("STATUS (", buffer: &buffer, tracker: tracker)
             var array = [try self.parseStatusAttribute(buffer: &buffer, tracker: tracker)]
             try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker) { (buffer, tracker) -> MailboxAttribute in
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 return try self.parseStatusAttribute(buffer: &buffer, tracker: tracker)
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return array
         }
     }
 
     // store           = "STORE" SP sequence-set SP store-att-flags
-    static func parseStore(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("STORE ", buffer: &buffer, tracker: tracker)
+    static func parseStore(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("STORE ", buffer: &buffer, tracker: tracker)
             let sequence = try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
-            let modifiers = try optional(buffer: &buffer, tracker: tracker) { buffer, tracker -> [StoreModifier] in
-                try space(buffer: &buffer, tracker: tracker)
-                try fixedString("(", buffer: &buffer, tracker: tracker)
+            let modifiers = try ParserLibrary.optional(buffer: &buffer, tracker: tracker) { buffer, tracker -> [StoreModifier] in
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
                 var array = [try self.parseStoreModifier(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &array, tracker: tracker, parser: { (buffer, tracker) in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try self.parseStoreModifier(buffer: &buffer, tracker: tracker)
                 })
-                try fixedString(")", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
                 return array
             } ?? []
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let flags = try self.parseStoreAttributeFlags(buffer: &buffer, tracker: tracker)
             return .store(sequence, modifiers, flags)
         }
     }
 
-    static func parseStoreModifier(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StoreModifier {
-        func parseFetchModifier_unchangedSince(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StoreModifier {
+    static func parseStoreModifier(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StoreModifier {
+        func parseFetchModifier_unchangedSince(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StoreModifier {
             .unchangedSince(try self.parseUnchangedSinceModifier(buffer: &buffer, tracker: tracker))
         }
 
-        func parseFetchModifier_other(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StoreModifier {
+        func parseFetchModifier_other(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StoreModifier {
             .other(try self.parseParameter(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFetchModifier_unchangedSince,
             parseFetchModifier_other,
         ], buffer: &buffer, tracker: tracker)
@@ -2150,49 +2117,49 @@ extension GrammarParser {
 
     // store-att-flags = (["+" / "-"] "FLAGS" [".SILENT"]) SP
     //                   (flag-list / (flag *(SP flag)))
-    static func parseStoreAttributeFlags(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StoreFlags {
-        func parseStoreAttributeFlags_silent(buffer: inout ByteBuffer, tracker: StackTracker) -> Bool {
+    static func parseStoreAttributeFlags(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StoreFlags {
+        func parseStoreAttributeFlags_silent(buffer: inout ParseBuffer, tracker: StackTracker) -> Bool {
             do {
-                try fixedString(".SILENT", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(".SILENT", buffer: &buffer, tracker: tracker)
                 return true
             } catch {
                 return false
             }
         }
 
-        func parseStoreAttributeFlags_array(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [Flag] {
-            try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [Flag] in
+        func parseStoreAttributeFlags_array(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [Flag] {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> [Flag] in
                 var output = [try self.parseFlag(buffer: &buffer, tracker: tracker)]
                 try ParserLibrary.parseZeroOrMore(buffer: &buffer, into: &output, tracker: tracker) { (buffer, tracker) -> Flag in
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     return try self.parseFlag(buffer: &buffer, tracker: tracker)
                 }
                 return output
             }
         }
 
-        func parseStoreAttributeFlags_operation(buffer: inout ByteBuffer, tracker: StackTracker) throws -> StoreFlags.Operation {
-            try oneOf([
-                { (buffer: inout ByteBuffer, tracker: StackTracker) -> StoreFlags.Operation in
-                    try fixedString("+FLAGS", buffer: &buffer, tracker: tracker)
+        func parseStoreAttributeFlags_operation(buffer: inout ParseBuffer, tracker: StackTracker) throws -> StoreFlags.Operation {
+            try ParserLibrary.oneOf([
+                { (buffer: inout ParseBuffer, tracker: StackTracker) -> StoreFlags.Operation in
+                    try ParserLibrary.fixedString("+FLAGS", buffer: &buffer, tracker: tracker)
                     return .add
                 },
-                { (buffer: inout ByteBuffer, tracker: StackTracker) -> StoreFlags.Operation in
-                    try fixedString("-FLAGS", buffer: &buffer, tracker: tracker)
+                { (buffer: inout ParseBuffer, tracker: StackTracker) -> StoreFlags.Operation in
+                    try ParserLibrary.fixedString("-FLAGS", buffer: &buffer, tracker: tracker)
                     return .remove
                 },
-                { (buffer: inout ByteBuffer, tracker: StackTracker) -> StoreFlags.Operation in
-                    try fixedString("FLAGS", buffer: &buffer, tracker: tracker)
+                { (buffer: inout ParseBuffer, tracker: StackTracker) -> StoreFlags.Operation in
+                    try ParserLibrary.fixedString("FLAGS", buffer: &buffer, tracker: tracker)
                     return .replace
                 },
             ], buffer: &buffer, tracker: tracker)
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> StoreFlags in
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> StoreFlags in
             let operation = try parseStoreAttributeFlags_operation(buffer: &buffer, tracker: tracker)
             let silent = parseStoreAttributeFlags_silent(buffer: &buffer, tracker: tracker)
-            try space(buffer: &buffer, tracker: tracker)
-            let flags = try oneOf([
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
+            let flags = try ParserLibrary.oneOf([
                 parseStoreAttributeFlags_array,
                 parseFlagList,
             ], buffer: &buffer, tracker: tracker)
@@ -2201,32 +2168,32 @@ extension GrammarParser {
     }
 
     // string          = quoted / literal
-    static func parseString(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
-        try oneOf([
+    static func parseString(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
+        try ParserLibrary.oneOf([
             Self.parseQuoted,
             Self.parseLiteral,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // subscribe       = "SUBSCRIBE" SP mailbox
-    static func parseSubscribe(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("SUBSCRIBE ", buffer: &buffer, tracker: tracker)
+    static func parseSubscribe(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("SUBSCRIBE ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
             return .subscribe(mailbox)
         }
     }
 
     // tag             = 1*<any ASTRING-CHAR except "+">
-    static func parseTag(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parseTag(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
         try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char -> Bool in
             char.isAStringChar && char != UInt8(ascii: "+")
         }
     }
 
     // tagged-ext = tagged-ext-label SP tagged-ext-val
-    static func parseTaggedExtension(buffer: inout ByteBuffer, tracker: StackTracker) throws -> KeyValue<String, ParameterValue> {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+    static func parseTaggedExtension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> KeyValue<String, ParameterValue> {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             let key = try self.parseParameterName(buffer: &buffer, tracker: tracker)
 
             // Warning: weird hack alert.
@@ -2237,19 +2204,17 @@ extension GrammarParser {
                 throw ParserError(hint: "catenate extension")
             }
 
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let value = try self.parseParameterValue(buffer: &buffer, tracker: tracker)
             return .init(key: key, value: value)
         }
     }
 
     // tagged-ext-label    = tagged-label-fchar *tagged-label-char
-    static func parseParameterName(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> String in
+    static func parseParameterName(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> String in
 
-            guard let fchar = buffer.readBytes(length: 1)?.first else {
-                throw _IncompleteMessage()
-            }
+            let fchar = try ParserLibrary.parseByte(buffer: &buffer, tracker: tracker)
             guard fchar.isTaggedLabelFchar else {
                 throw ParserError(hint: "\(fchar) is not a valid fchar’")
             }
@@ -2267,12 +2232,12 @@ extension GrammarParser {
     // tagged-ext-comp = astring continuation | '(' tagged-ext-comp ')' continuation
     static func parseTaggedExtensionComplex_continuation(
         into: inout [String],
-        buffer: inout ByteBuffer,
+        buffer: inout ParseBuffer,
         tracker: StackTracker
     ) throws {
         while true {
             do {
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 try self.parseTaggedExtensionComplex_helper(into: &into, buffer: &buffer, tracker: tracker)
             } catch {
                 return
@@ -2282,12 +2247,12 @@ extension GrammarParser {
 
     static func parseTaggedExtensionComplex_helper(
         into: inout [String],
-        buffer: inout ByteBuffer,
+        buffer: inout ParseBuffer,
         tracker: StackTracker
     ) throws {
         func parseTaggedExtensionComplex_string(
             into: inout [String],
-            buffer: inout ByteBuffer,
+            buffer: inout ParseBuffer,
             tracker: StackTracker
         ) throws {
             into.append(String(buffer: try self.parseAString(buffer: &buffer, tracker: tracker)))
@@ -2296,18 +2261,18 @@ extension GrammarParser {
 
         func parseTaggedExtensionComplex_bracketed(
             into: inout [String],
-            buffer: inout ByteBuffer,
+            buffer: inout ParseBuffer,
             tracker: StackTracker
         ) throws {
-            try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-                try fixedString("(", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
                 try self.parseTaggedExtensionComplex_helper(into: &into, buffer: &buffer, tracker: tracker)
-                try fixedString(")", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
                 try self.parseTaggedExtensionComplex_continuation(into: &into, buffer: &buffer, tracker: tracker)
             }
         }
 
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             let save = buffer
             do {
                 try parseTaggedExtensionComplex_string(into: &into, buffer: &buffer, tracker: tracker)
@@ -2322,7 +2287,7 @@ extension GrammarParser {
     // tagged-ext-comp     = astring /
     //                       tagged-ext-comp *(SP tagged-ext-comp) /
     //                       "(" tagged-ext-comp ")"
-    static func parseTaggedExtensionComplex(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [String] {
+    static func parseTaggedExtensionComplex(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [String] {
         var result = [String]()
         try self.parseTaggedExtensionComplex_helper(into: &result, buffer: &buffer, tracker: tracker)
         return result
@@ -2330,32 +2295,32 @@ extension GrammarParser {
 
     // tagged-ext-val      = tagged-ext-simple /
     //                       "(" [tagged-ext-comp] ")"
-    static func parseParameterValue(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ParameterValue {
-        func parseTaggedExtensionSimple_set(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ParameterValue {
+    static func parseParameterValue(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ParameterValue {
+        func parseTaggedExtensionSimple_set(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ParameterValue {
             .sequence(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
         }
 
-        func parseTaggedExtensionVal_comp(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ParameterValue {
-            try fixedString("(", buffer: &buffer, tracker: tracker)
-            let comp = try optional(buffer: &buffer, tracker: tracker, parser: self.parseTaggedExtensionComplex) ?? []
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+        func parseTaggedExtensionVal_comp(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ParameterValue {
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
+            let comp = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: self.parseTaggedExtensionComplex) ?? []
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return .comp(comp)
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseTaggedExtensionSimple_set,
             parseTaggedExtensionVal_comp,
         ], buffer: &buffer, tracker: tracker)
     }
 
     // text            = 1*TEXT-CHAR
-    static func parseText(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ByteBuffer {
+    static func parseText(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteBuffer {
         try ParserLibrary.parseOneOrMoreCharactersByteBuffer(buffer: &buffer, tracker: tracker) { char -> Bool in
             char.isTextChar
         }
     }
 
-    static func parseUAuthMechanism(buffer: inout ByteBuffer, tracker: StackTracker) throws -> URLAuthenticationMechanism {
+    static func parseUAuthMechanism(buffer: inout ParseBuffer, tracker: StackTracker) throws -> URLAuthenticationMechanism {
         let string = try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker, where: { char in
             switch char {
             case UInt8(ascii: "a") ... UInt8(ascii: "z"),
@@ -2372,92 +2337,92 @@ extension GrammarParser {
     }
 
     // unsubscribe     = "UNSUBSCRIBE" SP mailbox
-    static func parseUnsubscribe(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
-            try fixedString("UNSUBSCRIBE ", buffer: &buffer, tracker: tracker)
+    static func parseUnsubscribe(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
+            try ParserLibrary.fixedString("UNSUBSCRIBE ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
             return .unsubscribe(mailbox)
         }
     }
 
     // userid          = astring
-    static func parseUserId(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parseUserId(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
         var astring = try Self.parseAString(buffer: &buffer, tracker: tracker)
         return astring.readString(length: astring.readableBytes)! // if this fails, something has gone very, very wrong
     }
 
     // vendor-token     = atom (maybe?!?!?!)
-    static func parseVendorToken(buffer: inout ByteBuffer, tracker: StackTracker) throws -> String {
+    static func parseVendorToken(buffer: inout ParseBuffer, tracker: StackTracker) throws -> String {
         try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char -> Bool in
             char.isAlpha
         }
     }
 
     // RFC 2087 = "GETQUOTA" / "GETQUOTAROOT" / "SETQUOTA"
-    static func parseCommandQuota(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        func parseQuotaRoot(buffer: inout ByteBuffer, tracker: StackTracker) throws -> QuotaRoot {
+    static func parseCommandQuota(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        func parseQuotaRoot(buffer: inout ParseBuffer, tracker: StackTracker) throws -> QuotaRoot {
             let string = try self.parseAString(buffer: &buffer, tracker: tracker)
             return QuotaRoot(string)
         }
 
         // setquota_list   ::= "(" 0#setquota_resource ")"
-        func parseQuotaLimits(buffer: inout ByteBuffer, tracker: StackTracker) throws -> [QuotaLimit] {
+        func parseQuotaLimits(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [QuotaLimit] {
             // setquota_resource ::= atom SP number
-            func parseQuotaLimit(buffer: inout ByteBuffer, tracker: StackTracker) throws -> QuotaLimit {
-                try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            func parseQuotaLimit(buffer: inout ParseBuffer, tracker: StackTracker) throws -> QuotaLimit {
+                try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
                     let resourceName = try parseAtom(buffer: &buffer, tracker: tracker)
-                    try space(buffer: &buffer, tracker: tracker)
+                    try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                     let limit = try parseNumber(buffer: &buffer, tracker: tracker)
                     return QuotaLimit(resourceName: resourceName, limit: limit)
                 }
             }
 
-            return try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) throws -> [QuotaLimit] in
-                try fixedString("(", buffer: &buffer, tracker: tracker)
+            return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) throws -> [QuotaLimit] in
+                try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
                 var limits: [QuotaLimit] = []
-                try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-                    while let limit = try optional(buffer: &buffer, tracker: tracker, parser: parseQuotaLimit) {
+                try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                    while let limit = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parseQuotaLimit) {
                         limits.append(limit)
-                        if try optional(buffer: &buffer, tracker: tracker, parser: space) == nil {
+                        if try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: ParserLibrary.space) == nil {
                             break
                         }
                     }
                 }
-                try fixedString(")", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
                 return limits
             }
         }
 
         // getquota        ::= "GETQUOTA" SP astring
-        func parseCommandQuota_getQuota(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-                try fixedString("GETQUOTA ", buffer: &buffer, tracker: tracker)
+        func parseCommandQuota_getQuota(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try ParserLibrary.fixedString("GETQUOTA ", buffer: &buffer, tracker: tracker)
                 let quotaRoot = try parseQuotaRoot(buffer: &buffer, tracker: tracker)
                 return .getQuota(quotaRoot)
             }
         }
 
         // getquotaroot    ::= "GETQUOTAROOT" SP astring
-        func parseCommandQuota_getQuotaRoot(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-                try fixedString("GETQUOTAROOT ", buffer: &buffer, tracker: tracker)
+        func parseCommandQuota_getQuotaRoot(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try ParserLibrary.fixedString("GETQUOTAROOT ", buffer: &buffer, tracker: tracker)
                 let mailbox = try parseMailbox(buffer: &buffer, tracker: tracker)
                 return .getQuotaRoot(mailbox)
             }
         }
 
         // setquota        ::= "SETQUOTA" SP astring SP setquota_list
-        func parseCommandQuota_setQuota(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-            try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-                try fixedString("SETQUOTA ", buffer: &buffer, tracker: tracker)
+        func parseCommandQuota_setQuota(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try ParserLibrary.fixedString("SETQUOTA ", buffer: &buffer, tracker: tracker)
                 let quotaRoot = try parseQuotaRoot(buffer: &buffer, tracker: tracker)
-                try space(buffer: &buffer, tracker: tracker)
+                try ParserLibrary.space(buffer: &buffer, tracker: tracker)
                 let quotaLimits = try parseQuotaLimits(buffer: &buffer, tracker: tracker)
                 return .setQuota(quotaRoot, quotaLimits)
             }
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseCommandQuota_getQuota,
             parseCommandQuota_getQuotaRoot,
             parseCommandQuota_setQuota,
@@ -2466,15 +2431,15 @@ extension GrammarParser {
 
     // RFC 5465
     // one-or-more-mailbox = mailbox / many-mailboxes
-    static func parseOneOrMoreMailbox(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Mailboxes {
+    static func parseOneOrMoreMailbox(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Mailboxes {
         // many-mailboxes  = "(" mailbox *(SP mailbox) ")
-        func parseManyMailboxes(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Mailboxes {
-            try fixedString("(", buffer: &buffer, tracker: tracker)
+        func parseManyMailboxes(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Mailboxes {
+            try ParserLibrary.fixedString("(", buffer: &buffer, tracker: tracker)
             var mailboxes: [MailboxName] = [try parseMailbox(buffer: &buffer, tracker: tracker)]
-            while try optional(buffer: &buffer, tracker: tracker, parser: space) != nil {
+            while try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: ParserLibrary.space) != nil {
                 mailboxes.append(try parseMailbox(buffer: &buffer, tracker: tracker))
             }
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             if let returnValue = Mailboxes(mailboxes) {
                 return returnValue
             } else {
@@ -2482,7 +2447,7 @@ extension GrammarParser {
             }
         }
 
-        func parseSingleMailboxes(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Mailboxes {
+        func parseSingleMailboxes(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Mailboxes {
             let mailboxes: [MailboxName] = [try parseMailbox(buffer: &buffer, tracker: tracker)]
             if let returnValue = Mailboxes(mailboxes) {
                 return returnValue
@@ -2491,7 +2456,7 @@ extension GrammarParser {
             }
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseManyMailboxes,
             parseSingleMailboxes,
         ], buffer: &buffer, tracker: tracker)
@@ -2499,54 +2464,54 @@ extension GrammarParser {
 
     // RFC 5465
     // filter-mailboxes = filter-mailboxes-selected / filter-mailboxes-other
-    static func parseFilterMailboxes(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
+    static func parseFilterMailboxes(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
         // filter-mailboxes-selected = "selected" / "selected-delayed"
-        func parseFilterMailboxes_Selected(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
-            try fixedString("selected", buffer: &buffer, tracker: tracker)
+        func parseFilterMailboxes_Selected(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
+            try ParserLibrary.fixedString("selected", buffer: &buffer, tracker: tracker)
             return .selected
         }
 
-        func parseFilterMailboxes_SelectedDelayed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
-            try fixedString("selected-delayed", buffer: &buffer, tracker: tracker)
+        func parseFilterMailboxes_SelectedDelayed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
+            try ParserLibrary.fixedString("selected-delayed", buffer: &buffer, tracker: tracker)
             return .selectedDelayed
         }
 
         // filter-mailboxes-other = "inboxes" / "personal" / "subscribed" /
         // ( "subtree" SP one-or-more-mailbox ) /
         // ( "mailboxes" SP one-or-more-mailbox )
-        func parseFilterMailboxes_Inboxes(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
-            try fixedString("inboxes", buffer: &buffer, tracker: tracker)
+        func parseFilterMailboxes_Inboxes(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
+            try ParserLibrary.fixedString("inboxes", buffer: &buffer, tracker: tracker)
             return .inboxes
         }
 
-        func parseFilterMailboxes_Personal(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
-            try fixedString("personal", buffer: &buffer, tracker: tracker)
+        func parseFilterMailboxes_Personal(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
+            try ParserLibrary.fixedString("personal", buffer: &buffer, tracker: tracker)
             return .personal
         }
 
-        func parseFilterMailboxes_Subscribed(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
-            try fixedString("subscribed", buffer: &buffer, tracker: tracker)
+        func parseFilterMailboxes_Subscribed(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
+            try ParserLibrary.fixedString("subscribed", buffer: &buffer, tracker: tracker)
             return .subscribed
         }
 
-        func parseFilterMailboxes_Subtree(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
-            try fixedString("subtree ", buffer: &buffer, tracker: tracker)
+        func parseFilterMailboxes_Subtree(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
+            try ParserLibrary.fixedString("subtree ", buffer: &buffer, tracker: tracker)
             return .subtree(try parseOneOrMoreMailbox(buffer: &buffer, tracker: tracker))
         }
 
-        func parseFilterMailboxes_Mailboxes(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
-            try fixedString("mailboxes ", buffer: &buffer, tracker: tracker)
+        func parseFilterMailboxes_Mailboxes(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
+            try ParserLibrary.fixedString("mailboxes ", buffer: &buffer, tracker: tracker)
             return .mailboxes(try parseOneOrMoreMailbox(buffer: &buffer, tracker: tracker))
         }
 
         // RFC 6237
         // filter-mailboxes-other =/  ("subtree-one" SP one-or-more-mailbox)
-        func parseFilterMailboxes_SubtreeOne(buffer: inout ByteBuffer, tracker: StackTracker) throws -> MailboxFilter {
-            try fixedString("subtree-one ", buffer: &buffer, tracker: tracker)
+        func parseFilterMailboxes_SubtreeOne(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxFilter {
+            try ParserLibrary.fixedString("subtree-one ", buffer: &buffer, tracker: tracker)
             return .subtreeOne(try parseOneOrMoreMailbox(buffer: &buffer, tracker: tracker))
         }
 
-        return try oneOf([
+        return try ParserLibrary.oneOf([
             parseFilterMailboxes_SelectedDelayed,
             parseFilterMailboxes_SubtreeOne,
             parseFilterMailboxes_Selected,
@@ -2560,10 +2525,10 @@ extension GrammarParser {
 
     // RFC 6237
     // scope-options =  scope-option *(SP scope-option)
-    static func parseExtendedSearchScopeOptions(buffer: inout ByteBuffer, tracker: StackTracker) throws -> ExtendedSearchScopeOptions {
+    static func parseExtendedSearchScopeOptions(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ExtendedSearchScopeOptions {
         var options = KeyValues<String, ParameterValue?>()
         options.append(try parseParameter(buffer: &buffer, tracker: tracker))
-        while try optional(buffer: &buffer, tracker: tracker, parser: space) != nil {
+        while try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: ParserLibrary.space) != nil {
             options.append(try parseParameter(buffer: &buffer, tracker: tracker))
         }
         if let returnValue = ExtendedSearchScopeOptions(options) {
@@ -2575,41 +2540,41 @@ extension GrammarParser {
 
     // RFC 6237
     // esearch-source-opts =  "IN" SP "(" source-mbox [SP "(" scope-options ")"] ")"
-    static func parseExtendedSearchSourceOptions(buffer: inout ByteBuffer,
+    static func parseExtendedSearchSourceOptions(buffer: inout ParseBuffer,
                                                  tracker: StackTracker) throws -> ExtendedSearchSourceOptions {
-        func parseExtendedSearchSourceOptions_spaceFilter(buffer: inout ByteBuffer,
+        func parseExtendedSearchSourceOptions_spaceFilter(buffer: inout ParseBuffer,
                                                           tracker: StackTracker) throws -> MailboxFilter {
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             return try parseFilterMailboxes(buffer: &buffer, tracker: tracker)
         }
 
         // source-mbox =  filter-mailboxes *(SP filter-mailboxes)
-        func parseExtendedSearchSourceOptions_sourceMBox(buffer: inout ByteBuffer,
+        func parseExtendedSearchSourceOptions_sourceMBox(buffer: inout ParseBuffer,
                                                          tracker: StackTracker) throws -> [MailboxFilter] {
             var sources = [try parseFilterMailboxes(buffer: &buffer, tracker: tracker)]
-            while let anotherSource = try optional(buffer: &buffer,
-                                                   tracker: tracker,
-                                                   parser: parseExtendedSearchSourceOptions_spaceFilter) {
+            while let anotherSource = try ParserLibrary.optional(buffer: &buffer,
+                                                                 tracker: tracker,
+                                                                 parser: parseExtendedSearchSourceOptions_spaceFilter) {
                 sources.append(anotherSource)
             }
             return sources
         }
 
-        func parseExtendedSearchSourceOptions_scopeOptions(buffer: inout ByteBuffer,
+        func parseExtendedSearchSourceOptions_scopeOptions(buffer: inout ParseBuffer,
                                                            tracker: StackTracker) throws -> ExtendedSearchScopeOptions {
-            try fixedString(" (", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(" (", buffer: &buffer, tracker: tracker)
             let result = try parseExtendedSearchScopeOptions(buffer: &buffer, tracker: tracker)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             return result
         }
 
-        return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("IN (", buffer: &buffer, tracker: tracker)
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("IN (", buffer: &buffer, tracker: tracker)
             let sourceMbox = try parseExtendedSearchSourceOptions_sourceMBox(buffer: &buffer, tracker: tracker)
-            let scopeOptions = try optional(buffer: &buffer,
-                                            tracker: tracker,
-                                            parser: parseExtendedSearchSourceOptions_scopeOptions)
-            try fixedString(")", buffer: &buffer, tracker: tracker)
+            let scopeOptions = try ParserLibrary.optional(buffer: &buffer,
+                                                          tracker: tracker,
+                                                          parser: parseExtendedSearchSourceOptions_scopeOptions)
+            try ParserLibrary.fixedString(")", buffer: &buffer, tracker: tracker)
             if let result = ExtendedSearchSourceOptions(sourceMailbox: sourceMbox, scopeOptions: scopeOptions) {
                 return result
             } else {
@@ -2622,22 +2587,22 @@ extension GrammarParser {
     // esearch =  "ESEARCH" [SP esearch-source-opts]
     // [SP search-return-opts] SP search-program
     // Ignoring the command here.
-    static func parseExtendedSearchOptions(buffer: inout ByteBuffer,
+    static func parseExtendedSearchOptions(buffer: inout ParseBuffer,
                                            tracker: StackTracker) throws -> ExtendedSearchOptions {
-        func parseExtendedSearchOptions_sourceOptions(buffer: inout ByteBuffer,
+        func parseExtendedSearchOptions_sourceOptions(buffer: inout ParseBuffer,
                                                       tracker: StackTracker) throws -> ExtendedSearchSourceOptions {
-            try space(buffer: &buffer, tracker: tracker)
+            try ParserLibrary.space(buffer: &buffer, tracker: tracker)
             let result = try parseExtendedSearchSourceOptions(buffer: &buffer, tracker: tracker)
             return result
         }
 
-        let sourceOptions = try optional(buffer: &buffer,
-                                         tracker: tracker,
-                                         parser: parseExtendedSearchOptions_sourceOptions)
-        let returnOpts = try optional(buffer: &buffer,
-                                      tracker: tracker,
-                                      parser: self.parseSearchReturnOptions) ?? []
-        try space(buffer: &buffer, tracker: tracker)
+        let sourceOptions = try ParserLibrary.optional(buffer: &buffer,
+                                                       tracker: tracker,
+                                                       parser: parseExtendedSearchOptions_sourceOptions)
+        let returnOpts = try ParserLibrary.optional(buffer: &buffer,
+                                                    tracker: tracker,
+                                                    parser: self.parseSearchReturnOptions) ?? []
+        try ParserLibrary.space(buffer: &buffer, tracker: tracker)
         let (charset, program) = try parseSearchProgram(buffer: &buffer, tracker: tracker)
         return ExtendedSearchOptions(key: program, charset: charset, returnOptions: returnOpts, sourceOptions: sourceOptions)
     }
@@ -2645,9 +2610,9 @@ extension GrammarParser {
     // RFC 6237
     // esearch =  "ESEARCH" [SP esearch-source-opts]
     // [SP search-return-opts] SP search-program
-    static func parseExtendedSearch(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            try fixedString("ESEARCH", buffer: &buffer, tracker: tracker)
+    static func parseExtendedSearch(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            try ParserLibrary.fixedString("ESEARCH", buffer: &buffer, tracker: tracker)
             return .extendedsearch(try parseExtendedSearchOptions(buffer: &buffer, tracker: tracker))
         }
     }
@@ -2656,17 +2621,17 @@ extension GrammarParser {
 // MARK: - Helper Parsers
 
 extension GrammarParser {
-    static func parse2Digit(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
+    static func parse2Digit(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
         try self.parseNDigits(buffer: &buffer, tracker: tracker, bytes: 2)
     }
 
-    static func parse4Digit(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Int {
+    static func parse4Digit(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
         try self.parseNDigits(buffer: &buffer, tracker: tracker, bytes: 4)
     }
 
-    static func parseNDigits(buffer: inout ByteBuffer, tracker: StackTracker, bytes: Int) throws -> Int {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
-            let (num, size) = try ParserLibrary.parseUnsignedInteger(buffer: &buffer, tracker: tracker)
+    static func parseNDigits(buffer: inout ParseBuffer, tracker: StackTracker, bytes: Int) throws -> Int {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            let (num, size) = try ParserLibrary.parseUnsignedInteger(buffer: &buffer, tracker: tracker, allowLeadingZeros: true)
             guard size == bytes else {
                 throw ParserError(hint: "Expected \(bytes) digits, got \(size)")
             }
@@ -2691,126 +2656,6 @@ struct StackTracker {
         self.stackDepth += 1
         guard self.stackDepth < self.maximumStackDepth else {
             throw TooMuchRecursion(limit: self.maximumStackDepth)
-        }
-    }
-}
-
-// MARK: - Parser Library
-
-extension GrammarParser {
-    static func space(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, _ in
-
-            // need at least one readable byte
-            guard buffer.readableBytes > 0 else { throw _IncompleteMessage() }
-
-            // if there are only spaces then just consume it all and move on
-            guard let index = buffer.readableBytesView.firstIndex(where: { $0 != UInt8(ascii: " ") }) else {
-                buffer.moveReaderIndex(to: buffer.writerIndex)
-                return
-            }
-
-            // first character wasn't a space
-            guard index > buffer.readableBytesView.startIndex else {
-                throw ParserError(hint: "Expected space, found \(buffer.readableBytesView[index])")
-            }
-
-            buffer.moveReaderIndex(to: index)
-        }
-    }
-
-    static func fixedString(_ needle: String, caseSensitive: Bool = false, buffer: inout ByteBuffer, tracker: StackTracker) throws {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, _ in
-            let needleCount = needle.utf8.count
-            guard let actual = buffer.readString(length: needleCount) else {
-                guard needle.utf8.starts(with: buffer.readableBytesView, by: { $0 & 0xDF == $1 & 0xDF }) else {
-                    throw ParserError(hint: "Tried to parse \(needle) in \(String(decoding: buffer.readableBytesView, as: Unicode.UTF8.self))")
-                }
-                throw _IncompleteMessage()
-            }
-
-            assert(needle.utf8.allSatisfy { $0 & 0b1000_0000 == 0 }, "needle needs to be ASCII but \(needle) isn't")
-            if actual == needle {
-                // great, we just match
-                return
-            } else if !caseSensitive {
-                // we know this is all ASCII so we can do an ASCII case-insensitive compare here
-                guard needleCount == actual.utf8.count,
-                    actual.utf8.elementsEqual(needle.utf8, by: { ($0 & 0xDF) == ($1 & 0xDF) }) else {
-                    throw ParserError(hint: "case insensitively looking for \(needle) found \(actual)")
-                }
-                return
-            } else {
-                throw ParserError(hint: "case sensitively looking for \(needle) found \(actual)")
-            }
-        }
-    }
-
-    static func oneOf<T>(_ subParsers: [SubParser<T>], buffer: inout ByteBuffer, tracker: StackTracker, file: String = (#file), line: Int = #line) throws -> T {
-        for parser in subParsers {
-            do {
-                return try composite(buffer: &buffer, tracker: tracker, parser)
-            } catch is ParserError {
-                continue
-            }
-        }
-        throw ParserError(hint: "none of the options match", file: file, line: line)
-    }
-
-    static func optional<T>(buffer: inout ByteBuffer, tracker: StackTracker, parser: SubParser<T>) throws -> T? {
-        do {
-            return try composite(buffer: &buffer, tracker: tracker, parser)
-        } catch is ParserError {
-            return nil
-        }
-    }
-
-    static func composite<T>(buffer: inout ByteBuffer, tracker: StackTracker, _ body: SubParser<T>) throws -> T {
-        var tracker = tracker
-        try tracker.newStackFrame()
-
-        let save = buffer
-        do {
-            return try body(&buffer, tracker)
-        } catch {
-            buffer = save
-            throw error
-        }
-    }
-
-    static func newline(buffer: inout ByteBuffer, tracker: StackTracker) throws {
-        switch buffer.getInteger(at: buffer.readerIndex, as: UInt16.self) {
-        case .some(UInt16(0x0D0A /* CRLF */ )):
-            // fast path: we find CRLF
-            buffer.moveReaderIndex(forwardBy: 2)
-            return
-        case .some(let x) where UInt8(x >> 8) == UInt8(ascii: "\n"):
-            // other fast path: we find LF + some other byte
-            buffer.moveReaderIndex(forwardBy: 1)
-            return
-        case .some(let x) where UInt8(x >> 8) == UInt8(ascii: " "):
-            // found a space that we’ll skip. Some servers insert an extra space at the end.
-            try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
-                buffer.moveReaderIndex(forwardBy: 1)
-                try newline(buffer: &buffer, tracker: tracker)
-            }
-        case .none:
-            guard let first = buffer.getInteger(at: buffer.readerIndex, as: UInt8.self) else {
-                throw _IncompleteMessage()
-            }
-            switch first {
-            case UInt8(ascii: "\n"):
-                buffer.moveReaderIndex(forwardBy: 1)
-                return
-            case UInt8(ascii: "\r"):
-                throw _IncompleteMessage()
-            default:
-                // found only one byte which is neither CR nor LF.
-                throw ParserError()
-            }
-        default:
-            // found two bytes but they're neither CRLF, nor start with a NL.
-            throw ParserError()
         }
     }
 }

--- a/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
+++ b/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
@@ -16,7 +16,23 @@ import struct NIO.ByteBuffer
 
 enum ParserLibrary {}
 
-typealias SubParser<T> = (inout ByteBuffer, StackTracker) throws -> T
+struct _IncompleteMessage: Error {
+    fileprivate init() {}
+}
+
+typealias SubParser<T> = (inout ParseBuffer, StackTracker) throws -> T
+
+internal struct ParseBuffer: Hashable {
+    fileprivate var bytes: ByteBuffer
+
+    internal init(_ bytes: ByteBuffer) {
+        self.bytes = bytes
+    }
+
+    internal var readableBytes: Int {
+        self.bytes.readableBytes
+    }
+}
 
 /// An error ocurred when parsing an IMAP command or response.
 public struct ParserError: Error {
@@ -45,126 +61,274 @@ public struct TooMuchRecursion: Error {
 }
 
 extension ParserLibrary {
-    static func parseZeroOrMoreCharacters(buffer: inout ByteBuffer, tracker: StackTracker, where: ((UInt8) -> Bool)) throws -> String {
-        try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
-            let maybeFirstBad = buffer.readableBytesView.firstIndex { char in
+    static func parseZeroOrMoreCharacters(buffer: inout ParseBuffer, tracker: StackTracker, where: ((UInt8) -> Bool)) throws -> String {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
+            let maybeFirstBad = buffer.bytes.readableBytesView.firstIndex { char in
                 !`where`(char)
             }
 
             guard let firstBad = maybeFirstBad else {
                 throw _IncompleteMessage()
             }
-            return buffer.readString(length: buffer.readableBytesView.startIndex.distance(to: firstBad))!
+            return buffer.bytes.readString(length: buffer.bytes.readableBytesView.startIndex.distance(to: firstBad))!
         }
     }
 
-    static func parseOneOrMoreCharacters(buffer: inout ByteBuffer, tracker: StackTracker, where: ((UInt8) -> Bool)) throws -> String {
-        try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
-            let maybeFirstBad = buffer.readableBytesView.firstIndex { char in
+    static func parseOneOrMoreCharacters(buffer: inout ParseBuffer, tracker: StackTracker, where: ((UInt8) -> Bool)) throws -> String {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
+            let maybeFirstBad = buffer.bytes.readableBytesView.firstIndex { char in
                 !`where`(char)
             }
 
             guard let firstBad = maybeFirstBad else {
                 throw _IncompleteMessage()
             }
-            guard firstBad != buffer.readableBytesView.startIndex else {
+            guard firstBad != buffer.bytes.readableBytesView.startIndex else {
                 throw ParserError(hint: "couldn't find one or more of the required characters")
             }
-            return buffer.readString(length: buffer.readableBytesView.startIndex.distance(to: firstBad))!
+            return buffer.bytes.readString(length: buffer.bytes.readableBytesView.startIndex.distance(to: firstBad))!
         }
     }
 
-    static func parseZeroOrMoreCharactersByteBuffer(buffer: inout ByteBuffer, tracker: StackTracker, where: ((UInt8) -> Bool)) throws -> ByteBuffer {
-        try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
-            let maybeFirstBad = buffer.readableBytesView.firstIndex { char in
+    static func parseZeroOrMoreCharactersByteBuffer(buffer: inout ParseBuffer, tracker: StackTracker, where: ((UInt8) -> Bool)) throws -> ByteBuffer {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
+            let maybeFirstBad = buffer.bytes.readableBytesView.firstIndex { char in
                 !`where`(char)
             }
 
             guard let firstBad = maybeFirstBad else {
                 throw _IncompleteMessage()
             }
-            return buffer.readSlice(length: buffer.readableBytesView.startIndex.distance(to: firstBad))!
+            return buffer.bytes.readSlice(length: buffer.bytes.readableBytesView.startIndex.distance(to: firstBad))!
         }
     }
 
-    static func parseOneOrMoreCharactersByteBuffer(buffer: inout ByteBuffer, tracker: StackTracker, where: ((UInt8) -> Bool)) throws -> ByteBuffer {
-        try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
-            let maybeFirstBad = buffer.readableBytesView.firstIndex { char in
+    static func parseOneOrMoreCharactersByteBuffer(buffer: inout ParseBuffer, tracker: StackTracker, where: ((UInt8) -> Bool)) throws -> ByteBuffer {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
+            let maybeFirstBad = buffer.bytes.readableBytesView.firstIndex { char in
                 !`where`(char)
             }
 
             guard let firstBad = maybeFirstBad else {
                 throw _IncompleteMessage()
             }
-            guard firstBad != buffer.readableBytesView.startIndex else {
+            guard firstBad != buffer.bytes.readableBytesView.startIndex else {
                 throw ParserError()
             }
-            return buffer.readSlice(length: buffer.readableBytesView.startIndex.distance(to: firstBad))!
+            return buffer.bytes.readSlice(length: buffer.bytes.readableBytesView.startIndex.distance(to: firstBad))!
         }
     }
 
-    static func parseOneOrMore<T>(buffer: inout ByteBuffer, tracker: StackTracker, parser: SubParser<T>) throws -> [T] {
+    static func parseOneOrMore<T>(buffer: inout ParseBuffer, tracker: StackTracker, parser: SubParser<T>) throws -> [T] {
         var parsed: [T] = []
         try Self.parseOneOrMore(buffer: &buffer, into: &parsed, tracker: tracker, parser: parser)
         return parsed
     }
 
-    static func parseOneOrMore<T>(buffer: inout ByteBuffer, into parsed: inout [T], tracker: StackTracker, parser: SubParser<T>) throws {
-        try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+    static func parseOneOrMore<T>(buffer: inout ParseBuffer, into parsed: inout [T], tracker: StackTracker, parser: SubParser<T>) throws {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             parsed.append(try parser(&buffer, tracker))
-            while let next = try GrammarParser.optional(buffer: &buffer, tracker: tracker, parser: parser) {
+            while let next = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parser) {
                 parsed.append(next)
             }
         }
     }
 
-    static func parseZeroOrMore<T>(buffer: inout ByteBuffer, into parsed: inout [T], tracker: StackTracker, parser: SubParser<T>) throws {
-        try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            while let next = try GrammarParser.optional(buffer: &buffer, tracker: tracker, parser: parser) {
+    static func parseZeroOrMore<T>(buffer: inout ParseBuffer, into parsed: inout [T], tracker: StackTracker, parser: SubParser<T>) throws {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            while let next = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parser) {
                 parsed.append(next)
             }
         }
     }
 
-    static func parseZeroOrMore<K, V>(buffer: inout ByteBuffer, into keyValues: inout KeyValues<K, V>, tracker: StackTracker, parser: SubParser<(K, V)>) throws {
-        try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            while let next = try GrammarParser.optional(buffer: &buffer, tracker: tracker, parser: parser) {
+    static func parseZeroOrMore<K, V>(buffer: inout ParseBuffer, into keyValues: inout KeyValues<K, V>, tracker: StackTracker, parser: SubParser<(K, V)>) throws {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            while let next = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parser) {
                 keyValues.append(next)
             }
         }
     }
 
-    static func parseZeroOrMore<K, V>(buffer: inout ByteBuffer, into keyValues: inout KeyValues<K, V>, tracker: StackTracker, parser: SubParser<KeyValue<K, V>>) throws {
-        try GrammarParser.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
-            while let next = try GrammarParser.optional(buffer: &buffer, tracker: tracker, parser: parser) {
+    static func parseZeroOrMore<K, V>(buffer: inout ParseBuffer, into keyValues: inout KeyValues<K, V>, tracker: StackTracker, parser: SubParser<KeyValue<K, V>>) throws {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            while let next = try ParserLibrary.optional(buffer: &buffer, tracker: tracker, parser: parser) {
                 keyValues.append(next)
             }
         }
     }
 
-    static func parseZeroOrMore<T>(buffer: inout ByteBuffer, tracker: StackTracker, parser: SubParser<T>) throws -> [T] {
+    static func parseZeroOrMore<T>(buffer: inout ParseBuffer, tracker: StackTracker, parser: SubParser<T>) throws -> [T] {
         var parsed: [T] = []
         try Self.parseZeroOrMore(buffer: &buffer, into: &parsed, tracker: tracker, parser: parser)
         return parsed
     }
 
-    static func parseUnsignedInteger(buffer: inout ByteBuffer, tracker: StackTracker) throws -> (number: Int, bytesConsumed: Int) {
-        let string = try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char in
-            char >= UInt8(ascii: "0") && char <= UInt8(ascii: "9")
+    static func parseUnsignedInteger(buffer: inout ParseBuffer, tracker: StackTracker, allowLeadingZeros: Bool = false) throws -> (number: Int, bytesConsumed: Int) {
+        let largeInt = try ParserLibrary.parseUInt64(buffer: &buffer, tracker: tracker, allowLeadingZeros: allowLeadingZeros)
+        if let int = Int(exactly: largeInt.number) {
+            return (number: int, bytesConsumed: largeInt.bytesConsumed)
+        } else {
+            throw ParserError(hint: "integer too large")
         }
-        guard let int = Int(string) else {
-            throw ParserError(hint: "\(string) is not a number")
-        }
-        return (int, string.count)
     }
 
-    static func parseUInt64(buffer: inout ByteBuffer, tracker: StackTracker) throws -> (number: UInt64, bytesConsumed: Int) {
-        let string = try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char in
-            char >= UInt8(ascii: "0") && char <= UInt8(ascii: "9")
+    static func parseUInt64(buffer: inout ParseBuffer, tracker: StackTracker, allowLeadingZeros: Bool = false) throws -> (number: UInt64, bytesConsumed: Int) {
+        return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            let string = try ParserLibrary.parseOneOrMoreCharacters(buffer: &buffer, tracker: tracker) { char in
+                char >= UInt8(ascii: "0") && char <= UInt8(ascii: "9")
+            }
+            guard let int = UInt64(string) else {
+                throw ParserError(hint: "\(string) is not a number")
+            }
+            if !allowLeadingZeros, string.utf8.first! == UInt8(ascii: "0") {
+                throw ParserError(hint: "starts with 0")
+            }
+            return (int, string.count)
         }
-        guard let int = UInt64(string) else {
-            throw ParserError(hint: "\(string) is not a number")
+    }
+
+    static func space(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
+
+            // need at least one readable byte
+            guard buffer.bytes.readableBytes > 0 else { throw _IncompleteMessage() }
+
+            // if there are only spaces then just consume it all and move on
+            guard let index = buffer.bytes.readableBytesView.firstIndex(where: { $0 != UInt8(ascii: " ") }) else {
+                buffer.bytes.moveReaderIndex(to: buffer.bytes.writerIndex)
+                return
+            }
+
+            // first character wasn't a space
+            guard index > buffer.bytes.readableBytesView.startIndex else {
+                throw ParserError(hint: "Expected space, found \(buffer.bytes.readableBytesView[index])")
+            }
+
+            buffer.bytes.moveReaderIndex(to: index)
         }
-        return (int, string.count)
+    }
+
+    static func fixedString(_ needle: String, caseSensitive: Bool = false, buffer: inout ParseBuffer, tracker: StackTracker) throws {
+        try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
+            let needleCount = needle.utf8.count
+            guard let actual = buffer.bytes.readString(length: needleCount) else {
+                guard needle.utf8.starts(with: buffer.bytes.readableBytesView, by: { $0 & 0xDF == $1 & 0xDF }) else {
+                    throw ParserError(hint: "Tried to parse \(needle) in \(String(decoding: buffer.bytes.readableBytesView, as: Unicode.UTF8.self))")
+                }
+                throw _IncompleteMessage()
+            }
+
+            assert(needle.utf8.allSatisfy { $0 & 0b1000_0000 == 0 }, "needle needs to be ASCII but \(needle) isn't")
+            if actual == needle {
+                // great, we just match
+                return
+            } else if !caseSensitive {
+                // we know this is all ASCII so we can do an ASCII case-insensitive compare here
+                guard needleCount == actual.utf8.count,
+                    actual.utf8.elementsEqual(needle.utf8, by: { ($0 & 0xDF) == ($1 & 0xDF) }) else {
+                    throw ParserError(hint: "case insensitively looking for \(needle) found \(actual)")
+                }
+                return
+            } else {
+                throw ParserError(hint: "case sensitively looking for \(needle) found \(actual)")
+            }
+        }
+    }
+
+    static func oneOf<T>(_ subParsers: [SubParser<T>], buffer: inout ParseBuffer, tracker: StackTracker, file: String = (#file), line: Int = #line) throws -> T {
+        for parser in subParsers {
+            do {
+                return try ParserLibrary.composite(buffer: &buffer, tracker: tracker, parser)
+            } catch is ParserError {
+                continue
+            }
+        }
+        throw ParserError(hint: "none of the options match", file: file, line: line)
+    }
+
+    static func optional<T>(buffer: inout ParseBuffer, tracker: StackTracker, parser: SubParser<T>) throws -> T? {
+        do {
+            return try ParserLibrary.composite(buffer: &buffer, tracker: tracker, parser)
+        } catch is ParserError {
+            return nil
+        }
+    }
+
+    static func composite<T>(buffer: inout ParseBuffer, tracker: StackTracker, _ body: SubParser<T>) throws -> T {
+        var tracker = tracker
+        try tracker.newStackFrame()
+
+        let save = buffer
+        do {
+            return try body(&buffer, tracker)
+        } catch {
+            buffer = save
+            throw error
+        }
+    }
+
+    static func newline(buffer: inout ParseBuffer, tracker: StackTracker) throws {
+        switch buffer.bytes.getInteger(at: buffer.bytes.readerIndex, as: UInt16.self) {
+        case .some(UInt16(0x0D0A /* CRLF */ )):
+            // fast path: we find CRLF
+            buffer.bytes.moveReaderIndex(forwardBy: 2)
+            return
+        case .some(let x) where UInt8(x >> 8) == UInt8(ascii: "\n"):
+            // other fast path: we find LF + some other byte
+            buffer.bytes.moveReaderIndex(forwardBy: 1)
+            return
+        case .some(let x) where UInt8(x >> 8) == UInt8(ascii: " "):
+            // found a space that we’ll skip. Some servers insert an extra space at the end.
+            try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
+                buffer.bytes.moveReaderIndex(forwardBy: 1)
+                try ParserLibrary.newline(buffer: &buffer, tracker: tracker)
+            }
+        case .none:
+            guard let first = buffer.bytes.getInteger(at: buffer.bytes.readerIndex, as: UInt8.self) else {
+                throw _IncompleteMessage()
+            }
+            switch first {
+            case UInt8(ascii: "\n"):
+                buffer.bytes.moveReaderIndex(forwardBy: 1)
+                return
+            case UInt8(ascii: "\r"):
+                throw _IncompleteMessage()
+            default:
+                // found only one byte which is neither CR nor LF.
+                throw ParserError()
+            }
+        default:
+            // found two bytes but they're neither CRLF, nor start with a NL.
+            throw ParserError()
+        }
+    }
+
+    static func parseByte(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UInt8 {
+        if let byte = buffer.bytes.readInteger(as: UInt8.self) {
+            return byte
+        } else {
+            throw _IncompleteMessage()
+        }
+    }
+
+    static func parseBytes(buffer: inout ParseBuffer, tracker: StackTracker, length: Int) throws -> ByteBuffer {
+        if let bytes = buffer.bytes.readSlice(length: length) {
+            return bytes
+        } else {
+            throw _IncompleteMessage()
+        }
+    }
+
+    static func parseBytes(buffer: inout ParseBuffer, tracker: StackTracker, upTo maxLength: Int) throws -> ByteBuffer {
+        guard buffer.readableBytes > 0 else {
+            throw _IncompleteMessage()
+        }
+
+        if buffer.bytes.readableBytes >= maxLength {
+            return buffer.bytes.readSlice(length: maxLength)! // safe, those bytes are readable.
+        } else {
+            return buffer.bytes.readSlice(length: buffer.bytes.readableBytes)! // safe, those bytes are readable.
+        }
     }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/ContinuationRequestTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/ContinuationRequestTests.swift
@@ -56,7 +56,7 @@ extension ContinuationRequestTests {
 
     func testParse() {
         for (expected, input, line) in fixtures {
-            var buffer = ByteBuffer(string: input + "a")
+            var buffer = ParseBuffer(ByteBuffer(string: input + "a"))
             do {
                 let cont = try GrammarParser.parseContinuationRequest(buffer: &buffer, tracker: StackTracker(maximumParserStackDepth: 100))
                 XCTAssertEqual(cont, expected, "parse", line: line)

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Append+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Append+Tests.swift
@@ -44,7 +44,7 @@ extension GrammarParser_Append_Tests {
     }
 
     func testNegativeAppendDataDoesNotParse() {
-        TestUtilities.withBuffer("{-1}\r\n", shouldRemainUnchanged: true) { buffer in
+        TestUtilities.withParseBuffer("{-1}\r\n", shouldRemainUnchanged: true) { buffer in
             XCTAssertThrowsError(try GrammarParser.parseAppendData(buffer: &buffer, tracker: .testTracker)) { error in
                 XCTAssertNotNil(error as? ParserError)
             }
@@ -53,7 +53,7 @@ extension GrammarParser_Append_Tests {
 
     func testHugeAppendDataDoesNotParse() {
         let oneAfterMaxInt = "\(UInt(Int.max) + 1)"
-        TestUtilities.withBuffer("{\(oneAfterMaxInt)}\r\n", shouldRemainUnchanged: true) { buffer in
+        TestUtilities.withParseBuffer("{\(oneAfterMaxInt)}\r\n", shouldRemainUnchanged: true) { buffer in
             XCTAssertThrowsError(try GrammarParser.parseAppendData(buffer: &buffer, tracker: .testTracker)) { error in
                 XCTAssertNotNil(error as? ParserError)
             }

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Body+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Body+Tests.swift
@@ -42,7 +42,7 @@ extension GrammarParser_Body_Tests {
 
 extension GrammarParser_Body_Tests {
     func testParseBodyFieldDsp_some() {
-        TestUtilities.withBuffer(#"("astring" ("f1" "v1"))"#) { (buffer) in
+        TestUtilities.withParseBuffer(#"("astring" ("f1" "v1"))"#) { (buffer) in
             let dsp = try GrammarParser.parseBodyFieldDsp(buffer: &buffer, tracker: .testTracker)
             XCTAssertNotNil(dsp)
             XCTAssertEqual(dsp, BodyStructure.Disposition(kind: "astring", parameters: ["f1": "v1"]))
@@ -50,7 +50,7 @@ extension GrammarParser_Body_Tests {
     }
 
     func testParseBodyFieldDsp_none() {
-        TestUtilities.withBuffer(#"NIL"#, terminator: "") { (buffer) in
+        TestUtilities.withParseBuffer(#"NIL"#, terminator: "") { (buffer) in
             let string = try GrammarParser.parseBodyFieldDsp(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(string, .none)
         }
@@ -77,7 +77,7 @@ extension GrammarParser_Body_Tests {
     }
 
     func testParseBodyEncoding_invalid_missingQuotes() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "other")
+        var buffer = TestUtilities.makeParseBuffer(for: "other")
         XCTAssertThrowsError(try GrammarParser.parseBodyEncoding(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
@@ -118,7 +118,7 @@ extension GrammarParser_Body_Tests {
     }
 
     func testParseBodyFieldParam_invalid_oneObject() {
-        var buffer = TestUtilities.createTestByteBuffer(for: #"("p1" "#)
+        var buffer = TestUtilities.makeParseBuffer(for: #"("p1" "#)
         XCTAssertThrowsError(try GrammarParser.parseBodyFieldParam(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage)
         }
@@ -129,7 +129,7 @@ extension GrammarParser_Body_Tests {
 
 extension GrammarParser_Body_Tests {
     func testParseBodyFields_valid() {
-        TestUtilities.withBuffer(#"("f1" "v1") "id" "desc" "8BIT" 1234"#, terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer(#"("f1" "v1") "id" "desc" "8BIT" 1234"#, terminator: " ") { (buffer) in
             let result = try GrammarParser.parseBodyFields(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(result.parameters, ["f1": "v1"])
             XCTAssertEqual(result.id, "id")

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Commands+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Commands+Tests.swift
@@ -22,7 +22,7 @@ class GrammarParser_Commands_Tests: XCTestCase, _ParserTestHelpers {}
 
 extension GrammarParser_Commands_Tests {
     func testParseCommand_valid_any() {
-        TestUtilities.withBuffer("a1 NOOP", terminator: "\r\n") { (buffer) in
+        TestUtilities.withParseBuffer("a1 NOOP", terminator: "\r\n") { (buffer) in
             let result = try GrammarParser.parseCommand(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(result.tag, "a1")
             XCTAssertEqual(result.command, .noop)
@@ -30,7 +30,7 @@ extension GrammarParser_Commands_Tests {
     }
 
     func testParseCommand_valid_auth() {
-        TestUtilities.withBuffer("a1 CREATE \"mailbox\"", terminator: "\r\n") { (buffer) in
+        TestUtilities.withParseBuffer("a1 CREATE \"mailbox\"", terminator: "\r\n") { (buffer) in
             let result = try GrammarParser.parseCommand(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(result.tag, "a1")
             XCTAssertEqual(result.command, .create(MailboxName("mailbox"), []))
@@ -38,7 +38,7 @@ extension GrammarParser_Commands_Tests {
     }
 
     func testParseCommand_valid_nonauth() {
-        TestUtilities.withBuffer("a1 STARTTLS", terminator: "\r\n") { (buffer) in
+        TestUtilities.withParseBuffer("a1 STARTTLS", terminator: "\r\n") { (buffer) in
             let result = try GrammarParser.parseCommand(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(result.tag, "a1")
             XCTAssertEqual(result.command, .starttls)
@@ -46,7 +46,7 @@ extension GrammarParser_Commands_Tests {
     }
 
     func testParseCommand_valid_select() {
-        TestUtilities.withBuffer("a1 CHECK", terminator: "\r\n") { (buffer) in
+        TestUtilities.withParseBuffer("a1 CHECK", terminator: "\r\n") { (buffer) in
             let result = try GrammarParser.parseCommand(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(result.tag, "a1")
             XCTAssertEqual(result.command, .check)

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Date+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Date+Tests.swift
@@ -22,28 +22,28 @@ class GrammarParser_Date_Tests: XCTestCase, _ParserTestHelpers {}
 
 extension GrammarParser_Date_Tests {
     func testDate_valid_plain() {
-        TestUtilities.withBuffer("25-Jun-1994", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("25-Jun-1994", terminator: " ") { (buffer) in
             let day = try GrammarParser.parseDate(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(day, IMAPDate(year: 1994, month: 6, day: 25))
         }
     }
 
     func testDate_valid_quoted() {
-        TestUtilities.withBuffer("\"25-Jun-1994\"") { (buffer) in
+        TestUtilities.withParseBuffer("\"25-Jun-1994\"") { (buffer) in
             let day = try GrammarParser.parseDate(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(day, IMAPDate(year: 1994, month: 6, day: 25))
         }
     }
 
     func testDate_invalid_quoted_missing_end_quote() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "\"25-Jun-1994 ")
+        var buffer = TestUtilities.makeParseBuffer(for: "\"25-Jun-1994 ")
         XCTAssertThrowsError(try GrammarParser.parseDate(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
     }
 
     func testDate_invalid_quoted_missing_date() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "\"\"")
+        var buffer = TestUtilities.makeParseBuffer(for: "\"\"")
         XCTAssertThrowsError(try GrammarParser.parseDate(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
@@ -54,35 +54,35 @@ extension GrammarParser_Date_Tests {
 
 extension GrammarParser_Date_Tests {
     func testDateDay_valid_single() {
-        TestUtilities.withBuffer("1", terminator: "\r") { (buffer) in
+        TestUtilities.withParseBuffer("1", terminator: "\r") { (buffer) in
             let day = try GrammarParser.parseDateDay(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(day, 1)
         }
     }
 
     func testDateDay_valid_double() {
-        TestUtilities.withBuffer("12", terminator: "\r") { (buffer) in
+        TestUtilities.withParseBuffer("12", terminator: "\r") { (buffer) in
             let day = try GrammarParser.parseDateDay(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(day, 12)
         }
     }
 
     func testDateDay_valid_single_followon() {
-        TestUtilities.withBuffer("1", terminator: "a") { (buffer) in
+        TestUtilities.withParseBuffer("1", terminator: "a") { (buffer) in
             let day = try GrammarParser.parseDateDay(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(day, 1)
         }
     }
 
     func testDateDay_invalid() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "a")
+        var buffer = TestUtilities.makeParseBuffer(for: "a")
         XCTAssertThrowsError(try GrammarParser.parseDateDay(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
     }
 
     func testDateDay_invalid_long() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "1234 ")
+        var buffer = TestUtilities.makeParseBuffer(for: "1234 ")
         XCTAssertThrowsError(try GrammarParser.parseDateDay(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
@@ -93,28 +93,28 @@ extension GrammarParser_Date_Tests {
 
 extension GrammarParser_Date_Tests {
     func testDateMonth_valid() {
-        TestUtilities.withBuffer("jun", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("jun", terminator: " ") { (buffer) in
             let month = try GrammarParser.parseDateMonth(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(month, 6)
         }
     }
 
     func testDateMonth_valid_mixedCase() {
-        TestUtilities.withBuffer("JUn", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("JUn", terminator: " ") { (buffer) in
             let month = try GrammarParser.parseDateMonth(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(month, 6)
         }
     }
 
     func testDateMonth_invalid_incomplete() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "ju")
+        var buffer = TestUtilities.makeParseBuffer(for: "ju")
         XCTAssertThrowsError(try GrammarParser.parseDateMonth(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage)
         }
     }
 
     func testDateMonth_invalid() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "aaa ")
+        var buffer = TestUtilities.makeParseBuffer(for: "aaa ")
         XCTAssertThrowsError(try GrammarParser.parseDateMonth(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
@@ -125,14 +125,14 @@ extension GrammarParser_Date_Tests {
 
 extension GrammarParser_Date_Tests {
     func testDateText_valid() {
-        TestUtilities.withBuffer("25-Jun-1994", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("25-Jun-1994", terminator: " ") { (buffer) in
             let date = try GrammarParser.parseDateText(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(date, IMAPDate(year: 1994, month: 6, day: 25))
         }
     }
 
     func testDateText_invalid_missing_year() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "25-Jun-")
+        var buffer = TestUtilities.makeParseBuffer(for: "25-Jun-")
         XCTAssertThrowsError(try GrammarParser.parseDateText(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage)
         }
@@ -145,7 +145,7 @@ extension GrammarParser_Date_Tests {
     // NOTE: Only a few sample failure cases tested, more will be handled by the `ByteToMessageDecoder`
 
     func testparseInternalDate_valid() {
-        TestUtilities.withBuffer(#""25-Jun-1994 01:02:03 +1020""#) { (buffer) in
+        TestUtilities.withParseBuffer(#""25-Jun-1994 01:02:03 +1020""#) { (buffer) in
             let internalDate = try GrammarParser.parseInternalDate(buffer: &buffer, tracker: .testTracker)
             let c = internalDate.components
             XCTAssertEqual(c.year, 1994)
@@ -156,7 +156,7 @@ extension GrammarParser_Date_Tests {
             XCTAssertEqual(c.second, 3)
             XCTAssertEqual(c.zoneMinutes, 620)
         }
-        TestUtilities.withBuffer(#""01-Jan-1900 00:00:00 -1559""#) { (buffer) in
+        TestUtilities.withParseBuffer(#""01-Jan-1900 00:00:00 -1559""#) { (buffer) in
             let internalDate = try GrammarParser.parseInternalDate(buffer: &buffer, tracker: .testTracker)
             let c = internalDate.components
             XCTAssertEqual(c.year, 1900)
@@ -167,7 +167,7 @@ extension GrammarParser_Date_Tests {
             XCTAssertEqual(c.second, 0)
             XCTAssertEqual(c.zoneMinutes, -959)
         }
-        TestUtilities.withBuffer(#""31-Dec-2579 23:59:59 +1559""#) { (buffer) in
+        TestUtilities.withParseBuffer(#""31-Dec-2579 23:59:59 +1559""#) { (buffer) in
             let internalDate = try GrammarParser.parseInternalDate(buffer: &buffer, tracker: .testTracker)
             let c = internalDate.components
             XCTAssertEqual(c.year, 2579)
@@ -181,29 +181,29 @@ extension GrammarParser_Date_Tests {
     }
 
     func testparseInternalDate__invalid_incomplete() {
-        var buffer = #""25-Jun-1994 01"# as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: #""25-Jun-1994 01"#)
         XCTAssertThrowsError(try GrammarParser.parseInternalDate(buffer: &buffer, tracker: .testTracker)) { error in
             XCTAssertTrue(error is _IncompleteMessage)
         }
     }
 
     func testparseInternalDate__invalid_missing_space() {
-        var buffer = #""25-Jun-199401:02:03+1020""# as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: #""25-Jun-199401:02:03+1020""#)
         XCTAssertThrowsError(try GrammarParser.parseInternalDate(buffer: &buffer, tracker: .testTracker)) { error in
             XCTAssert(error is ParserError)
         }
     }
 
     func testparseInternalDate__invalid_timeZone() {
-        var buffer = TestUtilities.createTestByteBuffer(for: #""25-Jun-1994 01:02:03 +12345678\n""#)
+        var buffer = TestUtilities.makeParseBuffer(for: #""25-Jun-1994 01:02:03 +12345678\n""#)
         XCTAssertThrowsError(try GrammarParser.parseInternalDate(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError, "e has type \(e)")
         }
-        buffer = TestUtilities.createTestByteBuffer(for: #""25-Jun-1994 01:02:03 +12""#)
+        buffer = TestUtilities.makeParseBuffer(for: #""25-Jun-1994 01:02:03 +12""#)
         XCTAssertThrowsError(try GrammarParser.parseInternalDate(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError, "e has type \(e)")
         }
-        buffer = TestUtilities.createTestByteBuffer(for: #""25-Jun-1994 01:02:03 abc""#)
+        buffer = TestUtilities.makeParseBuffer(for: #""25-Jun-1994 01:02:03 abc""#)
         XCTAssertThrowsError(try GrammarParser.parseInternalDate(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError, "e has type \(e)")
         }

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
@@ -144,7 +144,7 @@ extension GrammarParser_Envelope_Tests {
 
 extension GrammarParser_Envelope_Tests {
     func testParseEnvelopeTo_valid() {
-        TestUtilities.withBuffer(#"("date" "subject" (("name1" "adl1" "mailbox1" "host1")) (("name2" "adl2" "mailbox2" "host2")) (("name3" "adl3" "mailbox3" "host3")) (("name4" "adl4" "mailbox4" "host4")) (("name5" "adl5" "mailbox5" "host5")) (("name6" "adl6" "mailbox6" "host6")) "someone" "messageid")"#) { (buffer) in
+        TestUtilities.withParseBuffer(#"("date" "subject" (("name1" "adl1" "mailbox1" "host1")) (("name2" "adl2" "mailbox2" "host2")) (("name3" "adl3" "mailbox3" "host3")) (("name4" "adl4" "mailbox4" "host4")) (("name5" "adl5" "mailbox5" "host5")) (("name6" "adl6" "mailbox6" "host6")) "someone" "messageid")"#) { (buffer) in
             let envelope = try GrammarParser.parseEnvelope(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(envelope.date, "date")
             XCTAssertEqual(envelope.subject, "subject")

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+List+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+List+Tests.swift
@@ -41,7 +41,7 @@ extension GrammarParser_List_Tests {
         let invalid: Set<UInt8> = Set(UInt8.min ... UInt8.max).subtracting(valid)
 
         for v in valid {
-            var buffer = TestUtilities.createTestByteBuffer(for: [v])
+            var buffer = TestUtilities.makeParseBuffer(for: String(decoding: [v], as: UTF8.self))
             do {
                 let str = try GrammarParser.parseListWildcards(buffer: &buffer, tracker: .testTracker)
                 XCTAssertEqual(str[str.startIndex], Character(Unicode.Scalar(v)))
@@ -51,7 +51,7 @@ extension GrammarParser_List_Tests {
             }
         }
         for v in invalid {
-            var buffer = TestUtilities.createTestByteBuffer(for: [v])
+            var buffer = TestUtilities.makeParseBuffer(for: String(decoding: [v], as: UTF8.self))
             XCTAssertThrowsError(try GrammarParser.parseListWildcards(buffer: &buffer, tracker: .testTracker)) { e in
                 XCTAssertTrue(e is ParserError)
             }

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Mailbox+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Mailbox+Tests.swift
@@ -93,14 +93,14 @@ extension GrammarParser_Mailbox_Tests {
     }
 
     func testParseMailboxList_invalid_character_incomplete() {
-        var buffer = "() \"" as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: "() \"")
         XCTAssertThrowsError(try GrammarParser.parseMailboxList(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage)
         }
     }
 
     func testParseMailboxList_invalid_character() {
-        var buffer = "() \"\\\" inbox" as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: "() \"\\\" inbox")
         XCTAssertThrowsError(try GrammarParser.parseMailboxList(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Search+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Search+Tests.swift
@@ -151,7 +151,7 @@ extension GrammarParser_Search_Tests {
     }
 
     func testParseSearchKey_array_none_invalid() {
-        var buffer = "()" as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: "()")
         XCTAssertThrowsError(try GrammarParser.parseSearchKey(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Sequence.swift
@@ -29,9 +29,9 @@ extension GrammarParser_Sequence_Tests {
                 ("10", " ", 10, #line),
             ],
             parserErrorInputs: [
-                ("*", "", #line),
-                ("0", "", #line),
-                ("012", "", #line),
+                ("*", " ", #line),
+                ("0", " ", #line),
+                ("012", " ", #line),
             ],
             incompleteMessageInputs: [
                 ("", "", #line),

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -32,18 +32,18 @@ protocol _ParserTestHelpers {}
 final class ParserUnitTests: XCTestCase, _ParserTestHelpers {}
 
 extension _ParserTestHelpers {
-    private func iterateTestInputs_generic<T: Equatable>(_ inputs: [(String, String, T, UInt)], testFunction: (inout ByteBuffer, StackTracker) throws -> T) {
+    private func iterateTestInputs_generic<T: Equatable>(_ inputs: [(String, String, T, UInt)], testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
         for (input, terminator, expected, line) in inputs {
-            TestUtilities.withBuffer(input, terminator: terminator, shouldRemainUnchanged: false, file: (#file), line: line) { (buffer) in
+            TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: false, file: (#file), line: line) { (buffer) in
                 let testValue = try testFunction(&buffer, .testTracker)
                 XCTAssertEqual(testValue, expected, line: line)
             }
         }
     }
 
-    private func iterateInvalidTestInputs_ParserError_generic<T: Equatable>(_ inputs: [(String, String, UInt)], testFunction: (inout ByteBuffer, StackTracker) throws -> T) {
+    private func iterateInvalidTestInputs_ParserError_generic<T: Equatable>(_ inputs: [(String, String, UInt)], testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
         for (input, terminator, line) in inputs {
-            TestUtilities.withBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: (#file), line: line) { (buffer) in
+            TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: (#file), line: line) { (buffer) in
                 XCTAssertThrowsError(try testFunction(&buffer, .testTracker), line: line) { e in
                     XCTAssertTrue(e is ParserError, "Expected ParserError, got \(e)", line: line)
                 }
@@ -51,9 +51,9 @@ extension _ParserTestHelpers {
         }
     }
 
-    private func iterateInvalidTestInputs_IncompleteMessage_generic<T: Equatable>(_ inputs: [(String, String, UInt)], testFunction: (inout ByteBuffer, StackTracker) throws -> T) {
+    private func iterateInvalidTestInputs_IncompleteMessage_generic<T: Equatable>(_ inputs: [(String, String, UInt)], testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
         for (input, terminator, line) in inputs {
-            TestUtilities.withBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: (#file), line: line) { (buffer) in
+            TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: (#file), line: line) { (buffer) in
                 XCTAssertThrowsError(try testFunction(&buffer, .testTracker), line: line) { e in
                     XCTAssertTrue(e is _IncompleteMessage, "Expected IncompleteMessage, got \(e)", line: line)
                 }
@@ -61,17 +61,17 @@ extension _ParserTestHelpers {
         }
     }
 
-    private func iterateTestInputs(_ inputs: [(String, String, UInt)], testFunction: (inout ByteBuffer, StackTracker) throws -> Void) {
+    private func iterateTestInputs(_ inputs: [(String, String, UInt)], testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
         for (input, terminator, line) in inputs {
-            TestUtilities.withBuffer(input, terminator: terminator, shouldRemainUnchanged: false, file: (#file), line: line) { (buffer) in
+            TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: false, file: (#file), line: line) { (buffer) in
                 try testFunction(&buffer, .testTracker)
             }
         }
     }
 
-    private func iterateInvalidTestInputs_ParserError(_ inputs: [(String, String, UInt)], testFunction: (inout ByteBuffer, StackTracker) throws -> Void) {
+    private func iterateInvalidTestInputs_ParserError(_ inputs: [(String, String, UInt)], testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
         for (input, terminator, line) in inputs {
-            TestUtilities.withBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: (#file), line: line) { (buffer) in
+            TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: (#file), line: line) { (buffer) in
                 XCTAssertThrowsError(try testFunction(&buffer, .testTracker), line: line) { e in
                     XCTAssertTrue(e is ParserError, "Expected ParserError, got \(e)", line: line)
                 }
@@ -79,9 +79,9 @@ extension _ParserTestHelpers {
         }
     }
 
-    private func iterateInvalidTestInputs_IncompleteMessage(_ inputs: [(String, String, UInt)], testFunction: (inout ByteBuffer, StackTracker) throws -> Void) {
+    private func iterateInvalidTestInputs_IncompleteMessage(_ inputs: [(String, String, UInt)], testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
         for (input, terminator, line) in inputs {
-            TestUtilities.withBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: (#file), line: line) { (buffer) in
+            TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: (#file), line: line) { (buffer) in
                 XCTAssertThrowsError(try testFunction(&buffer, .testTracker), line: line) { e in
                     XCTAssertTrue(e is _IncompleteMessage, "Expected IncompleteMessage, got \(e)", line: line)
                 }
@@ -95,7 +95,7 @@ extension _ParserTestHelpers {
     /// - parameter parserErrorInputs: An array of (Input, Terminator, ExectedResult, Line). These inputs should fail by throwing a `ParserError`.
     /// - parameter incompleteMessageInputs: An array of (Input, Terminator, ExectedResult, Line). These inputs should fail by throwing an `_IncompleteMessage`.
     func iterateTests<T: Equatable>(
-        testFunction: (inout ByteBuffer, StackTracker) throws -> T,
+        testFunction: (inout ParseBuffer, StackTracker) throws -> T,
         validInputs: [(String, String, T, UInt)],
         parserErrorInputs: [(String, String, UInt)],
         incompleteMessageInputs: [(String, String, UInt)]
@@ -111,7 +111,7 @@ extension _ParserTestHelpers {
     /// - parameter parserErrorInputs: An array of (Input, Terminator, ExectedResult, Line). These inputs should fail by throwing a `ParserError`.
     /// - parameter incompleteMessageInputs: An array of (Input, Terminator, ExectedResult, Line). These inputs should fail by throwing an `_IncompleteMessage`.
     func iterateTests(
-        testFunction: (inout ByteBuffer, StackTracker) throws -> Void,
+        testFunction: (inout ParseBuffer, StackTracker) throws -> Void,
         validInputs: [(String, String, UInt)],
         parserErrorInputs: [(String, String, UInt)],
         incompleteMessageInputs: [(String, String, UInt)]
@@ -401,21 +401,21 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testAtom_valid() {
-        TestUtilities.withBuffer("hello", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("hello", terminator: " ") { (buffer) in
             let atom = try GrammarParser.parseAtom(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(atom, "hello")
         }
     }
 
     func testAtom_invalid_incomplete() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "hello")
+        var buffer = TestUtilities.makeParseBuffer(for: "hello")
         XCTAssertThrowsError(try GrammarParser.parseAtom(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage)
         }
     }
 
     func testAtom_invalid_short() {
-        var buffer = TestUtilities.createTestByteBuffer(for: " ")
+        var buffer = TestUtilities.makeParseBuffer(for: " ")
         XCTAssertThrowsError(try GrammarParser.parseAtom(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
@@ -497,14 +497,14 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testParseBase64Terminal_valid_short() {
-        TestUtilities.withBuffer("YWFh", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("YWFh", terminator: " ") { (buffer) in
             let result = try GrammarParser.parseBase64(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(result, "aaa")
         }
     }
 
     func testParseBase64Terminal_valid_short_terminal() {
-        TestUtilities.withBuffer("YQ==", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("YQ==", terminator: " ") { (buffer) in
             let result = try GrammarParser.parseBase64(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(result, "a")
         }
@@ -530,7 +530,7 @@ extension ParserUnitTests {
     }
 
     func testCapability_invalid_empty() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "")
+        var buffer = TestUtilities.makeParseBuffer(for: "")
         XCTAssertThrowsError(try GrammarParser.parseSequenceNumber(buffer: &buffer, tracker: .testTracker)) { error in
             XCTAssertTrue(error is _IncompleteMessage)
         }
@@ -657,7 +657,7 @@ extension ParserUnitTests {
     }
 
     func testCreate_invalid_incomplete() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "CREATE ")
+        var buffer = TestUtilities.makeParseBuffer(for: "CREATE ")
         XCTAssertThrowsError(try GrammarParser.parseCreate(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage, "e has type \(e)")
         }
@@ -738,7 +738,7 @@ extension ParserUnitTests {
         ]
 
         for (input, line) in inputs {
-            TestUtilities.withBuffer(input, terminator: " ") { (buffer) in
+            TestUtilities.withParseBuffer(input, terminator: " ") { (buffer) in
                 XCTAssertNoThrow(try GrammarParser.parseConditionalStoreParameter(buffer: &buffer, tracker: .testTracker), line: line)
             }
         }
@@ -767,7 +767,7 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testCopy_valid() {
-        TestUtilities.withBuffer("COPY 1,2,3 inbox", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("COPY 1,2,3 inbox", terminator: " ") { (buffer) in
             let copy = try GrammarParser.parseCopy(buffer: &buffer, tracker: .testTracker)
             let expectedSequence = LastCommandSet<SequenceRangeSet>([1, 2, 3])!
             let expectedMailbox = MailboxName.inbox
@@ -776,15 +776,15 @@ extension ParserUnitTests {
     }
 
     func testCopy_invalid_missing_mailbox() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "COPY 1,2,3,4 ")
-        XCTAssertThrowsError(try GrammarParser.newline(buffer: &buffer, tracker: .testTracker)) { error in
+        var buffer = TestUtilities.makeParseBuffer(for: "COPY 1,2,3,4 ")
+        XCTAssertThrowsError(try ParserLibrary.newline(buffer: &buffer, tracker: .testTracker)) { error in
             XCTAssert(error is ParserError)
         }
     }
 
     func testCopy_invalid_missing_set() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "COPY inbox ")
-        XCTAssertThrowsError(try GrammarParser.newline(buffer: &buffer, tracker: .testTracker)) { error in
+        var buffer = TestUtilities.makeParseBuffer(for: "COPY inbox ")
+        XCTAssertThrowsError(try ParserLibrary.newline(buffer: &buffer, tracker: .testTracker)) { error in
             XCTAssert(error is ParserError)
         }
     }
@@ -794,7 +794,7 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testDelete_valid() {
-        TestUtilities.withBuffer("DELETE inbox", terminator: "\n") { (buffer) in
+        TestUtilities.withParseBuffer("DELETE inbox", terminator: "\n") { (buffer) in
             let commandType = try GrammarParser.parseDelete(buffer: &buffer, tracker: .testTracker)
             guard case Command.delete(let mailbox) = commandType else {
                 XCTFail("Didn't parse delete")
@@ -805,7 +805,7 @@ extension ParserUnitTests {
     }
 
     func testDelete_valid_mixedCase() {
-        TestUtilities.withBuffer("DELete inbox", terminator: "\n") { (buffer) in
+        TestUtilities.withParseBuffer("DELete inbox", terminator: "\n") { (buffer) in
             let commandType = try GrammarParser.parseDelete(buffer: &buffer, tracker: .testTracker)
             guard case Command.delete(let mailbox) = commandType else {
                 XCTFail("Didn't parse delete")
@@ -816,7 +816,7 @@ extension ParserUnitTests {
     }
 
     func testDelete_invalid_incomplete() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "DELETE ")
+        var buffer = TestUtilities.makeParseBuffer(for: "DELETE ")
         XCTAssertThrowsError(try GrammarParser.parseDelete(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage, "e has type \(e)")
         }
@@ -1221,7 +1221,7 @@ extension ParserUnitTests {
     }
 
     func testExamine_invalid_incomplete() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "EXAMINE ")
+        var buffer = TestUtilities.makeParseBuffer(for: "EXAMINE ")
         XCTAssertThrowsError(try GrammarParser.parseExamine(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage, "e has type \(e)")
         }
@@ -1357,14 +1357,14 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testParseFlagExtension_valid() {
-        TestUtilities.withBuffer("\\Something", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("\\Something", terminator: " ") { (buffer) in
             let flagExtension = try GrammarParser.parseFlagExtension(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(flagExtension, "\\Something")
         }
     }
 
     func testParseFlagExtension_invalid_noSlash() {
-        var buffer = "Something " as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: "Something ")
         XCTAssertThrowsError(try GrammarParser.parseFlagExtension(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
@@ -1375,7 +1375,7 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testParseFlagKeyword_valid() {
-        TestUtilities.withBuffer("keyword", terminator: " ") { (buffer) in
+        TestUtilities.withParseBuffer("keyword", terminator: " ") { (buffer) in
             let flagExtension = try GrammarParser.parseFlagKeyword(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(flagExtension, Flag.Keyword("keyword"))
         }
@@ -1405,14 +1405,14 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testHeaderList_valid_one() {
-        TestUtilities.withBuffer(#"("field")"#) { (buffer) in
+        TestUtilities.withParseBuffer(#"("field")"#) { (buffer) in
             let array = try GrammarParser.parseHeaderList(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(array[0], "field")
         }
     }
 
     func testHeaderList_valid_many() {
-        TestUtilities.withBuffer(#"("first" "second" "third")"#) { (buffer) in
+        TestUtilities.withParseBuffer(#"("first" "second" "third")"#) { (buffer) in
             let array = try GrammarParser.parseHeaderList(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(array[0], "first")
             XCTAssertEqual(array[1], "second")
@@ -1421,7 +1421,7 @@ extension ParserUnitTests {
     }
 
     func testHeaderList_invalid_none() {
-        var buffer = #"()"# as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: #"()"#)
         XCTAssertThrowsError(try GrammarParser.parseHeaderList(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
@@ -1815,7 +1815,7 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testParseMediaBasic_valid_match() {
-        var buffer = #""APPLICATION" "multipart/mixed""# as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: #""APPLICATION" "multipart/mixed""#)
         do {
             let mediaBasic = try GrammarParser.parseMediaBasic(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(mediaBasic, Media.Basic(kind: .application, subtype: .mixed))
@@ -1825,7 +1825,7 @@ extension ParserUnitTests {
     }
 
     func testParseMediaBasic_valid_string() {
-        var buffer = #""STRING" "multipart/related""# as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: #""STRING" "multipart/related""#)
         do {
             let mediaBasic = try GrammarParser.parseMediaBasic(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(mediaBasic, Media.Basic(kind: .init("STRING"), subtype: .related))
@@ -1835,7 +1835,7 @@ extension ParserUnitTests {
     }
 
     func testParseMediaBasic_valid_invalidString() {
-        var buffer = #"hey "something""# as ByteBuffer
+        var buffer = TestUtilities.makeParseBuffer(for: #"hey "something""#)
         XCTAssertThrowsError(try GrammarParser.parseMediaBasic(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError)
         }
@@ -1846,24 +1846,24 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testMediaMessage_valid_rfc() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "\"MESSAGE\" \"RFC822\"")
+        var buffer = TestUtilities.makeParseBuffer(for: "\"MESSAGE\" \"RFC822\"")
         XCTAssertNoThrow(try GrammarParser.parseMediaMessage(buffer: &buffer, tracker: .testTracker))
     }
 
     func testMediaMessage_valid_mixedCase() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "\"messAGE\" \"RfC822\"")
+        var buffer = TestUtilities.makeParseBuffer(for: "\"messAGE\" \"RfC822\"")
         XCTAssertNoThrow(try GrammarParser.parseMediaMessage(buffer: &buffer, tracker: .testTracker))
     }
 
     func testMediaMessage_invalid() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "abcdefghijklmnopqrstuvwxyz\n")
+        var buffer = TestUtilities.makeParseBuffer(for: "abcdefghijklmnopqrstuvwxyz\n")
         XCTAssertThrowsError(try GrammarParser.parseMediaMessage(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError, "e has type \(e)")
         }
     }
 
     func testMediaMessage_invalid_partial() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "\"messAGE\"")
+        var buffer = TestUtilities.makeParseBuffer(for: "\"messAGE\"")
         XCTAssertThrowsError(try GrammarParser.parseMediaMessage(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage, "e has type \(e)")
         }
@@ -1874,28 +1874,28 @@ extension ParserUnitTests {
 
 extension ParserUnitTests {
     func testMediaText_valid() {
-        TestUtilities.withBuffer(#""TEXT" "something""#, terminator: "\n") { (buffer) in
+        TestUtilities.withParseBuffer(#""TEXT" "something""#, terminator: "\n") { (buffer) in
             let media = try GrammarParser.parseMediaText(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(media, "something")
         }
     }
 
     func testMediaText_valid_mixedCase() {
-        TestUtilities.withBuffer(#""TExt" "something""#, terminator: "\n") { (buffer) in
+        TestUtilities.withParseBuffer(#""TExt" "something""#, terminator: "\n") { (buffer) in
             let media = try GrammarParser.parseMediaText(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(media, "something")
         }
     }
 
     func testMediaText_invalid_missingQuotes() {
-        var buffer = TestUtilities.createTestByteBuffer(for: #"TEXT "something"\n"#)
+        var buffer = TestUtilities.makeParseBuffer(for: #"TEXT "something"\n"#)
         XCTAssertThrowsError(try GrammarParser.parseMediaText(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError, "e has type \(e)")
         }
     }
 
     func testMediaText_invalid_missingSubtype() {
-        var buffer = TestUtilities.createTestByteBuffer(for: #""TEXT""#)
+        var buffer = TestUtilities.makeParseBuffer(for: #""TEXT""#)
         XCTAssertThrowsError(try GrammarParser.parseMediaText(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is _IncompleteMessage, "e has type \(e)")
         }
@@ -2008,7 +2008,7 @@ extension ParserUnitTests {
 extension ParserUnitTests {
     func testParseNewline() {
         self.iterateTests(
-            testFunction: GrammarParser.newline,
+            testFunction: ParserLibrary.newline,
             validInputs: [
                 ("\n", "", #line),
                 ("\r\n", "", #line),
@@ -2370,7 +2370,7 @@ extension ParserUnitTests {
     func testStatusAttribute_valid_all() {
         for att in MailboxAttribute.AllCases() {
             do {
-                var buffer = TestUtilities.createTestByteBuffer(for: att.rawValue)
+                var buffer = TestUtilities.makeParseBuffer(for: att.rawValue)
                 let parsedAtt = try GrammarParser.parseStatusAttribute(buffer: &buffer, tracker: .testTracker)
                 XCTAssertEqual(att, parsedAtt)
             } catch {
@@ -2381,13 +2381,13 @@ extension ParserUnitTests {
     }
 
     func testStatusAttribute_invalid_incomplete() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "a")
+        var buffer = TestUtilities.makeParseBuffer(for: "a")
         XCTAssertThrowsError(try GrammarParser.parseStatusAttribute(buffer: &buffer, tracker: .testTracker)) { _ in
         }
     }
 
     func testStatusAttribute_invalid_noMatch() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "a ")
+        var buffer = TestUtilities.makeParseBuffer(for: "a ")
         XCTAssertThrowsError(try GrammarParser.parseStatusAttribute(buffer: &buffer, tracker: .testTracker)) { e in
             XCTAssertTrue(e is ParserError, "e has type \(e)")
         }

--- a/Tests/NIOIMAPCoreTests/Parser/ParserLibraryTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/ParserLibraryTests.swift
@@ -23,34 +23,34 @@ final class ParserLibraryTests: XCTestCase {}
 
 extension ParserLibraryTests {
     func test_parseOptionalWorksForNothing() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "")
-        XCTAssertThrowsError(try GrammarParser.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
-            try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+        var buffer = TestUtilities.makeParseBuffer(for: "")
+        XCTAssertThrowsError(try ParserLibrary.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
+            try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
         }) { error in
             XCTAssertTrue(error is _IncompleteMessage)
         }
     }
 
     func test_parseOptionalWorks() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "x")
-        XCTAssertNoThrow(try GrammarParser.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
-            try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+        var buffer = TestUtilities.makeParseBuffer(for: "x")
+        XCTAssertNoThrow(try ParserLibrary.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
+            try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
         })
     }
 
     func test_parseOptionalWorksIfNotPresent() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "y")
-        XCTAssertNoThrow(try GrammarParser.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
-            try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+        var buffer = TestUtilities.makeParseBuffer(for: "y")
+        XCTAssertNoThrow(try ParserLibrary.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
+            try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
         })
         XCTAssertEqual(1, buffer.readableBytes)
     }
 
     func test_parseOptionalCorrectlyResetsForCompositesIfNotEnough() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "x")
-        XCTAssertThrowsError(try GrammarParser.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
-            try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-            try GrammarParser.fixedString("y", buffer: &buffer, tracker: tracker)
+        var buffer = TestUtilities.makeParseBuffer(for: "x")
+        XCTAssertThrowsError(try ParserLibrary.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
+            try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("y", buffer: &buffer, tracker: tracker)
         }) { error in
             XCTAssertTrue(error is _IncompleteMessage)
         }
@@ -58,10 +58,10 @@ extension ParserLibraryTests {
     }
 
     func test_parseOptionalCorrectlyResetsForCompositesIfNotMatching() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "xz")
-        XCTAssertNoThrow(try GrammarParser.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
-            try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-            try GrammarParser.fixedString("y", buffer: &buffer, tracker: tracker)
+        var buffer = TestUtilities.makeParseBuffer(for: "xz")
+        XCTAssertNoThrow(try ParserLibrary.optional(buffer: &buffer, tracker: StackTracker.testTracker) { buffer, tracker in
+            try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+            try ParserLibrary.fixedString("y", buffer: &buffer, tracker: tracker)
         })
         XCTAssertEqual(2, buffer.readableBytes)
     }
@@ -71,23 +71,23 @@ extension ParserLibraryTests {
 
 extension ParserLibraryTests {
     func test_fixedStringCaseSensitively() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "fooFooFOO")
+        var buffer = TestUtilities.makeParseBuffer(for: "fooFooFOO")
 
-        XCTAssertNoThrow(try GrammarParser.fixedString("fooFooFOO",
+        XCTAssertNoThrow(try ParserLibrary.fixedString("fooFooFOO",
                                                        caseSensitive: true,
                                                        buffer: &buffer,
                                                        tracker: .testTracker))
 
-        buffer = TestUtilities.createTestByteBuffer(for: "fooFooFOO")
-        XCTAssertThrowsError(try GrammarParser.fixedString("foofoofoo",
+        buffer = TestUtilities.makeParseBuffer(for: "fooFooFOO")
+        XCTAssertThrowsError(try ParserLibrary.fixedString("foofoofoo",
                                                            caseSensitive: true,
                                                            buffer: &buffer,
                                                            tracker: .testTracker)) { error in
             XCTAssert(error is ParserError)
         }
 
-        buffer = TestUtilities.createTestByteBuffer(for: "foo")
-        XCTAssertThrowsError(try GrammarParser.fixedString("fooFooFOO",
+        buffer = TestUtilities.makeParseBuffer(for: "foo")
+        XCTAssertThrowsError(try ParserLibrary.fixedString("fooFooFOO",
                                                            caseSensitive: true,
                                                            buffer: &buffer,
                                                            tracker: .testTracker)) { error in
@@ -96,19 +96,19 @@ extension ParserLibraryTests {
     }
 
     func test_fixedStringCaseInsensitively() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "fooFooFOO")
+        var buffer = TestUtilities.makeParseBuffer(for: "fooFooFOO")
 
-        XCTAssertNoThrow(try GrammarParser.fixedString("fooFooFOO",
+        XCTAssertNoThrow(try ParserLibrary.fixedString("fooFooFOO",
                                                        buffer: &buffer,
                                                        tracker: .testTracker))
 
-        buffer = TestUtilities.createTestByteBuffer(for: "fooFooFOO")
-        XCTAssertNoThrow(try GrammarParser.fixedString("foofoofoo",
+        buffer = TestUtilities.makeParseBuffer(for: "fooFooFOO")
+        XCTAssertNoThrow(try ParserLibrary.fixedString("foofoofoo",
                                                        buffer: &buffer,
                                                        tracker: .testTracker))
 
-        buffer = TestUtilities.createTestByteBuffer(for: "foo")
-        XCTAssertThrowsError(try GrammarParser.fixedString("fooFooFOO",
+        buffer = TestUtilities.makeParseBuffer(for: "foo")
+        XCTAssertThrowsError(try ParserLibrary.fixedString("fooFooFOO",
                                                            buffer: &buffer,
                                                            tracker: .testTracker)) { error in
             XCTAssertTrue(error is _IncompleteMessage)
@@ -116,10 +116,10 @@ extension ParserLibraryTests {
     }
 
     func test_fixedStringNonASCII() {
-        var buffer = TestUtilities.createTestByteBuffer(for: "fooFooFOO")
+        var buffer = TestUtilities.makeParseBuffer(for: "fooFooFOO")
 
-        buffer = TestUtilities.createTestByteBuffer(for: "fooFooFOÖ")
-        XCTAssertThrowsError(try GrammarParser.fixedString("fooFooFOO",
+        buffer = TestUtilities.makeParseBuffer(for: "fooFooFOÖ")
+        XCTAssertThrowsError(try ParserLibrary.fixedString("fooFooFOO",
                                                            caseSensitive: true,
                                                            buffer: &buffer,
                                                            tracker: .testTracker)) { error in
@@ -132,21 +132,21 @@ extension ParserLibraryTests {
 
 extension ParserLibraryTests {
     func test_parseZeroOrMoreParsesNothingButThereIsData() {
-        TestUtilities.withBuffer("", terminator: "xy") { buffer in
+        TestUtilities.withParseBuffer("", terminator: "xy") { buffer in
             XCTAssertNoThrow(XCTAssertEqual([],
                                             try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker -> Int in
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
                                                 return 1
             }))
         }
     }
 
     func test_parseZeroOrMoreParsesNothingNoData() {
-        TestUtilities.withBuffer("") { buffer in
+        TestUtilities.withParseBuffer("") { buffer in
             XCTAssertThrowsError(try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker in
-                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
             }) { error in
                 XCTAssertTrue(error is _IncompleteMessage)
             }
@@ -154,22 +154,22 @@ extension ParserLibraryTests {
     }
 
     func test_parseZeroOrMoreParsesOneItemAndThereIsMore() {
-        TestUtilities.withBuffer("xx", terminator: "xy") { buffer in
+        TestUtilities.withParseBuffer("xx", terminator: "xy") { buffer in
             XCTAssertNoThrow(XCTAssertEqual([1],
                                             try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker -> Int in
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
                                                 return 1
             }))
         }
     }
 
     func test_parseZeroOrMoreParsesTwoItemsAndThereIsMore() {
-        TestUtilities.withBuffer("xxxx", terminator: "xy") { buffer in
+        TestUtilities.withParseBuffer("xxxx", terminator: "xy") { buffer in
             XCTAssertNoThrow(XCTAssertEqual([1, 1],
                                             try ParserLibrary.parseZeroOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker -> Int in
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
                                                 return 1
             }))
         }
@@ -180,10 +180,10 @@ extension ParserLibraryTests {
 
 extension ParserLibraryTests {
     func test_parseOneOrMoreParsesNothingButThereIsData() {
-        TestUtilities.withBuffer("", terminator: "xy") { buffer in
+        TestUtilities.withParseBuffer("", terminator: "xy") { buffer in
             XCTAssertThrowsError(try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker in
-                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
             }) { error in
                 XCTAssert(error is ParserError)
             }
@@ -191,10 +191,10 @@ extension ParserLibraryTests {
     }
 
     func test_parseOneOrMoreParsesNothingNoData() {
-        TestUtilities.withBuffer("") { buffer in
+        TestUtilities.withParseBuffer("") { buffer in
             XCTAssertThrowsError(try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker in
-                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
             }) { error in
                 XCTAssertTrue(error is _IncompleteMessage)
             }
@@ -202,22 +202,22 @@ extension ParserLibraryTests {
     }
 
     func test_parseOneOrMoreParsesOneItemAndThereIsMore() {
-        TestUtilities.withBuffer("xx", terminator: "xy") { buffer in
+        TestUtilities.withParseBuffer("xx", terminator: "xy") { buffer in
             XCTAssertNoThrow(XCTAssertEqual([1],
                                             try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker -> Int in
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
                                                 return 1
             }))
         }
     }
 
     func test_parseOneOrMoreParsesTwoItemsAndThereIsMore() {
-        TestUtilities.withBuffer("xxxx", terminator: "xy") { buffer in
+        TestUtilities.withParseBuffer("xxxx", terminator: "xy") { buffer in
             XCTAssertNoThrow(XCTAssertEqual([1, 1],
                                             try ParserLibrary.parseOneOrMore(buffer: &buffer, tracker: .testTracker) { buffer, tracker -> Int in
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
-                                                try GrammarParser.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
+                                                try ParserLibrary.fixedString("x", buffer: &buffer, tracker: tracker)
                                                 return 1
             }))
         }
@@ -228,14 +228,15 @@ extension ParserLibraryTests {
 
 extension ParserLibraryTests {
     func testParseSpace() {
-        let inputs: [(ByteBuffer, ByteBuffer, UInt)] = [
+        let inputs: [(String, String, UInt)] = [
             (" a", "a", #line),
             ("       a", "a", #line),
             ("  a  ", "a  ", #line),
         ]
         for (string, remaining, line) in inputs {
-            var string = string
-            XCTAssertNoThrow(try GrammarParser.space(buffer: &string, tracker: .makeNewDefaultLimitStackTracker), line: line)
+            var string = ParseBuffer(ByteBuffer(string: string))
+            let remaining = ParseBuffer(ByteBuffer(string: remaining))
+            XCTAssertNoThrow(try ParserLibrary.space(buffer: &string, tracker: .makeNewDefaultLimitStackTracker), line: line)
             XCTAssertEqual(string, remaining, line: line)
         }
     }
@@ -245,14 +246,14 @@ extension ParserLibraryTests {
 
 extension ParserLibraryTests {
     func testParseUInt64() {
-        let inputs: [(ByteBuffer, UInt64, Int, UInt)] = [
+        let inputs: [(String, UInt64, Int, UInt)] = [
             ("12345\r", 12345, 5, #line),
             ("18446744073709551615\r", UInt64.max, 20, #line),
             ("12345 a", 12345, 5, #line),
             ("18446744073709551615b", UInt64.max, 20, #line),
         ]
         for (string, result, consumed, line) in inputs {
-            var string = string
+            var string = ParseBuffer(ByteBuffer(string: string))
             var id = UInt64(0)
             var actualConsumed = 0
             XCTAssertNoThrow((id, actualConsumed) = try ParserLibrary.parseUInt64(buffer: &string, tracker: .makeNewDefaultLimitStackTracker), line: line)

--- a/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
@@ -114,7 +114,8 @@ final class RoundtripTests: XCTestCase {
                 }
             }
             do {
-                let decoded = try GrammarParser.parseCommand(buffer: &buffer, tracker: .testTracker)
+                var parseBuffer = ParseBuffer(buffer)
+                let decoded = try GrammarParser.parseCommand(buffer: &parseBuffer, tracker: .testTracker)
                 XCTAssertEqual(command, decoded, line: line)
             } catch {
                 XCTFail("\(error) - \(buffer.readString(length: buffer.readableBytesView.count)!)", line: line)

--- a/Tests/NIOIMAPTests/RealWorldTests.swift
+++ b/Tests/NIOIMAPTests/RealWorldTests.swift
@@ -30,6 +30,7 @@ extension RealWorldTests {
         * 2 FETCH (UID 55 RFC822.SIZE 27984)
         * 3 FETCH (UID 56 RFC822.SIZE 34007)
         15.16 OK Fetch completed (0.001 + 0.000 secs).
+        tag OK [REFERRAL imap://hostname/foo/bar/;UID=1234]
 
         """
 
@@ -50,6 +51,21 @@ extension RealWorldTests {
                     .response(.fetchResponse(.simpleAttribute(.rfc822Size(34007)))),
                     .response(.fetchResponse(.finish)),
                     .response(.taggedResponse(.init(tag: "15.16", state: .ok(.init(code: nil, text: "Fetch completed (0.001 + 0.000 secs)."))))),
+                    .response(.taggedResponse(
+                        TaggedResponse(tag: "tag",
+                                       state: .ok(ResponseText(code:
+                                           .referral(IMAPURL(server: IMAPServer(userInfo: nil, host: "hostname", port: nil),
+                                                             query: IPathQuery(command: ICommand.messagePart(
+                                                                 part: IMessagePart(
+                                                                     mailboxReference: IMailboxReference(encodeMailbox: EncodedMailbox(mailbox: "foo/bar"),
+                                                                                                         uidValidity: nil),
+                                                                     iUID: try! IUID(uid: 1234),
+                                                                     iSection: nil,
+                                                                     iPartial: nil
+                                                                 ),
+                                                                 authenticatedURL: nil
+                                                             )))),
+                                                               text: ""))))),
                 ]
             ),
         ]

--- a/dev/process_grammar.sh
+++ b/dev/process_grammar.sh
@@ -54,8 +54,8 @@ function output_last() {
     returnType=$( echo $swift_id | sed "s/Env/Envelope\./g" )
     returnType=$( echo $swift_id | sed "s/Fld/Field\./g" )
 
-    echo "func parse$swift_id(buffer: inout ByteBuffer, tracker: StackTracker) throws -> NIOIMAO.$returnType {"
-    echo "    return try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> $swift_id in"
+    echo "func parse$swift_id(buffer: inout ParseBuffer, tracker: StackTracker) throws -> NIOIMAO.$returnType {"
+    echo "    return try ParserLibrary.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> $swift_id in"
     echo "        fatalError(\"$last_begin is not implemented yet\")"
     echo "    }"
     echo "}"


### PR DESCRIPTION
### Motivation:

Over time, the previously informal separation between the parser library and the parser has vanished a little bit which is very dangerous. It allows users of the parser way too many operations (everything from `ByteBuffer`), most of which they can't actually safely use without understanding the implementation details of the parser library.

### Modifications:

Restore separation and enforce using access modifiers.

### Result:

- Safer & better code.
- fixes #467 