### PR TITLE
Disallow directo conversion between SequenceNumber and UID

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Sequence/SequenceNumber.swift
+++ b/Sources/NIOIMAPCore/Grammar/Sequence/SequenceNumber.swift
@@ -26,6 +26,20 @@ public struct SequenceNumber: MessageIdentifier {
     }
 }
 
+// MARK: - Conversion
+
+extension SequenceNumber {
+    init(_ other: UnknownMessageIdentifier) {
+        self.init(rawValue: other.rawValue)
+    }
+}
+
+extension UnknownMessageIdentifier {
+    init(_ other: SequenceNumber) {
+        self.init(rawValue: other.rawValue)
+    }
+}
+
 // MARK: - Encoding
 
 extension EncodeBuffer {

--- a/Sources/NIOIMAPCore/Grammar/UID/UID.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UID.swift
@@ -86,16 +86,23 @@ public struct UnknownMessageIdentifier: MessageIdentifier {
     }
 }
 
-extension MessageIdentifier {
-    /// Used to convert between `UID`, `SequenceNumber`, and `UnknownMessageIdentifier`.
-    init<T: MessageIdentifier>(id: T) {
-        self.init(rawValue: id.rawValue)
-    }
-}
-
 extension BinaryInteger {
     public init<IdentifierType: MessageIdentifier>(_ id: IdentifierType) {
         self = Self(id.rawValue)
+    }
+}
+
+// MARK: - Conversion
+
+extension UID {
+    init(_ other: UnknownMessageIdentifier) {
+        self.init(rawValue: other.rawValue)
+    }
+}
+
+extension UnknownMessageIdentifier {
+    init(_ other: UID) {
+        self.init(rawValue: other.rawValue)
     }
 }
 


### PR DESCRIPTION
With this, you’d have to explicitly go through `UnknownMessageIdentifier`.