### PR TITLE
Convert parsing fetch attributes to use the lookup table parser

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
@@ -130,7 +130,6 @@ extension GrammarParser {
             "RFC822.TEXT": { _, _ in .rfc822Text },
             "RFC822": { _, _ in .rfc822 },
             "BODYSTRUCTURE": { _, _ in .bodyStructure(extensions: true) },
-
             "BODY": parseFetchAttribute_bodySection,
             "BODY.PEEK": parseFetchAttribute_bodyPeekSection,
             "BINARY.SIZE": parseFetchAttribute_binarySize,
@@ -144,9 +143,7 @@ extension GrammarParser {
         do {
             return try self.parseFromLookupTable(buffer: &buffer, tracker: tracker, parsers: parsers)
         } catch is ParserError {
-            return try PL.parseOneOf([
-                parseFetchAttribute_modificationSequence,
-            ], buffer: &buffer, tracker: tracker)
+            return try parseFetchAttribute_modificationSequence(buffer: &buffer, tracker: tracker)
         }
     }
 


### PR DESCRIPTION
Resolves #412 

All but one fetch attributes now use the table parser, making it ~30% faster.

The only exception is parsing the "modification sequence", which doesn't any alpha prefix, and is some user-input number. This obviously can't be table-parsed, so we need to fallback and try to parser a number if the table parser fails.

Added benefit - quite a lot less code.

Perf before:
```
(1.30s) Completed parse_fetch_last_command_lots
(1.42s) Completed parse_fetch_all_lots
(1.42s) Completed parse_fetch_set_one_lots
(1.70s) Completed parse_fetch_set_many_lots
```


Perf after:
```
(0.74s) Completed parse_fetch_last_command_lots
(0.88s) Completed parse_fetch_all_lots
(0.91s) Completed parse_fetch_set_one_lots
(1.26s) Completed parse_fetch_set_many_lots
```