### PR TITLE
remove dead code

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -73,31 +73,6 @@ extension GrammarParser {
         ], buffer: &buffer, tracker: tracker)
     }
 
-    static func parseAuthIMAPURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AuthIMAPURL {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AuthIMAPURL in
-            try fixedString("imap://", buffer: &buffer, tracker: tracker)
-            let server = try self.parseIServer(buffer: &buffer, tracker: tracker)
-            try fixedString("/", buffer: &buffer, tracker: tracker)
-            let messagePart = try self.parseIMessagePart(buffer: &buffer, tracker: tracker)
-            return .init(server: server, messagePart: messagePart)
-        }
-    }
-
-    static func parseAuthIMAPURLFull(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AuthIMAPURLFull {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AuthIMAPURLFull in
-            let imapURL = try self.parseAuthIMAPURL(buffer: &buffer, tracker: tracker)
-            let urlAuth = try self.parseIURLAuth(buffer: &buffer, tracker: tracker)
-            return .init(imapURL: imapURL, urlAuth: urlAuth)
-        }
-    }
-
-    static func parseAuthIMAPURLRump(buffer: inout ByteBuffer, tracker: StackTracker) throws -> AuthIMAPURLRump {
-        try composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> AuthIMAPURLRump in
-            let imapURL = try self.parseAuthIMAPURL(buffer: &buffer, tracker: tracker)
-            let authRump = try self.parseIURLAuthRump(buffer: &buffer, tracker: tracker)
-            return .init(imapURL: imapURL, authRump: authRump)
-        }
-    }
 
     // authenticate  = "AUTHENTICATE" SP auth-type [SP (base64 / "=")] *(CRLF base64)
     static func parseAuthenticate(buffer: inout ByteBuffer, tracker: StackTracker) throws -> Command {
@@ -670,24 +645,6 @@ extension GrammarParser {
             return try parseIDParamsList(buffer: &buffer, tracker: tracker)
         }
     }
-
-    static func parseINetworkPath(buffer: inout ByteBuffer, tracker: StackTracker) throws -> INetworkPath {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> INetworkPath in
-            try fixedString("//", buffer: &buffer, tracker: tracker)
-            let server = try self.parseIServer(buffer: &buffer, tracker: tracker)
-            let query = try self.parseIPathQuery(buffer: &buffer, tracker: tracker)
-            return .init(server: server, query: query)
-        }
-    }
-
-    static func parseIAbsolutePath(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IAbsolutePath {
-        try composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> IAbsolutePath in
-            try fixedString("/", buffer: &buffer, tracker: tracker)
-            let command = try optional(buffer: &buffer, tracker: tracker, parser: self.parseICommand)
-            return .init(command: command)
-        }
-    }
-
     static func parseIAuth(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IAuth {
         func parseIAuth_any(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IAuth {
             try fixedString("*", buffer: &buffer, tracker: tracker)
@@ -895,30 +852,6 @@ extension GrammarParser {
         }
     }
 
-    static func parseRelativeIMAPURL(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
-        func parseRelativeIMAPURL_absolute(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
-            .absolutePath(try self.parseIAbsolutePath(buffer: &buffer, tracker: tracker))
-        }
-
-        func parseRelativeIMAPURL_network(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
-            .networkPath(try self.parseINetworkPath(buffer: &buffer, tracker: tracker))
-        }
-
-        func parseRelativeIMAPURL_relative(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
-            .relativePath(try self.parseIRelativePath(buffer: &buffer, tracker: tracker))
-        }
-
-        func parseRelativeIMAPURL_empty(buffer: inout ByteBuffer, tracker: StackTracker) throws -> RelativeIMAPURL {
-            .empty
-        }
-
-        return try oneOf([
-            parseRelativeIMAPURL_network,
-            parseRelativeIMAPURL_absolute,
-            parseRelativeIMAPURL_relative,
-            parseRelativeIMAPURL_empty,
-        ], buffer: &buffer, tracker: tracker)
-    }
 
     static func parseIRelativePath(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IRelativePath {
         func parseIRelativePath_list(buffer: inout ByteBuffer, tracker: StackTracker) throws -> IRelativePath {

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -438,61 +438,6 @@ extension ParserUnitTests {
     }
 }
 
-// MARK: - parseAuthIMAPURL
-
-extension ParserUnitTests {
-    func testParseAuthIMAPURL() {
-        self.iterateTests(
-            testFunction: GrammarParser.parseAuthIMAPURL,
-            validInputs: [
-                ("imap://localhost/test/;UID=123", " ", .init(server: .init(host: "localhost"), messagePart: .init(mailboxReference: .init(encodeMailbox: .init(mailbox: "test")), iUID: try! .init(uid: 123))), #line),
-            ],
-            parserErrorInputs: [],
-            incompleteMessageInputs: []
-        )
-    }
-}
-
-// MARK: - parseAuthIMAPURLFull
-
-extension ParserUnitTests {
-    func testParseAuthIMAPURLFull() {
-        self.iterateTests(
-            testFunction: GrammarParser.parseAuthIMAPURLFull,
-            validInputs: [
-                (
-                    "imap://localhost/test/;UID=123;URLAUTH=anonymous:INTERNAL:01234567890123456789012345678901",
-                    " ",
-                    .init(imapURL: .init(server: .init(host: "localhost"), messagePart: .init(mailboxReference: .init(encodeMailbox: .init(mailbox: "test")), iUID: try! .init(uid: 123))), urlAuth: .init(auth: .init(access: .anonymous), verifier: .init(uAuthMechanism: .internal, encodedURLAuth: .init(data: "01234567890123456789012345678901")))),
-                    #line
-                ),
-            ],
-            parserErrorInputs: [],
-            incompleteMessageInputs: []
-        )
-    }
-}
-
-// MARK: - parseAuthIMAPURLRump
-
-extension ParserUnitTests {
-    func testParseAuthIMAPURLRump() {
-        self.iterateTests(
-            testFunction: GrammarParser.parseAuthIMAPURLRump,
-            validInputs: [
-                (
-                    "imap://localhost/test/;UID=123;URLAUTH=anonymous",
-                    " ",
-                    .init(imapURL: .init(server: .init(host: "localhost"), messagePart: .init(mailboxReference: .init(encodeMailbox: .init(mailbox: "test")), iUID: try! .init(uid: 123))), authRump: .init(access: .anonymous)),
-                    #line
-                ),
-            ],
-            parserErrorInputs: [],
-            incompleteMessageInputs: []
-        )
-    }
-}
-
 // MARK: - parseBase64
 
 extension ParserUnitTests {
@@ -877,24 +822,6 @@ extension ParserUnitTests {
     }
 }
 
-// MARK: - IAbsolutePath
-
-extension ParserUnitTests {
-    func testParseIAbsolutePath() {
-        self.iterateTests(
-            testFunction: GrammarParser.parseIAbsolutePath,
-            validInputs: [
-                ("/", " ", .init(command: nil), #line),
-                ("/test", " ", .init(command: .messageList(.init(mailboxReference: .init(encodeMailbox: .init(mailbox: "test"))))), #line),
-            ],
-            parserErrorInputs: [
-                ],
-            incompleteMessageInputs: [
-                ]
-        )
-    }
-}
-
 // MARK: - ICommand
 
 extension ParserUnitTests {
@@ -1089,23 +1016,6 @@ extension ParserUnitTests {
             testFunction: GrammarParser.parseEncodedMailbox,
             validInputs: [
                 ("hello%FF", " ", .init(mailbox: "hello%FF"), #line),
-            ],
-            parserErrorInputs: [
-                ],
-            incompleteMessageInputs: [
-                ]
-        )
-    }
-}
-
-// MARK: - parseINetworkPath
-
-extension ParserUnitTests {
-    func testParseINetworkPath() {
-        self.iterateTests(
-            testFunction: GrammarParser.parseINetworkPath,
-            validInputs: [
-                ("//localhost/", " ", .init(server: .init(host: "localhost"), query: .init(command: nil)), #line),
             ],
             parserErrorInputs: [
                 ],
@@ -1636,26 +1546,6 @@ extension ParserUnitTests {
             validInputs: [
                 ("url NIL", " ", .init(url: "url", data: nil), #line),
                 ("url \"data\"", " ", .init(url: "url", data: "data"), #line),
-            ],
-            parserErrorInputs: [
-                ],
-            incompleteMessageInputs: [
-                ]
-        )
-    }
-}
-
-// MARK: - parseIMapURLRel
-
-extension ParserUnitTests {
-    func testParseIMAPURLRel() {
-        self.iterateTests(
-            testFunction: GrammarParser.parseRelativeIMAPURL,
-            validInputs: [
-                ("/test", " ", .absolutePath(.init(command: .messageList(.init(mailboxReference: .init(encodeMailbox: .init(mailbox: "test")))))), #line),
-                ("//localhost/", " ", .networkPath(.init(server: .init(host: "localhost"), query: .init(command: nil))), #line),
-                ("test", " ", .relativePath(.list(.init(mailboxReference: .init(encodeMailbox: .init(mailbox: "test"))))), #line),
-                ("", " ", .empty, #line),
             ],
             parserErrorInputs: [
                 ],


### PR DESCRIPTION
### Motivation:

There's a lot of dead code in IMAP that's never called into from the real parser.

### Modifications:

Remove the first dead bits I've seen.

### Result:

Less dead code.