### PR TITLE
Implement generic parseMessageIdentifierSet

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
@@ -231,7 +231,7 @@ extension GrammarParser {
     static func parseCommandSuffix_store(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
-            let sequence = try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
+            let sequence: LastCommandSet<SequenceSet> = try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker)
             let modifiers = try PL.parseOptional(buffer: &buffer, tracker: tracker) { buffer, tracker -> [StoreModifier] in
                 try PL.parseSpaces(buffer: &buffer, tracker: tracker)
                 try PL.parseFixedString("(", buffer: &buffer, tracker: tracker)
@@ -260,7 +260,7 @@ extension GrammarParser {
     static func parseCommandSuffix_move(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
-            let set = try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
+            let set: LastCommandSet<SequenceSet> = try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker)
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
             return .move(set, mailbox)
@@ -280,7 +280,7 @@ extension GrammarParser {
     static func parseCommandSuffix_copy(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
-            let sequence = try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
+            let sequence: LastCommandSet<SequenceSet> = try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker)
             try PL.parseFixedString(" ", buffer: &buffer, tracker: tracker)
             let mailbox = try self.parseMailbox(buffer: &buffer, tracker: tracker)
             return .copy(sequence, mailbox)
@@ -475,7 +475,7 @@ extension GrammarParser {
     static func parseCommandSuffix_fetch(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
-            let sequence = try self.parseSequenceSet(buffer: &buffer, tracker: tracker)
+            let sequence: LastCommandSet<SequenceSet> = try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker)
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
             let att = try parseFetch_type(buffer: &buffer, tracker: tracker)
             let modifiers = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: self.parseParameters) ?? [:]

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
@@ -220,7 +220,7 @@ extension GrammarParser {
 
         func parseResponseTextCode_modified(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
             try PL.parseFixedString("MODIFIED ", buffer: &buffer, tracker: tracker)
-            return .modificationSequence(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
+            return .modificationSequence(try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker))
         }
 
         func parseResponseTextCode_highestModifiedSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
@@ -293,7 +293,7 @@ extension GrammarParser {
         }
 
         func parseSearchKey_sequenceSet(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
-            .sequenceNumbers(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
+            .sequenceNumbers(try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker))
         }
 
         func parseSearchKey_array(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchKey {
@@ -407,7 +407,7 @@ extension GrammarParser {
 
         func parseSearchReturnData_all(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
             try PL.parseFixedString("ALL ", buffer: &buffer, tracker: tracker)
-            return .all(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
+            return .all(try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker))
         }
 
         func parseSearchReturnData_count(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -2221,7 +2221,7 @@ extension GrammarParser {
     //                       "(" [tagged-ext-comp] ")"
     static func parseParameterValue(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ParameterValue {
         func parseTaggedExtensionSimple_set(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ParameterValue {
-            .sequence(try self.parseSequenceSet(buffer: &buffer, tracker: tracker))
+            .sequence(try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker))
         }
 
         func parseTaggedExtensionVal_comp(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ParameterValue {

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Sequence.swift
@@ -23,7 +23,7 @@ class GrammarParser_Sequence_Tests: XCTestCase, _ParserTestHelpers {}
 extension GrammarParser_Sequence_Tests {
     func testSequenceSet() {
         self.iterateTests(
-            testFunction: GrammarParser.parseSequenceSet,
+            testFunction: GrammarParser.parseMessageIdentifierSet,
             validInputs: [
                 ("765", " ", .set([765]), #line),
                 ("1,2:5,7,9:*", " ", .set([MessageIdentifierRange<SequenceNumber>(1), MessageIdentifierRange<SequenceNumber>(2 ... 5), MessageIdentifierRange<SequenceNumber>(7), MessageIdentifierRange<SequenceNumber>(9...)]), #line),


### PR DESCRIPTION
`parseSequenceSet` wasn't generic yet, however it was about to be.