### PR TITLE
Don’t upper case in MailboxName.debugDescription. Fixes #594

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
@@ -210,8 +210,7 @@ public struct MailboxName: Hashable {
 extension MailboxName: CustomDebugStringConvertible {
     /// Provides a human-readable description.
     public var debugDescription: String {
-        let bytes = self.bytes.readableBytesView.map { $0 & 0xDF }
-        return String(decoding: bytes, as: Unicode.UTF8.self)
+        String(bestEffortDecodingUTF8Bytes: self.bytes.readableBytesView)
     }
 }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxName+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxName+Tests.swift
@@ -104,6 +104,22 @@ extension MailboxName_Tests {
             XCTAssertTrue(e is InvalidPathSeparatorError)
         }
     }
+
+    func testCustomDebugStringConvertible() {
+        let inputs: [(MailboxName, String, UInt)] = [
+            (.inbox, "INBOX", #line),
+            (.init(ByteBuffer()), "", #line),
+            (.init(ByteBuffer("Food")), "Food", #line),
+            (.init(ByteBuffer("food")), "food", #line),
+            (.init(ByteBuffer("FOOD")), "FOOD", #line),
+            (.init(ByteBuffer("box/&AKM-")), "box/&AKM-", #line),
+            (.init(ByteBuffer("a\u{11}b")), "a\u{11}b", #line),
+            (.init(ByteBuffer("båd")), "båd", #line),
+        ]
+        for (name, expected, line) in inputs {
+            XCTAssertEqual(name.debugDescription, expected, line: line)
+        }
+    }
 }
 
 // MARK: - MailboxName


### PR DESCRIPTION
Previously `debugDescription` would output all-uppercase names.

We basically just want `debugDescription` to dump the raw bytes — potentially fixing any invalid UTF-8 if needed.