### PR TITLE
Use typealiases for `MessageIdentifier<>` generic types

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -94,19 +94,19 @@ public enum Command: Equatable {
     case idleStart
 
     /// Copies each message in a given set to a new mailbox, preserving the original in the current mailbox.
-    case copy(LastCommandSet<MessageIdentifierSet<SequenceNumber>>, MailboxName)
+    case copy(LastCommandSet<SequenceSet>, MailboxName)
 
     /// Fetches an array of specified attributes for each message in a given set.
-    case fetch(LastCommandSet<MessageIdentifierSet<SequenceNumber>>, [FetchAttribute], OrderedDictionary<String, ParameterValue?>)
+    case fetch(LastCommandSet<SequenceSet>, [FetchAttribute], OrderedDictionary<String, ParameterValue?>)
 
     /// Alters data associated with a message, typically returning the new data as an untagged fetch response.
-    case store(LastCommandSet<MessageIdentifierSet<SequenceNumber>>, [StoreModifier], StoreData)
+    case store(LastCommandSet<SequenceSet>, [StoreModifier], StoreData)
 
     /// Searches the currently-selected mailbox for messages that match the search criteria.
     case search(key: SearchKey, charset: String? = nil, returnOptions: [SearchReturnOption] = [])
 
     /// Moves each message in a given set into a new mailbox, removing the copy from the current mailbox.
-    case move(LastCommandSet<MessageIdentifierSet<SequenceNumber>>, MailboxName)
+    case move(LastCommandSet<SequenceSet>, MailboxName)
 
     /// Identifies the client to the server
     case id(OrderedDictionary<String, String?>)
@@ -490,7 +490,7 @@ extension CommandEncodeBuffer {
             }
     }
 
-    private mutating func writeCommandKind_copy(set: LastCommandSet<MessageIdentifierSet<SequenceNumber>>, mailbox: MailboxName) -> Int {
+    private mutating func writeCommandKind_copy(set: LastCommandSet<SequenceSet>, mailbox: MailboxName) -> Int {
         self.buffer.writeString("COPY ") +
             self.buffer.writeLastCommandSet(set) +
             self.buffer.writeSpace() +
@@ -504,7 +504,7 @@ extension CommandEncodeBuffer {
             self.buffer.writeMailbox(mailbox)
     }
 
-    private mutating func writeCommandKind_fetch(set: LastCommandSet<MessageIdentifierSet<SequenceNumber>>, atts: [FetchAttribute], modifiers: OrderedDictionary<String, ParameterValue?>) -> Int {
+    private mutating func writeCommandKind_fetch(set: LastCommandSet<SequenceSet>, atts: [FetchAttribute], modifiers: OrderedDictionary<String, ParameterValue?>) -> Int {
         self.buffer.writeString("FETCH ") +
             self.buffer.writeLastCommandSet(set) +
             self.buffer.writeSpace() +
@@ -524,7 +524,7 @@ extension CommandEncodeBuffer {
             }
     }
 
-    private mutating func writeCommandKind_store(set: LastCommandSet<MessageIdentifierSet<SequenceNumber>>, modifiers: [StoreModifier], data: StoreData) -> Int {
+    private mutating func writeCommandKind_store(set: LastCommandSet<SequenceSet>, modifiers: [StoreModifier], data: StoreData) -> Int {
         self.buffer.writeString("STORE ") +
             self.buffer.writeLastCommandSet(set) +
             self.buffer.write(if: modifiers.count >= 1) {
@@ -564,7 +564,7 @@ extension CommandEncodeBuffer {
             self.writeCommandKind_search(key: key, charset: charset, returnOptions: returnOptions)
     }
 
-    private mutating func writeCommandKind_move(set: LastCommandSet<MessageIdentifierSet<SequenceNumber>>, mailbox: MailboxName) -> Int {
+    private mutating func writeCommandKind_move(set: LastCommandSet<SequenceSet>, mailbox: MailboxName) -> Int {
         self.buffer.writeString("MOVE ") +
             self.buffer.writeLastCommandSet(set) +
             self.buffer.writeSpace() +
@@ -620,7 +620,7 @@ extension Command {
     /// - parameter messages: The set of message UIDs to use.
     /// - parameter mailbox: The destination mailbox.
     /// - returns: `nil` if `messages` is empty, otherwise a `Command`.
-    public static func uidMove(messages: MessageIdentifierSet<UID>, mailbox: MailboxName) -> Command? {
+    public static func uidMove(messages: UIDSet, mailbox: MailboxName) -> Command? {
         guard let set = MessageIdentifierSetNonEmpty(set: messages) else {
             return nil
         }
@@ -632,7 +632,7 @@ extension Command {
     /// - parameter messages: The set of message UIDs to use.
     /// - parameter mailbox: The destination mailbox.
     /// - returns: `nil` if `messages` is empty, otherwise a `Command`.
-    public static func uidCopy(messages: MessageIdentifierSet<UID>, mailbox: MailboxName) -> Command? {
+    public static func uidCopy(messages: UIDSet, mailbox: MailboxName) -> Command? {
         guard let set = MessageIdentifierSetNonEmpty(set: messages) else {
             return nil
         }
@@ -645,7 +645,7 @@ extension Command {
     /// - parameter attributes: Which attributes to retrieve.
     /// - parameter modifiers: Fetch modifiers.
     /// - returns: `nil` if `messages` is empty, otherwise a `Command`.
-    public static func uidFetch(messages: MessageIdentifierSet<UID>, attributes: [FetchAttribute], modifiers: OrderedDictionary<String, ParameterValue?>) -> Command? {
+    public static func uidFetch(messages: UIDSet, attributes: [FetchAttribute], modifiers: OrderedDictionary<String, ParameterValue?>) -> Command? {
         guard let set = MessageIdentifierSetNonEmpty(set: messages) else {
             return nil
         }
@@ -658,7 +658,7 @@ extension Command {
     /// - parameter modifiers: Store modifiers.
     /// - parameter flags: The flags to store.
     /// - returns: `nil` if `messages` is empty, otherwise a `Command`.
-    public static func uidStore(messages: MessageIdentifierSet<UID>, modifiers: OrderedDictionary<String, ParameterValue?>, data: StoreData) -> Command? {
+    public static func uidStore(messages: UIDSet, modifiers: OrderedDictionary<String, ParameterValue?>, data: StoreData) -> Command? {
         guard let set = MessageIdentifierSetNonEmpty(set: messages) else {
             return nil
         }
@@ -669,7 +669,7 @@ extension Command {
     /// Pass in a `UIDSet`, and if that set is valid (i.e. non-empty) then a command is returned.
     /// - parameter messages: The set of message UIDs to use.
     /// - returns: `nil` if `messages` is empty, otherwise a `Command`.
-    public static func uidExpunge(messages: MessageIdentifierSet<UID>, mailbox: MailboxName) -> Command? {
+    public static func uidExpunge(messages: UIDSet, mailbox: MailboxName) -> Command? {
         guard let set = MessageIdentifierSetNonEmpty(set: messages) else {
             return nil
         }

--- a/Sources/NIOIMAPCore/Grammar/Message/MessageData.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/MessageData.swift
@@ -23,14 +23,14 @@ public enum MessageData: Equatable {
     /// The VANISHED UID FETCH modifier instructs the server to report those
     /// messages from the UID set parameter that have been expunged and whose
     /// associated mod-sequence is larger than the specified mod-sequence.
-    case vanished(MessageIdentifierSet<UID>)
+    case vanished(UIDSet)
 
     /// RFC 7162 Condstore
     /// The VANISHED (EARLIER) response is caused by a UID FETCH (VANISHED)
     /// or a SELECT/EXAMINE (QRESYNC) command.  This response is sent if the
     /// UID set parameter to the UID FETCH (VANISHED) command includes UIDs
     /// of messages that are no longer in the mailbox.
-    case vanishedEarlier(MessageIdentifierSet<UID>)
+    case vanishedEarlier(UIDSet)
 
     /// An array of URLAUTH-authorized URLs
     case generateAuthorizedURL([ByteBuffer])

--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseCodeCopy.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseCodeCopy.swift
@@ -21,16 +21,16 @@ public struct ResponseCodeCopy: Equatable {
     public var destinationUIDValidity: UIDValidity
 
     /// The message UIDs in the source mailbox.
-    public var sourceUIDs: [MessageIdentifierRange<UID>]
+    public var sourceUIDs: [UIDRange]
 
     /// The copied message UIDs in the destination mailbox.
-    public var destinationUIDs: [MessageIdentifierRange<UID>]
+    public var destinationUIDs: [UIDRange]
 
     /// Creates a new `ResponseCodeCopy`.
     /// - parameter destinationUIDValidity: The `UIDValidity` of the destination mailbox.
     /// - parameter sourceUIDs: The message UIDs in the source mailbox.
     /// - parameter destinationUIDs: The copied message UIDs in the destination mailbox.
-    public init(destinationUIDValidity: UIDValidity, sourceUIDs: [MessageIdentifierRange<UID>], destinationUIDs: [MessageIdentifierRange<UID>]) {
+    public init(destinationUIDValidity: UIDValidity, sourceUIDs: [UIDRange], destinationUIDs: [UIDRange]) {
         self.destinationUIDValidity = destinationUIDValidity
         self.sourceUIDs = sourceUIDs
         self.destinationUIDs = destinationUIDs
@@ -47,7 +47,7 @@ extension EncodeBuffer {
             self.writeUIDRangeArray(data.destinationUIDs)
     }
 
-    @discardableResult private mutating func writeUIDRangeArray(_ array: [MessageIdentifierRange<UID>]) -> Int {
+    @discardableResult private mutating func writeUIDRangeArray(_ array: [UIDRange]) -> Int {
         self.writeArray(array, separator: ",", parenthesis: false) { (element, self) in
             self.writeMessageIdentifierRange(element)
         }

--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
@@ -132,7 +132,7 @@ public enum ResponseTextCode: Equatable {
 
     /// Used with an OK response to the STORE command.  (It can also be used in a NO
     /// response.)
-    case modificationSequence(LastCommandSet<MessageIdentifierSet<SequenceNumber>>)
+    case modificationSequence(LastCommandSet<SequenceSet>)
 
     /// A server supporting the persistent storage of mod-sequences for the mailbox
     /// MUST send the OK untagged response including HIGHESTMODSEQ response

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchKey.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchKey.swift
@@ -122,7 +122,7 @@ public indirect enum SearchKey: Hashable {
     case uid(LastCommandSet<MessageIdentifierSetNonEmpty<UID>>)
 
     /// RFC 3501: Messages that match a given sequence set.
-    case sequenceNumbers(LastCommandSet<MessageIdentifierSet<SequenceNumber>>)
+    case sequenceNumbers(LastCommandSet<SequenceSet>)
 
     /// RFC 3501: Messages that match all of the given keys.
     case and([SearchKey])

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchReturnData.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchReturnData.swift
@@ -23,7 +23,7 @@ public enum SearchReturnData: Equatable {
     case max(Int)
 
     /// Return all message numbers/UIDs that satisfy the SEARCH criteria.
-    case all(LastCommandSet<MessageIdentifierSet<SequenceNumber>>)
+    case all(LastCommandSet<SequenceSet>)
 
     /// Return number of the messages that satisfy the SEARCH criteria.
     case count(Int)

--- a/Sources/NIOIMAPCore/Grammar/SelectParameter.swift
+++ b/Sources/NIOIMAPCore/Grammar/SelectParameter.swift
@@ -22,7 +22,7 @@ public struct QResyncParameter: Equatable {
     public var modificationSequenceValue: ModificationSequenceValue
 
     /// The optional set of known UIDs.
-    public var knownUIDs: MessageIdentifierSet<UID>?
+    public var knownUIDs: UIDSet?
 
     /// An optional parenthesized list of known sequence ranges and their corresponding UIDs.
     public var sequenceMatchData: SequenceMatchData?
@@ -32,7 +32,7 @@ public struct QResyncParameter: Equatable {
     /// - parameter modificationSequenceValue: The last known modification sequence
     /// - parameter knownUIDs: The optional set of known UIDs.
     /// - parameter sequenceMatchData: An optional parenthesized list of known sequence ranges and their corresponding UIDs.
-    public init(uidValidity: UIDValidity, modificationSequenceValue: ModificationSequenceValue, knownUIDs: MessageIdentifierSet<UID>?, sequenceMatchData: SequenceMatchData?) {
+    public init(uidValidity: UIDValidity, modificationSequenceValue: ModificationSequenceValue, knownUIDs: UIDSet?, sequenceMatchData: SequenceMatchData?) {
         self.uidValidity = uidValidity
         self.modificationSequenceValue = modificationSequenceValue
         self.knownUIDs = knownUIDs

--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceRange.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 // MARK: - Encoding
 
 extension EncodeBuffer {
-    @discardableResult mutating func writeSequenceRange(_ range: MessageIdentifierRange<SequenceNumber>) -> Int {
+    @discardableResult mutating func writeSequenceRange(_ range: SequenceRange) -> Int {
         self.writeSequenceNumberOrWildcard(range.range.lowerBound) +
             self.write(if: range.range.lowerBound < range.range.upperBound) {
                 self.writeString(":") +

--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceSet.swift
@@ -14,11 +14,11 @@
 
 import struct NIO.ByteBuffer
 
-extension LastCommandSet where SetType == MessageIdentifierSet<SequenceNumber> {
+extension LastCommandSet where SetType == SequenceSet {
     /// Creates a `SequenceSet` from a non-empty array of `SequenceRange`.
     /// - parameter ranges: An array of `SequenceRange` to use.
     /// - returns: `nil` if `ranges` is empty, otherwise a new `SequenceSet`.
-    public init?(_ ranges: [MessageIdentifierRange<SequenceNumber>]) {
+    public init?(_ ranges: [SequenceRange]) {
         guard !ranges.isEmpty else {
             return nil
         }
@@ -28,29 +28,29 @@ extension LastCommandSet where SetType == MessageIdentifierSet<SequenceNumber> {
     /// Creates a `SequenceSet` from a single range.
     /// - parameter range: The underlying range to use.
     public init(_ range: ClosedRange<SequenceNumber>) {
-        self = .set(MessageIdentifierSet<SequenceNumber>(range))
+        self = .set(SequenceSet(range))
     }
 
     /// Creates a `SequenceSet` from a single range.
     /// - parameter range: The underlying range to use from `.min`.
     public init(_ range: PartialRangeThrough<SequenceNumber>) {
-        self = .set(MessageIdentifierSet<SequenceNumber>(range))
+        self = .set(SequenceSet(range))
     }
 
     /// Creates a `SequenceSet` from a single range.
     /// - parameter range: The underlying range to use, up to `.max`.
     public init(_ range: PartialRangeFrom<SequenceNumber>) {
-        self = .set(MessageIdentifierSet<SequenceNumber>(range))
+        self = .set(SequenceSet(range))
     }
 
     /// Creates a `SequenceSet` from a single range.
     /// - parameter range: The underlying range to use.
-    public init(_ range: MessageIdentifierRange<SequenceNumber>) {
-        self = .set(MessageIdentifierSet<SequenceNumber>(range))
+    public init(_ range: SequenceRange) {
+        self = .set(SequenceSet(range))
     }
 }
 
-extension LastCommandSet where SetType == MessageIdentifierSet<SequenceNumber> {
+extension LastCommandSet where SetType == SequenceSet {
     /// A `SequenceSet` that contains a single `SequenceRangeSet`, that in turn covers every possible `SequenceNumber`.
-    public static let all: Self = .set(MessageIdentifierSet<SequenceNumber>.all)
+    public static let all: Self = .set(SequenceSet.all)
 }

--- a/Sources/NIOIMAPCore/Grammar/Tagged/ParameterValue.swift
+++ b/Sources/NIOIMAPCore/Grammar/Tagged/ParameterValue.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 /// Implemented as a catch-all to support types defined in future extensions.
 public enum ParameterValue: Hashable {
     /// Specifies a `SequenceSet` as the value.
-    case sequence(LastCommandSet<MessageIdentifierSet<SequenceNumber>>)
+    case sequence(LastCommandSet<SequenceSet>)
 
     /// Uses an array of `String` as the value.
     case comp([String])

--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -15,6 +15,21 @@
 import struct NIO.ByteBuffer
 import StandardLibraryPreview
 
+/// See `MessageIdentifierRange<SequenceNumber>`
+public typealias SequenceRange = MessageIdentifierRange<SequenceNumber>
+
+/// See `MessageIdentifierRange<UID>`
+public typealias UIDRange = MessageIdentifierRange<UID>
+
+/// See `MessageIdentifierSet<SequenceNumber>`
+public typealias SequenceSet = MessageIdentifierSet<SequenceNumber>
+
+/// See `MessageIdentifierSet<UID>`
+public typealias UIDSet = MessageIdentifierSet<UID>
+
+/// See `MessageIdentifierSetNonEmpty<UID>`
+public typealias UIDSetNonEmpty = MessageIdentifierSetNonEmpty<UID>
+
 /// A set contains an array of `UIDRange` to represent a (potentially large) collection of messages.
 ///
 /// UIDs are _not_ sorted.

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
@@ -25,7 +25,7 @@ import struct NIO.ByteBufferView
 
 extension GrammarParser {
     // uid-range       = (uniqueid ":" uniqueid)
-    static func parseUIDRange(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<UID> {
+    static func parseUIDRange(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
         func parse_wildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UID {
             try PL.parseFixedString("*", buffer: &buffer, tracker: tracker)
             return .max
@@ -45,16 +45,16 @@ extension GrammarParser {
             return try parse_UIDOrWildcard(buffer: &buffer, tracker: tracker)
         }
 
-        return try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> MessageIdentifierRange<UID> in
+        return try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> UIDRange in
             let id1 = try parse_UIDOrWildcard(buffer: &buffer, tracker: tracker)
             let id2 = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: parse_colonAndUIDOrWildcard)
             if let id2 = id2 {
                 guard id1 <= id2 else {
                     throw ParserError(hint: "Invalid range \(id1):\(id2)")
                 }
-                return MessageIdentifierRange<UID>(id1 ... id2)
+                return UIDRange(id1 ... id2)
             } else {
-                return MessageIdentifierRange<UID>(id1)
+                return UIDRange(id1)
             }
         }
     }
@@ -76,13 +76,13 @@ extension GrammarParser {
     }
 
     // uid-set
-    static func parseUIDSet(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierSet<UID> {
-        func parseUIDSet_number(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<UID> {
+    static func parseUIDSet(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDSet {
+        func parseUIDSet_number(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
             let num = try self.parseUID(buffer: &buffer, tracker: tracker)
-            return MessageIdentifierRange<UID>(num)
+            return UIDRange(num)
         }
 
-        func parseUIDSet_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<UID> {
+        func parseUIDSet_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
             try PL.parseOneOf(
                 self.parseUIDRange,
                 parseUIDSet_number,
@@ -114,13 +114,13 @@ extension GrammarParser {
         }
     }
 
-    static func parseUIDRangeArray(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [MessageIdentifierRange<UID>] {
-        func parseUIDArray_number(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<UID> {
+    static func parseUIDRangeArray(buffer: inout ParseBuffer, tracker: StackTracker) throws -> [UIDRange] {
+        func parseUIDArray_number(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
             let num = try self.parseUID(buffer: &buffer, tracker: tracker)
-            return MessageIdentifierRange<UID>(num)
+            return UIDRange(num)
         }
 
-        func parseUIDArray_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<UID> {
+        func parseUIDArray_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> UIDRange {
             try PL.parseOneOf(
                 self.parseUIDRange,
                 parseUIDArray_number,

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -1909,7 +1909,7 @@ extension GrammarParser {
             let uidValidity = try self.parseUIDValidity(buffer: &buffer, tracker: tracker)
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
             let modSeqVal = try self.parseModificationSequenceValue(buffer: &buffer, tracker: tracker)
-            let knownUIDs = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: { (buffer, tracker) -> MessageIdentifierSet<UID> in
+            let knownUIDs = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: { (buffer, tracker) -> UIDSet in
                 try PL.parseSpaces(buffer: &buffer, tracker: tracker)
                 return try self.parseUIDSet(buffer: &buffer, tracker: tracker)
             })


### PR DESCRIPTION
`UIDRange` == `MessageIdentifierRange<UID>`
`UIDSet` == `MessageIdentifierSet<UID>`
`UIDSetNonEmpty` == `MessageIdentifierSetNonEmpty<UID>`

`SequenceRange` == `MessageIdentifierRange<SequenceNumber>`
`SequenceSet` == `MessageIdentifierSet<SequenceNumber>`