### PR TITLE
Fix crash when parsing invalid mod-seq

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
@@ -127,7 +127,12 @@ extension GrammarParser {
 
     // mod-sequence-valzer = "0" / mod-sequence-value
     func parseModificationSequenceValue(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ModificationSequenceValue {
-        let (number, _) = try ParserLibrary.parseUnsignedInt64(buffer: &buffer, tracker: tracker, allowLeadingZeros: true)
-        return ModificationSequenceValue(number)
+        try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            let (number, _) = try ParserLibrary.parseUnsignedInt64(buffer: &buffer, tracker: tracker, allowLeadingZeros: true)
+            guard let v = ModificationSequenceValue(exactly: number) else {
+                throw ParserError(hint: "Mod-seq value is too large.")
+            }
+            return v
+        }
     }
 }

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Sequence.swift
@@ -66,17 +66,21 @@ extension GrammarParser_Sequence_Tests {
     }
 }
 
-// MARK: - mod-sequence-valzer parseModifierSequenceValueZero
+// MARK: - mod-sequence-valzer testParseModifierSequenceValueExtremes
 
 extension GrammarParser_Sequence_Tests {
-    func testParseModifierSequenceValueZero() {
+    func testParseModifierSequenceValueExtremes() {
         self.iterateTests(
             testFunction: GrammarParser().parseModificationSequenceValue,
             validInputs: [
                 ("0", " ", .zero, #line),
-                ("123", " ", 123, #line),
+                ("9223372036854775807", " ", 9223372036854775807, #line),
             ],
-            parserErrorInputs: [],
+            parserErrorInputs: [
+                ("9223372036854775808", " ", #line),
+                ("13853076851840262211", " ", #line),
+                ("18446744073709551615", " ", #line),
+            ],
             incompleteMessageInputs: []
         )
     }


### PR DESCRIPTION
Modification sequence numbers need to be in the range 0-Int64.max (63 bit unsiged values). When parsing, use the failing initializer, instead of the one with a `precondition()`.
