### PR TITLE
Add `BinaryInteger` init for `ModificationSequenceValue`

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Modifier/ModificationSequenceValue.swift
+++ b/Sources/NIOIMAPCore/Grammar/Modifier/ModificationSequenceValue.swift
@@ -56,7 +56,7 @@ extension ModificationSequenceValue: CustomDebugStringConvertible {
 // MARK: - BinaryInteger
 
 extension BinaryInteger {
-    init(_ modificationSequenceValue: ModificationSequenceValue) {
+    public init(_ modificationSequenceValue: ModificationSequenceValue) {
         self = Self(modificationSequenceValue.value)
     }
 }


### PR DESCRIPTION
Resolves #598 

Hide the underlying raw value, and instead provide the `BinaryInteger` initialisers like we do for other similar types.