### PR TITLE
Convert line length limit to 8192

### DIFF
--- a/Sources/NIOIMAP/Client/FrameDecoder.swift
+++ b/Sources/NIOIMAP/Client/FrameDecoder.swift
@@ -20,7 +20,7 @@ public struct FrameDecoder: ByteToMessageDecoder {
 
     private var framingParser: FramingParser
 
-    public init(frameSizeLimit: Int = FramingParser.defaultFrameSizeLimit) {
+    public init(frameSizeLimit: Int = IMAPDefaults.lineLengthLimit) {
         self.framingParser = FramingParser(bufferSizeLimit: frameSizeLimit)
     }
 

--- a/Sources/NIOIMAP/Client/FramingParser.swift
+++ b/Sources/NIOIMAP/Client/FramingParser.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
+import NIOIMAPCore
 
 private let LITERAL_HEADER_START = UInt8(ascii: "{")
 private let LITERAL_HEADER_END = UInt8(ascii: "}")
@@ -110,9 +111,6 @@ enum FrameStatus: Hashable {
 }
 
 public struct FramingParser: Hashable {
-    /// RFC 3501 states that a line should be no more than 1000 bytes.
-    public static let defaultFrameSizeLimit = 1_000
-
     enum LiteralHeaderState: Hashable {
         case findingBinaryFlag
         case findingSize(ByteBuffer)
@@ -133,7 +131,7 @@ public struct FramingParser: Hashable {
     var buffer = ByteBuffer()
     var bufferSizeLimit: Int
 
-    @_spi(NIOIMAPInternal) public init(bufferSizeLimit: Int = Self.defaultFrameSizeLimit) {
+    @_spi(NIOIMAPInternal) public init(bufferSizeLimit: Int = IMAPDefaults.lineLengthLimit) {
         self.bufferSizeLimit = bufferSizeLimit
     }
 

--- a/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
@@ -44,7 +44,7 @@ public final class IMAPClientHandler: ChannelDuplexHandler {
 
     public init(encodingChangeCallback: @escaping (OrderedDictionary<String, String?>, inout CommandEncodingOptions) -> Void = { _, _ in }) {
         self.state = .init(encodingOptions: CommandEncodingOptions(capabilities: self.lastKnownCapabilities))
-        self.decoder = NIOSingleStepByteToMessageProcessor(ResponseDecoder(), maximumBufferSize: 1_000)
+        self.decoder = NIOSingleStepByteToMessageProcessor(ResponseDecoder(), maximumBufferSize: IMAPDefaults.lineLengthLimit)
         self.encodingChangeCallback = encodingChangeCallback
         self.lastKnownCapabilities = []
     }

--- a/Sources/NIOIMAP/Coders/IMAPServerHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPServerHandler.swift
@@ -60,7 +60,7 @@ public final class IMAPServerHandler: ChannelDuplexHandler {
     public var capabilities: [Capability] = []
 
     public init(continuationRequest: ContinuationRequest = .responseText(ResponseText(text: "OK"))) {
-        self.decoder = NIOSingleStepByteToMessageProcessor(CommandDecoder(), maximumBufferSize: 1_000)
+        self.decoder = NIOSingleStepByteToMessageProcessor(CommandDecoder(), maximumBufferSize: IMAPDefaults.lineLengthLimit)
         self._continuationRequest = continuationRequest
         let buffer = ByteBufferAllocator().buffer(capacity: 16)
         var encodeBuffer = ResponseEncodeBuffer(buffer: buffer, capabilities: self.capabilities)

--- a/Sources/NIOIMAPCore/IMAPDefaults.swift
+++ b/Sources/NIOIMAPCore/IMAPDefaults.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public struct IMAPDefaults {
+    /// A line should be no more than 8192 bytes according to RFC 7162 section 4.
+    public static let lineLengthLimit: Int = 8_192
+
+    private init() {}
+}

--- a/Sources/NIOIMAPCore/Parser/CommandParser.swift
+++ b/Sources/NIOIMAPCore/Parser/CommandParser.swift
@@ -58,8 +58,8 @@ public struct CommandParser: Parser {
     private var synchronisingLiteralParser = SynchronizingLiteralParser()
 
     /// Creates a new `CommandParser` with a built in buffer limit. Used to prevent DOS attacks, an error will be thrown if this limit is exceeded.
-    /// - parameter bufferLimit. The maximum size of the buffer in bytes at any one time. Defaults to 1000 bytes.
-    public init(bufferLimit: Int = 1_000) {
+    /// - parameter bufferLimit. The maximum size of the buffer in bytes at any one time. Defaults to 8192 bytes.
+    public init(bufferLimit: Int = IMAPDefaults.lineLengthLimit) {
         self.bufferLimit = bufferLimit
     }
 

--- a/Sources/NIOIMAPCore/Parser/ResponseParser.swift
+++ b/Sources/NIOIMAPCore/Parser/ResponseParser.swift
@@ -39,7 +39,7 @@ public struct ResponseParser: Parser {
 
     /// Creates a new `ResponseParser`.
     /// - parameter bufferLimit: The maximum amount of data that may be buffered by the parser. If this limit is exceeded then an error will be thrown. Defaults to 1000 bytes.
-    public init(bufferLimit: Int = 1_000) {
+    public init(bufferLimit: Int = 8_192) {
         self.bufferLimit = bufferLimit
         self.mode = .response(.fetchOrNormal)
     }

--- a/Tests/NIOIMAPCoreTests/Parser/CommandParser+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/CommandParser+Tests.swift
@@ -23,7 +23,7 @@ class CommandParser_Tests: XCTestCase {}
 extension CommandParser_Tests {
     func testInit_defaultBufferSize() {
         let parser = CommandParser()
-        XCTAssertEqual(parser.bufferLimit, 1_000)
+        XCTAssertEqual(parser.bufferLimit, 8_192)
     }
 
     func testInit_customBufferSize() {

--- a/Tests/NIOIMAPCoreTests/Parser/ResponseParser+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/ResponseParser+Tests.swift
@@ -23,7 +23,7 @@ class ResponseParser_Tests: XCTestCase {}
 extension ResponseParser_Tests {
     func testInit_defaultBufferSize() {
         let parser = CommandParser()
-        XCTAssertEqual(parser.bufferLimit, 1_000)
+        XCTAssertEqual(parser.bufferLimit, 8_192)
     }
 
     func testInit_customBufferSize() {


### PR DESCRIPTION
Resolves #663 

Convert the default limits from 1000 to 8192 octets, as per RFC 7162.