### PR TITLE
Update `MessageID` documentation. Hide implementation details.

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/MessageID.swift
+++ b/Sources/NIOIMAPCore/Grammar/MessageID.swift
@@ -13,14 +13,25 @@
 //===----------------------------------------------------------------------===//
 
 /// Represents the identifier of a message stored on a server.
-public struct MessageID: Hashable, RawRepresentable {
+///
+/// This is the “full” Message-ID, including the angled brackets, e.g.
+/// `<B27397-0100000@cac.washington.edu>`.
+///
+/// See RFC 2822 section 3.6.4.
+public struct MessageID: Hashable {
     /// The `String` message identifier.
-    public var rawValue: String
+    var rawValue: String
 
     /// Creates a new `MessageID` from the given string.
     /// - rawValue: The `String` message identifier.
-    public init(rawValue: String) {
+    public init(_ rawValue: String) {
         self.rawValue = rawValue
+    }
+}
+
+extension String {
+    public init(_ id: MessageID) {
+        self = id.rawValue
     }
 }
 

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
@@ -95,7 +95,7 @@ extension GrammarParser {
     static func parseMessageID(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageID? {
         if let parsed = try self.parseNString(buffer: &buffer, tracker: tracker) {
             let string = try ParserLibrary.parseBufferAsUTF8(parsed)
-            return .init(rawValue: string)
+            return .init(string)
         }
         return nil
     }


### PR DESCRIPTION
Message-IDs look like `<B27397-0100000@cac.washington.edu>` — and there’s often confusion about if the `<` + `>` are included in its representation. Thus, calling out that they are included helps. 😄 

Also: hide the `rawValue` implementation details to align with the project code style.