### PR TITLE
Fix stack exhaustion due to recursion

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -426,7 +426,7 @@ extension GrammarParser {
     }
 
     func parseEncodedURLAuth(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EncodedAuthenticatedURL {
-        try PL.composite(buffer: &buffer, tracker: tracker) { buffer, _ -> EncodedAuthenticatedURL in
+        try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EncodedAuthenticatedURL in
             let bytes = try PL.parseBytes(buffer: &buffer, tracker: tracker, length: 32)
             guard bytes.readableBytesView.allSatisfy(\.isHexCharacter) else {
                 throw ParserError(hint: "Found invalid character in \(String(buffer: bytes))")

--- a/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
+++ b/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
@@ -206,7 +206,7 @@ extension ParserLibrary {
     }
 
     static func parseFixedString(_ needle: String, caseSensitive: Bool = false, allowLeadingSpaces: Bool = false, buffer: inout ParseBuffer, tracker: StackTracker) throws {
-        try PL.composite(buffer: &buffer, tracker: tracker) { buffer, _ in
+        try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
 
             if allowLeadingSpaces {
                 try self.parseOptional(buffer: &buffer, tracker: tracker, parser: self.parseSpaces)

--- a/Tests/NIOIMAPCoreTests/Parser/ParserLibraryTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/ParserLibraryTests.swift
@@ -116,15 +116,22 @@ extension ParserLibraryTests {
     }
 
     func test_fixedStringNonASCII() {
-        var buffer = TestUtilities.makeParseBuffer(for: "fooFooFOO")
-
-        buffer = TestUtilities.makeParseBuffer(for: "fooFooFOÖ")
+        var buffer = TestUtilities.makeParseBuffer(for: "fooFooFOÖ")
         XCTAssertThrowsError(try PL.parseFixedString("fooFooFOO",
                                                      caseSensitive: true,
                                                      buffer: &buffer,
                                                      tracker: .testTracker)) { error in
             XCTAssert(error is ParserError, "\(error)")
         }
+    }
+
+    func test_fixedStringWithLeadingSpaces() {
+        var buffer = TestUtilities.makeParseBuffer(for: String(repeating: " ", count: 500) + "fooFooFOO")
+        XCTAssertNoThrow(try PL.parseFixedString("fooFooFOO",
+                                                 caseSensitive: true,
+                                                 allowLeadingSpaces: true,
+                                                 buffer: &buffer,
+                                                 tracker: .testTracker))
     }
 }
 
@@ -285,7 +292,7 @@ extension ParserLibraryTests {
 
 extension ParserLibraryTests {
     func checkParseNewline(newline: String, line: UInt = #line) {
-        var buffer = ParseBuffer(ByteBuffer(string: newline + "hello, world"))
+        var buffer = TestUtilities.makeParseBuffer(for: newline + "hello, world")
         XCTAssertNoThrow(try ParserLibrary.parseNewline(buffer: &buffer, tracker: StackTracker.makeNewDefaultLimitStackTracker), line: line)
         XCTAssertNoThrow(try ParserLibrary.parseFixedString("hello, world", buffer: &buffer, tracker: StackTracker.makeNewDefaultLimitStackTracker), line: line)
     }
@@ -305,13 +312,13 @@ extension ParserLibraryTests {
     }
 
     func testParseNewlineRecursion() {
-        var buffer = ParseBuffer(ByteBuffer(string: String(repeating: " ", count: 80) + "\r\nhello, world"))
+        var buffer = TestUtilities.makeParseBuffer(for: String(repeating: " ", count: 80) + "\r\nhello, world")
         XCTAssertNoThrow(try ParserLibrary.parseNewline(buffer: &buffer, tracker: StackTracker(maximumParserStackDepth: 100)))
         XCTAssertNoThrow(try ParserLibrary.parseFixedString("hello, world", buffer: &buffer, tracker: StackTracker.makeNewDefaultLimitStackTracker))
     }
 
     func testParseNewlineTooMuchRecursion() {
-        var buffer = ParseBuffer(ByteBuffer(string: String(repeating: " ", count: 200) + "\r\nhello, world"))
+        var buffer = TestUtilities.makeParseBuffer(for: String(repeating: " ", count: 200) + "\r\nhello, world")
         XCTAssertThrowsError(try ParserLibrary.parseNewline(buffer: &buffer, tracker: StackTracker(maximumParserStackDepth: 100)))
     }
 }


### PR DESCRIPTION
Found the (deep) recursion in `ParserLibrary.parseNewline()` through fuzzing.