### PR TITLE
Fix parsing escapes in “quoted” strings

### DIFF
--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Message+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Message+Tests.swift
@@ -56,7 +56,8 @@ extension GrammarParser_Message_Tests {
                 ("X-GM-LABELS (\\Inbox \\Sent Important \"Muy Importante\")", " ", .gmailLabels([GmailLabel("\\Inbox"), GmailLabel("\\Sent"), GmailLabel("Important"), GmailLabel("Muy Importante")]), #line),
                 ("X-GM-LABELS (foo)", " ", .gmailLabels([GmailLabel("foo")]), #line),
                 ("X-GM-LABELS ()", " ", .gmailLabels([]), #line),
-                ("X-GM-LABELS (\\Drafts)", " ", .gmailLabels([GmailLabel("\\Drafts")]), #line),
+                (#"X-GM-LABELS (\Drafts)"#, " ", .gmailLabels([GmailLabel(#"\Drafts"#)]), #line),
+                (#"X-GM-LABELS ("\\Important")"#, " ", .gmailLabels([GmailLabel(#"\Important"#)]), #line),
             ],
             parserErrorInputs: [],
             incompleteMessageInputs: []

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -1974,6 +1974,36 @@ extension ParserUnitTests {
     }
 }
 
+// MARK: - astring parseNString
+
+extension ParserUnitTests {
+    func testParseAString() {
+        // 1*ASTRING-CHAR / quoted / literal
+        self.iterateTests(
+            testFunction: GrammarParser().parseAString,
+            validInputs: [
+                ("NIL", " ", "NIL", #line),
+                ("A", " ", "A", #line),
+                ("Foo", " ", "Foo", #line),
+                ("a]b", " ", "a]b", #line),
+                ("{3}\r\nabc", "", "abc", #line),
+                ("{3+}\r\nabc", "", "abc", #line),
+                (#""abc""#, "", "abc", #line),
+                (#""a\\bc""#, "", #"a\bc"#, #line),
+                (#""a\"bc""#, "", #"a"bc"#, #line),
+            ],
+            parserErrorInputs: [
+                (#""a\bc""#, "", #line),
+            ],
+            incompleteMessageInputs: [
+                ("\"", "", #line),
+                (#""a\""#, "", #line),
+                ("{1}\r\n", "", #line),
+            ]
+        )
+    }
+}
+
 // MARK: - nstring parseNString
 
 extension ParserUnitTests {
@@ -1984,10 +2014,13 @@ extension ParserUnitTests {
                 ("NIL", "", nil, #line),
                 ("{3}\r\nabc", "", "abc", #line),
                 ("{3+}\r\nabc", "", "abc", #line),
-                ("\"abc\"", "", "abc", #line),
+                (#""abc""#, "", "abc", #line),
+                (#""a\\bc""#, "", #"a\bc"#, #line),
+                (#""a\"bc""#, "", #"a"bc"#, #line),
             ],
             parserErrorInputs: [
                 ("abc", " ", #line),
+                (#""a\bc""#, "", #line),
             ],
             incompleteMessageInputs: [
                 ("\"", "", #line),


### PR DESCRIPTION
So-called IMAP “quoted” strings can have 2 escape sequences `\"` and `\\` which map to `"` and `\` respectively.

The parser wasn’t handling this, and Gmail labels use this extensively.

```text
quoted          = DQUOTE *QUOTED-CHAR DQUOTE
QUOTED-CHAR     = <any TEXT-CHAR except quoted-specials> /
                  "\" quoted-specials
quoted-specials = DQUOTE / "\"
```