### PR TITLE
Make CommandEncodeBuffer hashable

### DIFF
--- a/Sources/NIOIMAPCore/CommandEncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/CommandEncodeBuffer.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// Used to buffer commands before writing to the network.
-public struct CommandEncodeBuffer {
+public struct CommandEncodeBuffer: Hashable {
     /// The underlying buffer containing data to be written.
     @_spi(NIOIMAPInternal) public var buffer: EncodeBuffer
 

--- a/Sources/NIOIMAPCore/CommandEncodingOptions.swift
+++ b/Sources/NIOIMAPCore/CommandEncodingOptions.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Options that may change how commands are written to the network.
-public struct CommandEncodingOptions: Equatable {
+public struct CommandEncodingOptions: Hashable {
     /// Use RFC 3501 _quoted strings_ when possible (and the string is relatively short).
     public var useQuotedString: Bool
     /// Use the RFC 3501 `{20}` style literals.

--- a/Sources/NIOIMAPCore/EncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/EncodeBuffer.swift
@@ -18,9 +18,9 @@ import struct NIO.CircularBuffer
 
 /// A buffer that handles encoding of Swift types into IMAP commands/responses that
 /// will be sent/recieved by clients and servers.
-@_spi(NIOIMAPInternal) public struct EncodeBuffer {
+@_spi(NIOIMAPInternal) public struct EncodeBuffer: Hashable {
     /// Used to define if the buffer should act as a client or server.
-    public enum Mode: Equatable {
+    public enum Mode: Hashable {
         /// Act as a client using the given `CommandEncodingOptions`.
         case client(options: CommandEncodingOptions)
 

--- a/Sources/NIOIMAPCore/ResponseEncodingOptions.swift
+++ b/Sources/NIOIMAPCore/ResponseEncodingOptions.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Configuration options for writing Responses to a buffer for transmission.
-public struct ResponseEncodingOptions: Equatable {
+public struct ResponseEncodingOptions: Hashable {
     /// Use RFC 3501 _quoted strings_ when possible (and the string is relatively short).
     public var useQuotedString: Bool
 


### PR DESCRIPTION
We need `CommandEncodeBuffer` to be `Equatable`, but might as well make it `Hashable`. This required adding a few `Hashable` conformances downstream, and changing promoting existing `Equatable` conformance to `Hashable`.