### PR TITLE
Add `init?(exactly:)` to `ModificationSequenceValue`

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Modifier/ModificationSequenceValue.swift
+++ b/Sources/NIOIMAPCore/Grammar/Modifier/ModificationSequenceValue.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 /// Represents the a *mod-sequence-value` as defined in RFC 7162.
 public struct ModificationSequenceValue: Hashable {
-    fileprivate var value: UInt64
+    var value: UInt64
 
     /// A  zero *mod-sequence-value*
     public static var zero: Self {
@@ -27,6 +27,18 @@ public struct ModificationSequenceValue: Hashable {
     /// - parameter value: The raw value.
     public init(_ value: UInt64) {
         precondition(value <= UInt64(Int64.max), "mod-sequence-values are 63-bit")
+        self.value = value
+    }
+
+    /// Creates a `ModificationSequenceValue` from some `BinaryInteger`, ensuring that the given value fits within the valid range `0...Int64.max`.
+    /// - parameter source: The raw value to use.
+    /// - returns: `nil` if `source` is not within the valid range.
+    public init?<T>(exactly source: T) where T: BinaryInteger {
+        guard
+            source >= 0,
+            let value = UInt64(exactly: source),
+            value <= UInt64(Int64.max)
+        else { return nil }
         self.value = value
     }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/Modifier/ModifierSequenceValue+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Modifier/ModifierSequenceValue+Tests.swift
@@ -17,6 +17,17 @@ import NIO
 import XCTest
 
 class ModifierSequenceValue_Tests: EncodeTestClass {
+    func testLossyConversionFromInteger() {
+        XCTAssertEqual(ModificationSequenceValue(exactly: 0)?.value, 0)
+        XCTAssertEqual(ModificationSequenceValue(exactly: 100 as Int64)?.value, 100)
+        XCTAssertEqual(ModificationSequenceValue(exactly: 100 as UInt64)?.value, 100)
+        XCTAssertEqual(ModificationSequenceValue(exactly: Int64.max)?.value, UInt64(Int64.max))
+
+        XCTAssertNil(ModificationSequenceValue(exactly: -1))
+        XCTAssertNil(ModificationSequenceValue(exactly: UInt64(Int64.max) + 1))
+        XCTAssertNil(ModificationSequenceValue(exactly: UInt64.max))
+    }
+
     func testModifierSequenceValue_encode() {
         let inputs: [(ModificationSequenceValue, String)] = ClosedRange(uncheckedBounds: (0, 10000)).map { num in
             (.init(integerLiteral: num), "\(num)")


### PR DESCRIPTION
To allow safe conversion of `UInt64` → `ModificationSequenceValue` since the latter is 63 bit only.