### PR TITLE
FramingParser additions

### DIFF
--- a/Sources/NIOIMAP/Client/FramingParser.swift
+++ b/Sources/NIOIMAP/Client/FramingParser.swift
@@ -151,7 +151,7 @@ public struct FramingParser: Hashable {
         }
         self.buffer.writeBuffer(&buffer)
 
-        return try adjustBufferAndParseFrames()
+        return try self.adjustBufferAndParseFrames()
     }
 
     @_spi(NIOIMAPInternal) public mutating func appendAndFrameBytes(_ bytes: UnsafeRawBufferPointer) throws -> [FramingResult] {
@@ -162,11 +162,11 @@ public struct FramingParser: Hashable {
 
         self.buffer.writeBytes(bytes)
 
-        return try adjustBufferAndParseFrames()
+        return try self.adjustBufferAndParseFrames()
     }
 
     @_spi(NIOIMAPInternal) public var inputBufferByteCount: Int {
-        buffer.readableBytes
+        self.buffer.readableBytes
     }
 
     private mutating func adjustBufferAndParseFrames() throws -> [FramingResult] {

--- a/Tests/NIOIMAPTests/FramingParserTests.swift
+++ b/Tests/NIOIMAPTests/FramingParserTests.swift
@@ -71,7 +71,7 @@ extension FramingParserTests {
         buffer = " 2\r\n"
         XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("* SEARCH 2\r\n")])
     }
-    
+
     func testSimpleCommandTimes2() {
         var buffer: ByteBuffer = "A1 NOOP\r\nA2 NOOP\r\n"
         XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("A1 NOOP\r\n"), .complete("A2 NOOP\r\n")])


### PR DESCRIPTION
Support appending a `UnsafeRawBufferPointer`. This is useful when the input is `Data` or `DispatchData`.

Add `inputBufferByteCount: Int` property -- which is useful for logging and tests.

Add `testTwoCommandsAcrossMultipleBuffers()` test case.
