### PR TITLE
Rename modificationSequence to modification

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
@@ -132,7 +132,7 @@ public enum ResponseTextCode: Hashable {
 
     /// Used with an OK response to the STORE command.  (It can also be used in a NO
     /// response.)
-    case modificationSequence(LastCommandSet<SequenceSet>)
+    case modified(LastCommandSet<MessageIdentifierSet<UnknownMessageIdentifier>>)
 
     /// A server supporting the persistent storage of mod-sequences for the mailbox
     /// MUST send the OK untagged response including HIGHESTMODSEQ response
@@ -309,7 +309,7 @@ extension EncodeBuffer {
             return self.writeString("CLOSED")
         case .noModificationSequence:
             return self.writeString("NOMODSEQ")
-        case .modificationSequence(let set):
+        case .modified(let set):
             return self.writeString("MODIFIED ") + self.writeLastCommandSet(set)
         case .highestModificationSequence(let val):
             return self.writeString("HIGHESTMODSEQ ") + self.writeModificationSequenceValue(val)

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
@@ -220,7 +220,7 @@ extension GrammarParser {
 
         func parseResponseTextCode_modified(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {
             try PL.parseFixedString("MODIFIED ", buffer: &buffer, tracker: tracker)
-            return .modificationSequence(try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker))
+            return .modified(try self.parseMessageIdentifierSet(buffer: &buffer, tracker: tracker))
         }
 
         func parseResponseTextCode_highestModifiedSequence(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ResponseTextCode {

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/ResponseTextCodeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/ResponseTextCodeTests.swift
@@ -44,7 +44,7 @@ extension ResponseTextCodeTests {
             (.notSaved, "NOTSAVED", #line),
             (.closed, "CLOSED", #line),
             (.noModificationSequence, "NOMODSEQ", #line),
-            (.modificationSequence(.set([1])), "MODIFIED 1", #line),
+            (.modified(.set([1])), "MODIFIED 1", #line),
             (.highestModificationSequence(1), "HIGHESTMODSEQ 1", #line),
             (.metadataMaxsize(123), "METADATA MAXSIZE 123", #line),
             (.metadataLongEntries(456), "METADATA LONGENTRIES 456", #line),

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Response+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Response+Tests.swift
@@ -77,7 +77,7 @@ extension GrammarParser_Response_Tests {
                 ("UIDVALIDITY 34", "\r", .uidValidity(34), #line),
                 ("UNSEEN 56", "\r", .unseen(56), #line),
                 ("NOMODSEQ", "\r", .noModificationSequence, #line),
-                ("MODIFIED 1", "\r", .modificationSequence(.set([1])), #line),
+                ("MODIFIED 1", "\r", .modified(.set([1])), #line),
                 ("HIGHESTMODSEQ 1", "\r", .highestModificationSequence(.init(integerLiteral: 1)), #line),
                 ("NAMESPACE NIL NIL NIL", "\r", .namespace(.init(userNamespace: [], otherUserNamespace: [], sharedNamespace: [])), #line),
                 ("some", "\r", .other("some", nil), #line),


### PR DESCRIPTION
Resolves #604 

Rename `modificationSequence` to just `modified` as it might not contain `SequenceNumber`s. Also change the associated type from `SequenceSet` (aka `MessageIdentifierSet<SequenceNumber`>) to `UnknownIdentifier`, which can then be treated as either `UID`s or `SequenceNumber`s depending on what the user is expecting.

(Note this is required as it is impossible to distinguish between `SequenceNumber`s and `UID`s when parsing).