### PR TITLE
Conform `CommandStreamPart`, `TaggedCommand`, and `Command` to `CustomDebugStringConvertible`

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -175,6 +175,14 @@ public enum Command: Equatable {
     case urlFetch([ByteBuffer])
 }
 
+extension Command: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501)
+        buffer.writeCommand(self)
+        return String(buffer: buffer.buffer.nextChunk().bytes)
+    }
+}
+
 // MARK: - IMAP
 
 extension CommandEncodeBuffer {

--- a/Sources/NIOIMAPCore/Grammar/Command/CommandStreamPart.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/CommandStreamPart.swift
@@ -101,6 +101,14 @@ public enum CommandStreamPart: Equatable {
     case continuationResponse(ByteBuffer)
 }
 
+extension CommandStreamPart: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501)
+        buffer.writeCommandStream(self)
+        return String(buffer: buffer.buffer.nextChunk().bytes)
+    }
+}
+
 extension CommandEncodeBuffer {
     /// Writes a `CommandStreamPart` to the buffer ready to be sent to the network.
     /// - parameter stream: The `CommandStreamPart` to write.

--- a/Sources/NIOIMAPCore/Grammar/Command/TaggedCommand.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/TaggedCommand.swift
@@ -31,6 +31,14 @@ public struct TaggedCommand: Equatable {
     }
 }
 
+extension TaggedCommand: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501)
+        buffer.writeCommand(self)
+        return String(buffer: buffer.buffer.nextChunk().bytes)
+    }
+}
+
 extension CommandEncodeBuffer {
     /// Writes a `TaggedCommand` to the buffer ready to be sent down the network.
     /// - parameter command: The `TaggedCommand` to write.

--- a/Tests/NIOIMAPTests/CommandEncoder+Tests.swift
+++ b/Tests/NIOIMAPTests/CommandEncoder+Tests.swift
@@ -23,7 +23,7 @@ final class CommandEncoder_Tests: XCTestCase {}
 
 extension CommandEncoder_Tests {
     func testEncoding() {
-        // Ror now this is a fairly limited sequence of test
+        // For now this is a fairly limited sequence of test
         // just to ensure that CommandEncoder correctly uses
         // CommandEncodeBuffer.
         // When we add a state to CommandEncoder, it'll be more
@@ -39,6 +39,7 @@ extension CommandEncoder_Tests {
             let encoder = CommandEncoder()
             encoder.encode(data: command, out: &buffer)
             XCTAssertEqual(expected, buffer, "\(String(buffer: expected)) is not equal to \(String(buffer: buffer))", line: line)
+            XCTAssertEqual(String(reflecting: command), String(buffer: expected), line: line)
         }
     }
 }


### PR DESCRIPTION
For debugging and testing purposes, it's very helpful to print the raw IMAP—it's much more readable than the Swift representation.