### PR TITLE
Fix mailbox name initialiser behaviour

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
@@ -200,10 +200,8 @@ public struct MailboxName: Hashable {
     /// - note: The bytes provided should be UTF-7.
     /// - parameter bytes: The bytes to construct a `MailboxName` from. Note that if any case-insensitive variation of *INBOX* is provided then it will be uppercased.
     public init(_ bytes: ByteBuffer) {
-        let decodedString = bytes.readableBytesView.withUnsafeBytes { pointer in
-            String(validatingUTF8: pointer.baseAddress!.assumingMemoryBound(to: CChar.self))
-        }
-        if let string = decodedString, string.uppercased() == "INBOX" {
+        let isInbox = bytes.readableBytesView.lazy.map { $0 & 0xDF }.elementsEqual("INBOX".utf8)
+        if isInbox {
             self.bytes = ByteBuffer(ByteBufferView("INBOX".utf8))
         } else {
             self.bytes = bytes

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxName+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxName+Tests.swift
@@ -107,27 +107,26 @@ extension MailboxName_Tests {
 }
 
 // MARK: - MailboxName
+
 extension MailboxName_Tests {
-    
     func testMailboxNameInitInbox() {
         let test1 = MailboxName("INBOX")
         XCTAssertEqual(test1.bytes, "INBOX")
         XCTAssertTrue(test1.isInbox)
-        
+
         let test2 = MailboxName("inbox")
         XCTAssertEqual(test2.bytes, "INBOX")
         XCTAssertTrue(test2.isInbox)
-        
+
         let test3 = MailboxName("notinbox")
-        XCTAssertEqual(test2.bytes, "notinbox")
-        XCTAssertFalse(test2.isInbox)
+        XCTAssertEqual(test3.bytes, "notinbox")
+        XCTAssertFalse(test3.isInbox)
     }
-    
+
     func testMailboxNameInitNonUTF8() {
         let hexBytes: [UInt8] = [0x80]
         let test1 = MailboxName(.init(bytes: hexBytes))
         XCTAssertEqual(test1.bytes, .init(bytes: hexBytes))
         XCTAssertFalse(test1.isInbox)
     }
-    
 }


### PR DESCRIPTION
Resolves #560

An invalid UTF-8 string may crash the `MailboxName` initialiser depending on how the bytes are read into a string. NIO uses `String(decoding:, as:)` which is not failable, and will mutate bytes to use their unicode equivalents if needed. This isn't what we want in IMAP mailbox names, where byte preservation is important.

The new solution is to actually validate the bytes, and only if they are valid UTF-8 to bother checking if the bytes given represent an "inbox".