### PR TITLE
Basic IDLE continuation support

### DIFF
--- a/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
@@ -73,7 +73,7 @@ public final class IMAPClientHandler: ChannelDuplexHandler {
                         // continuations must have finished: change the state to standard continuation handling
                         self._state = .expectingResponses
 
-                    case .untaggedResponse, .fetchResponse, .fatalResponse, .authenticationChallenge:
+                    case .untaggedResponse, .fetchResponse, .fatalResponse, .authenticationChallenge, .idleContinuation:
                         break
                     }
                     context.fireChannelRead(self.wrapInboundOut(out))

--- a/Sources/NIOIMAPCore/Grammar/Response/Response.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/Response.swift
@@ -47,6 +47,10 @@ public enum Response: Equatable {
     /// as part of the authentication flow. The client will send the necessary
     /// bytes in response to the challenge.
     case authenticationChallenge(ByteBuffer)
+    
+    /// May be sent periodicially by the server to, for example, remind the client
+    /// that the connection is still active, update capabilities, provide status updates, etc.
+    case idleContinuation(ContinuationRequest)
 }
 
 /// The first event will always be `start`

--- a/Sources/NIOIMAPCore/ResponseEncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/ResponseEncodeBuffer.swift
@@ -81,6 +81,8 @@ extension ResponseEncodeBuffer {
             return self.buffer.writeResponseFatal(fatal)
         case .authenticationChallenge(let bytes):
             return self.writeAuthenticationChallenge(bytes)
+        case .idleContinuation(let req):
+            return self.writeContinuationRequest(req)
         }
     }
 

--- a/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
+++ b/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
@@ -234,6 +234,29 @@ class IMAPClientHandlerTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertEqual(try channel.readInbound(), ResponseOrContinuationRequest.response(.taggedResponse(.init(tag: "A001", state: .ok(.init(text: "GSSAPI authentication successful")))))))
         XCTAssertEqual(handler._state, .expectingResponses)
     }
+    
+    func testIdleFlow() {
+        
+        // begin idle
+        self.writeOutbound(.command(.init(tag: "A1", command: .idleStart)), wait: true)
+        self.assertOutboundString("A1 IDLE\r\n")
+        
+        // recieved n continuations from server
+        self.writeInbound("+ Waiting 1\r\n")
+        self.assertInbound(.response(.idleContinuation(.responseText(.init(text: "Waiting 1")))))
+        
+        self.writeInbound("+ Waiting 2\r\n")
+        self.assertInbound(.response(.idleContinuation(.responseText(.init(text: "Waiting 2")))))
+        
+        self.writeInbound("+ Waiting 3\r\n")
+        self.assertInbound(.response(.idleContinuation(.responseText(.init(text: "Waiting 3")))))
+        
+        self.writeInbound("+ Waiting 4\r\n")
+        self.assertInbound(.response(.idleContinuation(.responseText(.init(text: "Waiting 4")))))
+        
+        self.writeOutbound(.idleDone, wait: true)
+        self.assertOutboundString("DONE\r\n")
+    }
 
     // MARK: - setup / tear down
 

--- a/Tests/NIOIMAPTests/Coders/IMAPServerHandlerTests.swift
+++ b/Tests/NIOIMAPTests/Coders/IMAPServerHandlerTests.swift
@@ -147,9 +147,6 @@ class IMAPServerHandlerTests: XCTestCase {
     }
 
     func testAuthenticationFlow() {
-        self.handler = IMAPServerHandler()
-        self.channel = EmbeddedChannel(handler: self.handler)
-
         // client starts authentication
         self.writeInbound("A1 AUTHENTICATE GSSAPI\r\n")
         self.assertInbound(.command(.init(tag: "A1", command: .authenticate(method: .gssAPI, initialClientResponse: nil))))


### PR DESCRIPTION
I really hate this - we have to tell the response parser that the connection is idling, as there's no way for the response parser to know on it's own currently.

I don't think this should be merged, we need to think about it a little.

IMO the best solution is to re-introduce `ResponseOrContinuationRequest` at the top level, then it doesn't matter as we'll always be able to parse continuation requests.