### PR TITLE
Rename UserInfo

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/IMAPServer.swift
+++ b/Sources/NIOIMAPCore/Grammar/IMAPServer.swift
@@ -18,7 +18,7 @@ import struct NIO.ByteBuffer
 /// to an IMAP server.
 public struct IMAPServer: Equatable {
     /// If present, authentication details for the server.
-    public var userInfo: UserAuthenticationMechanism?
+    public var userAuthenticationMechanism: UserAuthenticationMechanism?
 
     /// The hostname of the server.
     public var host: String
@@ -27,11 +27,11 @@ public struct IMAPServer: Equatable {
     public var port: Int?
 
     /// Creates a new `IMAPServer`.
-    /// - parameter userInfo: If present, authentication details for the server. Defaults to `nil`.
+    /// - parameter userAuthenticationMechanism: If present, authentication details for the server. Defaults to `nil`.
     /// - parameter host: The hostname of the server.
     /// - parameter port: The host post of the server. Defaults to `nil`.
-    public init(userInfo: UserAuthenticationMechanism? = nil, host: String, port: Int? = nil) {
-        self.userInfo = userInfo
+    public init(userAuthenticationMechanism: UserAuthenticationMechanism? = nil, host: String, port: Int? = nil) {
+        self.userAuthenticationMechanism = userAuthenticationMechanism
         self.host = host
         self.port = port
     }
@@ -41,8 +41,8 @@ public struct IMAPServer: Equatable {
 
 extension _EncodeBuffer {
     @discardableResult mutating func writeIMAPServer(_ server: IMAPServer) -> Int {
-        self.writeIfExists(server.userInfo) { userInfo in
-            self.writeUserInfo(userInfo) + self._writeString("@")
+        self.writeIfExists(server.userAuthenticationMechanism) { authMechanism in
+            self.writeUserAuthenticationMechanism(authMechanism) + self._writeString("@")
         } +
             self._writeString("\(server.host)") +
             self.writeIfExists(server.port) { port in

--- a/Sources/NIOIMAPCore/Grammar/UserInfo.swift
+++ b/Sources/NIOIMAPCore/Grammar/UserInfo.swift
@@ -33,7 +33,7 @@ public struct UserAuthenticationMechanism: Equatable {
 // MARK: - Encoding
 
 extension _EncodeBuffer {
-    @discardableResult mutating func writeUserInfo(_ data: UserAuthenticationMechanism) -> Int {
+    @discardableResult mutating func writeUserAuthenticationMechanism(_ data: UserAuthenticationMechanism) -> Int {
         self.writeIfExists(data.encodedUser) { user in
             self.writeEncodedUser(user)
         } +

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -782,7 +782,7 @@ extension GrammarParser {
     static func parseIMAPServer(buffer: inout ParseBuffer, tracker: StackTracker) throws -> IMAPServer {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> IMAPServer in
             let info = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: { buffer, tracker -> UserAuthenticationMechanism in
-                let info = try self.parseUserInfo(buffer: &buffer, tracker: tracker)
+                let info = try self.parseUserAuthenticationMechanism(buffer: &buffer, tracker: tracker)
                 try PL.parseFixedString("@", buffer: &buffer, tracker: tracker)
                 return info
             })
@@ -791,7 +791,7 @@ extension GrammarParser {
                 try PL.parseFixedString(":", buffer: &buffer, tracker: tracker)
                 return try self.parseNumber(buffer: &buffer, tracker: tracker)
             })
-            return .init(userInfo: info, host: host, port: port)
+            return .init(userAuthenticationMechanism: info, host: host, port: port)
         }
     }
 
@@ -1181,7 +1181,7 @@ extension GrammarParser {
         }
     }
 
-    static func parseUserInfo(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UserAuthenticationMechanism {
+    static func parseUserAuthenticationMechanism(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UserAuthenticationMechanism {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> UserAuthenticationMechanism in
             let encodedUser = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: self.parseEncodedUser)
             let authenticationMechanism = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: self.parseIAuthentication)

--- a/Tests/NIOIMAPCoreTests/Grammar/IServer+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/IServer+Tests.swift
@@ -24,9 +24,9 @@ extension IMAPServer_Tests {
     func testEncode() {
         let inputs: [(IMAPServer, String, UInt)] = [
             (.init(host: "localhost"), "localhost", #line),
-            (.init(userInfo: .init(encodedUser: nil, authenticationMechanism: .any), host: "localhost"), ";AUTH=*@localhost", #line),
+            (.init(userAuthenticationMechanism: .init(encodedUser: nil, authenticationMechanism: .any), host: "localhost"), ";AUTH=*@localhost", #line),
             (.init(host: "localhost", port: 1234), "localhost:1234", #line),
-            (.init(userInfo: .init(encodedUser: nil, authenticationMechanism: .any), host: "localhost", port: 1234), ";AUTH=*@localhost:1234", #line),
+            (.init(userAuthenticationMechanism: .init(encodedUser: nil, authenticationMechanism: .any), host: "localhost", port: 1234), ";AUTH=*@localhost:1234", #line),
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeIMAPServer($0) })
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/IUserInfo+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/IUserInfo+Tests.swift
@@ -16,17 +16,17 @@ import NIO
 @testable import NIOIMAPCore
 import XCTest
 
-class UserInfo_Tests: EncodeTestClass {}
+class UserAuthenticationMechanism_Tests: EncodeTestClass {}
 
 // MARK: - IMAP
 
-extension UserInfo_Tests {
+extension UserAuthenticationMechanism_Tests {
     func testEncode() {
         let inputs: [(UserAuthenticationMechanism, String, UInt)] = [
             (.init(encodedUser: .init(data: "test"), authenticationMechanism: .any), "test;AUTH=*", #line),
             (.init(encodedUser: .init(data: "test"), authenticationMechanism: nil), "test", #line),
             (.init(encodedUser: nil, authenticationMechanism: .any), ";AUTH=*", #line),
         ]
-        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeUserInfo($0) })
+        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeUserAuthenticationMechanism($0) })
     }
 }

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -981,12 +981,12 @@ extension ParserUnitTests {
     }
 }
 
-// MARK: - UserInfo
+// MARK: - UserAuthenticationMechanism
 
 extension ParserUnitTests {
-    func testParseUserInfo() {
+    func testParseUserAuthenticationMechanism() {
         self.iterateTests(
-            testFunction: GrammarParser.parseUserInfo,
+            testFunction: GrammarParser.parseUserAuthenticationMechanism,
             validInputs: [
                 (";AUTH=*", " ", .init(encodedUser: nil, authenticationMechanism: .any), #line),
                 ("test", " ", .init(encodedUser: .init(data: "test"), authenticationMechanism: nil), #line),
@@ -1502,10 +1502,10 @@ extension ParserUnitTests {
         self.iterateTests(
             testFunction: GrammarParser.parseIMAPServer,
             validInputs: [
-                ("localhost", " ", .init(userInfo: nil, host: "localhost", port: nil), #line),
-                (";AUTH=*@localhost", " ", .init(userInfo: .init(encodedUser: nil, authenticationMechanism: .any), host: "localhost", port: nil), #line),
-                ("localhost:1234", " ", .init(userInfo: nil, host: "localhost", port: 1234), #line),
-                (";AUTH=*@localhost:1234", " ", .init(userInfo: .init(encodedUser: nil, authenticationMechanism: .any), host: "localhost", port: 1234), #line),
+                ("localhost", " ", .init(userAuthenticationMechanism: nil, host: "localhost", port: nil), #line),
+                (";AUTH=*@localhost", " ", .init(userAuthenticationMechanism: .init(encodedUser: nil, authenticationMechanism: .any), host: "localhost", port: nil), #line),
+                ("localhost:1234", " ", .init(userAuthenticationMechanism: nil, host: "localhost", port: 1234), #line),
+                (";AUTH=*@localhost:1234", " ", .init(userAuthenticationMechanism: .init(encodedUser: nil, authenticationMechanism: .any), host: "localhost", port: 1234), #line),
             ],
             parserErrorInputs: [
             ],

--- a/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
+++ b/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
@@ -34,7 +34,7 @@ class IMAPClientHandlerTests: XCTestCase {
         let expectedResponse = Response.taggedResponse(
             TaggedResponse(tag: "tag",
                            state: .ok(ResponseText(code:
-                               .referral(IMAPURL(server: IMAPServer(userInfo: nil, host: "hostname", port: nil),
+                               .referral(IMAPURL(server: IMAPServer(userAuthenticationMechanism: nil, host: "hostname", port: nil),
                                                  query: IPathQuery(command: ICommand.messagePart(
                                                      part: IMessagePart(
                                                          mailboxReference: IMailboxReference(encodeMailbox: EncodedMailbox(mailbox: "foo/bar"),

--- a/Tests/NIOIMAPTests/RealWorldTests.swift
+++ b/Tests/NIOIMAPTests/RealWorldTests.swift
@@ -54,7 +54,7 @@ extension RealWorldTests {
                     .response(.taggedResponse(
                         TaggedResponse(tag: "tag",
                                        state: .ok(ResponseText(code:
-                                           .referral(IMAPURL(server: IMAPServer(userInfo: nil, host: "hostname", port: nil),
+                                           .referral(IMAPURL(server: IMAPServer(userAuthenticationMechanism: nil, host: "hostname", port: nil),
                                                              query: IPathQuery(command: ICommand.messagePart(
                                                                  part: IMessagePart(
                                                                      mailboxReference: IMailboxReference(encodeMailbox: EncodedMailbox(mailbox: "foo/bar"),


### PR DESCRIPTION
`UserInfo` is ambiguous and conflicts with notification data on iOS. It's been renamed to `UserAuthenticationMechanism`, which better describes what the data actually is.