### PR TITLE
Fix performance testing output

### DIFF
--- a/Sources/NIOIMAPPerformanceTester/main.swift
+++ b/Sources/NIOIMAPPerformanceTester/main.swift
@@ -120,7 +120,7 @@ func measureAndPrint(desc: String, fn: () throws -> Int) rethrows {
 
 // MARK: Utilities
 
-let humanReadable = true
+let humanReadable = false
 
 let startDate = Date()
 for (description, command) in commands {


### PR DESCRIPTION
The code defaulted to pretty human-readable output. Instead we should default to the format that the NIO performance tester expects.