### PR TITLE
Always encode non-synchronizing literal with `+`

### DIFF
--- a/Sources/NIOIMAPCore/ByteBuffer+WriteLiteral.swift
+++ b/Sources/NIOIMAPCore/ByteBuffer+WriteLiteral.swift
@@ -45,10 +45,8 @@ extension EncodeBuffer {
             return writeString("{\(bytes.count)}\r\n") + writeBytes(bytes)
         case .clientSynchronizingLiteral:
             return writeString("{\(bytes.count)}\r\n") + markStopPoint() + writeBytes(bytes)
-        case .clientNonSynchronizingLiteralPlus:
+        case .clientNonSynchronizingLiteral:
             return writeString("{\(bytes.count)+}\r\n") + writeBytes(bytes)
-        case .clientNonSynchronizingLiteralMinus:
-            return writeString("{\(bytes.count)-}\r\n") + writeBytes(bytes)
         }
     }
 
@@ -60,9 +58,7 @@ extension EncodeBuffer {
         /// `{7}CRLF` + `foo bar`
         case clientSynchronizingLiteral
         /// `{7+}CRLFfoo bar`
-        case clientNonSynchronizingLiteralPlus
-        /// `{7-}CRLFfoo bar`
-        case clientNonSynchronizingLiteralMinus
+        case clientNonSynchronizingLiteral
     }
 
     private func stringEncoding<T: Collection>(for bytes: T) -> StringEncoding where T.Element == UInt8 {
@@ -70,10 +66,10 @@ extension EncodeBuffer {
         case .client(options: let options):
             if options.useQuotedString, canUseQuotedString(for: bytes) {
                 return .quotedString
-            } else if options.useNonSynchronizingLiteralMinus, bytes.count <= 4096 {
-                return .clientNonSynchronizingLiteralMinus
             } else if options.useNonSynchronizingLiteralPlus {
-                return .clientNonSynchronizingLiteralPlus
+                return .clientNonSynchronizingLiteral
+            } else if options.useNonSynchronizingLiteralMinus, bytes.count <= 4096 {
+                return .clientNonSynchronizingLiteral
             } else {
                 return .clientSynchronizingLiteral
             }

--- a/Tests/NIOIMAPCoreTests/Grammar/ByteBufferWriteLiteralTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/ByteBufferWriteLiteralTests.swift
@@ -39,7 +39,8 @@ extension ByteBufferWriteLiteralTests {
                 ["{71}\r\n", "01234567890123456789012345678901234567890123456789012345678901234567890"],
                 #line
             ),
-            (ByteBuffer(string: String(repeating: "a", count: 4096)), .literalMinus, ["{4096-}\r\n" + String(repeating: "a", count: 4096)], #line),
+            (ByteBuffer(string: String(repeating: "a", count: 100)), .literalMinus, ["{100+}\r\n" + String(repeating: "a", count: 100)], #line),
+            (ByteBuffer(string: String(repeating: "a", count: 4096)), .literalMinus, ["{4096+}\r\n" + String(repeating: "a", count: 4096)], #line),
             (ByteBuffer(string: String(repeating: "a", count: 4097)), .literalMinus, ["{4097}\r\n", String(repeating: "a", count: 4097)], #line),
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeIMAPString($0) })


### PR DESCRIPTION
RFC 7888, section 5 says:
> Note that the form of the non-synchronizing literal does not change: it still uses the "+" in the literal itself, even if the applicable extension is LITERAL-.


Fixes #675