### PR TITLE
Pre-calculate MailboxName hash value

### DIFF
--- a/Sources/NIOIMAPCore/ByteBuffer+WriteLiteral.swift
+++ b/Sources/NIOIMAPCore/ByteBuffer+WriteLiteral.swift
@@ -37,7 +37,13 @@ extension EncodeBuffer {
         self.writeIMAPString(buffer.readableBytesView)
     }
 
-    private mutating func writeIMAPString<T: Collection>(_ bytes: T) -> Int where T.Element == UInt8 {
+    /// Writes an IMAP `string` type as defined by the grammar in RFC 3501.
+    /// The function will decide to use either `quoted` or `literal` syntax based
+    /// upon what bytes `buffer` contains, and what encoding types are supported.
+    /// - parameters:
+    ///     - buffer: The buffer to write.
+    /// - returns: The number of bytes written.
+    @discardableResult mutating func writeIMAPString<T: Collection>(_ bytes: T) -> Int where T.Element == UInt8 {
         guard !self.loggingMode else {
             return self.writeIMAPStringLoggingMode(bytes)
         }

--- a/Sources/NIOIMAPCore/Grammar/Message/GmailLabel.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/GmailLabel.swift
@@ -26,7 +26,7 @@ public struct GmailLabel: Hashable {
 
     /// Creates a new `GmailLabel` from the given `MailboxName`.
     public init(mailboxName: MailboxName) {
-        self.buffer = mailboxName.bytes
+        self.buffer = ByteBuffer(bytes: mailboxName.bytes)
     }
 
     /// Creates a new `GmailLabel` from the given `UseAttribute`.


### PR DESCRIPTION
Since it’s common to use `MailboxName` as a key in a dictionary and/or compare `MailboxName` for equality, `MailboxName` will pre-calculate its hash value, and store it. As a result `Hashable` (and `Equatable`) performance is fast.