### PR TITLE
Make MessageIdentifierSet.RangeView conform to RandomAccessCollection

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -148,15 +148,14 @@ extension MessageIdentifierSet {
 }
 
 extension MessageIdentifierSet {
-    public struct RangeView: Sequence {
+    public struct RangeView: RandomAccessCollection {
         fileprivate var underlying: RangeSet<MessageIdentificationShiftWrapper>.Ranges
 
-        public func makeIterator() -> AnyIterator<MessageIdentifierRange<IdentifierType>> {
-            var u = underlying.makeIterator()
-            return AnyIterator {
-                guard let r = u.next() else { return nil }
-                return MessageIdentifierRange<IdentifierType>(r)
-            }
+        public var startIndex: Int { underlying.startIndex }
+        public var endIndex: Int { underlying.endIndex }
+
+        public subscript(i: Int) -> MessageIdentifierRange<IdentifierType> {
+            MessageIdentifierRange<IdentifierType>(underlying[i])
         }
     }
 


### PR DESCRIPTION
We need to loop over the ranges in reverse order.

The underlying `RangeSet.Ranges` already conforms to `RandomAccessCollection`, and thus this just requires calling into that implementation.