### PR TITLE
Allow converting MailboxInfo.Attribute → UseAttribute

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxInfo.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxInfo.swift
@@ -83,6 +83,13 @@ extension MailboxInfo {
     }
 }
 
+extension String {
+    /// The raw value of the attribute, e.g. `\\trash`. Always lowercase.
+    public init(_ other: MailboxInfo.Attribute) {
+        self = other.backing
+    }
+}
+
 // MARK: - Encoding
 
 extension EncodeBuffer {

--- a/Sources/NIOIMAPCore/Grammar/UseAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/UseAttribute.swift
@@ -50,6 +50,14 @@ public struct UseAttribute: Equatable {
     }
 }
 
+extension UseAttribute {
+    /// Special Use can be returned as part of the `LIST` response. They’ll then be
+    /// wrapped in `MailboxInfo.Attribute`.
+    public init(_ other: MailboxInfo.Attribute) {
+        self.init(String(other))
+    }
+}
+
 extension String {
     /// The raw value of the attribute, e.g. `\\trash`. Always lowercase.
     public init(_ other: UseAttribute) {

--- a/Tests/NIOIMAPCoreTests/Grammar/UseAttribute+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UseAttribute+Tests.swift
@@ -42,4 +42,8 @@ extension UseAttribute_Tests {
         XCTAssertEqual(t1.stringValue, "test")
         XCTAssertEqual(t2.stringValue, "test")
     }
+
+    func testConvertFromMailboxInfoAttribute() {
+        XCTAssertEqual(UseAttribute(MailboxInfo.Attribute(#"\All"#)).stringValue, #"\all"#)
+    }
 }


### PR DESCRIPTION
Special Use can be returned as part of the `LIST` response. They’ll then be wrapped in `MailboxInfo.Attribute`.

See RFC 6154 section 5.1 — https://datatracker.ietf.org/doc/html/rfc6154#section-5.1

```
C: t1 LIST "" "%"
S: * LIST (\Marked \HasNoChildren) "/" Inbox
S: * LIST (\HasNoChildren) "/" ToDo
S: * LIST (\HasChildren) "/" Projects
S: * LIST (\Sent \HasNoChildren) "/" SentMail
S: * LIST (\Marked \Drafts \HasNoChildren) "/" MyDrafts
S: * LIST (\Trash \HasNoChildren) "/" Trash
S: t1 OK done
```
