### PR TITLE
Fix a crash when parsing envelope address groups

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
@@ -29,7 +29,6 @@ extension GrammarParser {
         var stack: [EmailAddressGroup] = []
 
         for address in addresses {
-
             // RFC 2822 Syntaxt: If the host is nil then the group has started
             // if the mailbox is also nil, then the group has finished.
             if address.host == nil, let name = address.mailbox { // start of group

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
@@ -50,7 +50,7 @@ extension GrammarParser_Envelope_Tests {
                     .init(personName: nil, sourceRoot: nil, mailbox: nil, host: nil),
                 ],
                 [
-                    .singleAddress(.init(personName: nil, sourceRoot: nil, mailbox: nil, host: nil))
+                    .singleAddress(.init(personName: nil, sourceRoot: nil, mailbox: nil, host: nil)),
                 ],
                 #line
             ),


### PR DESCRIPTION
Found by Mail during the live-on program.

The issue was caused by a "completely nil" address, which we take to mean the end of an envelope group (as per rfc 2822). A completely nil address is valid on its own, without being part of a group, however we assumed that it would always denote the end. If a group hadn't previously been started then we'd crash.

Fix by checking if we have a group on top of the stack when attempting to compile individual addresses into groups.

Also added a test case to prevent regression.