### PR TITLE
Change `destinationUIDValidity` type to `UIDValidity`

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseCodeCopy.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseCodeCopy.swift
@@ -18,7 +18,7 @@
 /// so that the source UIDs can be matched to destination UIDs.
 public struct ResponseCodeCopy: Equatable {
     /// The `UIDValidity` of the destination mailbox
-    public var destinationUIDValidity: Int
+    public var destinationUIDValidity: UIDValidity
 
     /// The message UIDs in the source mailbox.
     public var sourceUIDs: [UIDRange]
@@ -30,7 +30,7 @@ public struct ResponseCodeCopy: Equatable {
     /// - parameter destinationUIDValidity: The `UIDValidity` of the destination mailbox.
     /// - parameter sourceUIDs: The message UIDs in the source mailbox.
     /// - parameter destinationUIDs: The copied message UIDs in the destination mailbox.
-    public init(destinationUIDValidity: Int, sourceUIDs: [UIDRange], destinationUIDs: [UIDRange]) {
+    public init(destinationUIDValidity: UIDValidity, sourceUIDs: [UIDRange], destinationUIDs: [UIDRange]) {
         self.destinationUIDValidity = destinationUIDValidity
         self.sourceUIDs = sourceUIDs
         self.destinationUIDs = destinationUIDs
@@ -41,7 +41,7 @@ public struct ResponseCodeCopy: Equatable {
 
 extension EncodeBuffer {
     @discardableResult mutating func writeResponseCodeCopy(_ data: ResponseCodeCopy) -> Int {
-        self.writeString("COPYUID \(data.destinationUIDValidity) ") +
+        self.writeString("COPYUID \(data.destinationUIDValidity.rawValue) ") +
             self.writeUIDRangeArray(data.sourceUIDs) +
             self.writeSpace() +
             self.writeUIDRangeArray(data.destinationUIDs)

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
@@ -60,7 +60,7 @@ extension GrammarParser {
     static func parseResponseCodeCopy(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseCodeCopy {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> ResponseCodeCopy in
             try PL.parseFixedString("COPYUID ", buffer: &buffer, tracker: tracker)
-            let uidValidity = try self.parseNumber(buffer: &buffer, tracker: tracker)
+            let uidValidity = try self.parseUIDValidity(buffer: &buffer, tracker: tracker)
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
             let sourceUIDRanges = try self.parseUIDRangeArray(buffer: &buffer, tracker: tracker)
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)


### PR DESCRIPTION
Resolves #584 

Previously it was `Int`, but we have a dedicated type to represent this data, so we should use it.