### PR TITLE
Rename and change type of ResponseCode.num to properly reflect UIDValidity

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseCodeAppend.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseCodeAppend.swift
@@ -16,16 +16,16 @@
 /// of the appended message, and the uid validity of the destination mailbox.
 public struct ResponseCodeAppend: Equatable {
     /// The UID validity of the destination mailbox.
-    public var num: Int
+    public var uidValidity: UIDValidity
 
     /// The UID of the message after it has been appended.
     public var uid: UID
 
     /// Creates a new `ResponseCodeAppend`.
-    /// - parameter num: The UID validity of the destination mailbox.
+    /// - parameter uidValidity: The UID validity of the destination mailbox.
     /// - parameter uid: The UID of the message after it has been appended.
-    public init(num: Int, uid: UID) {
-        self.num = num
+    public init(num: UIDValidity, uid: UID) {
+        self.uidValidity = num
         self.uid = uid
     }
 }
@@ -34,7 +34,7 @@ public struct ResponseCodeAppend: Equatable {
 
 extension EncodeBuffer {
     @discardableResult mutating func writeResponseCodeAppend(_ data: ResponseCodeAppend) -> Int {
-        self.writeString("APPENDUID \(data.num) ") +
+        self.writeString("APPENDUID \(data.uidValidity.rawValue) ") +
             self.writeUID(data.uid)
     }
 }

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
@@ -49,7 +49,7 @@ extension GrammarParser {
     static func parseResponseCodeAppend(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseCodeAppend {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ResponseCodeAppend in
             try PL.parseFixedString("APPENDUID ", buffer: &buffer, tracker: tracker)
-            let number = try self.parseNZNumber(buffer: &buffer, tracker: tracker)
+            let number = try self.parseUIDValidity(buffer: &buffer, tracker: tracker)
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
             let uid = try self.parseUID(buffer: &buffer, tracker: tracker)
             return ResponseCodeAppend(num: number, uid: uid)


### PR DESCRIPTION
Resolves #577 

`.num` isn't the best name, `uidValidity` is much better, as it describes exactly what the data is. Also `Int` isn't technically incorrect, but seeing as we have a dedicated type `UIDValidity`, we might as well use it.