### PR TITLE
“MIME” is not a valid section specifier (without a part)

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -1887,8 +1887,13 @@ extension GrammarParser {
     // section-spec    = section-msgtext / (section-part ["." section-text])
     func parseSectionSpecifier(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {
         func parseSectionSpecifier_noPart(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {
-            let kind = try self.parseSectionSpecifierKind(buffer: &buffer, tracker: tracker)
-            return .init(kind: kind)
+            try PL.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SectionSpecifier in
+                let kind = try self.parseSectionSpecifierKind(buffer: &buffer, tracker: tracker)
+                guard kind != .MIMEHeader else {
+                    throw ParserError(hint: "Cannot use MIME with an empty section part")
+                }
+                return .init(kind: kind)
+            }
         }
 
         func parseSectionSpecifier_withPart(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SectionSpecifier {

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -2223,7 +2223,9 @@ extension ParserUnitTests {
                 ("1.2.3", "\r", .init(part: [1, 2, 3], kind: .complete), #line),
                 ("1.2.3.HEADER", "\r", .init(part: [1, 2, 3], kind: .header), #line),
             ],
-            parserErrorInputs: [],
+            parserErrorInputs: [
+                ("MIME", "\r", #line),
+            ],
             incompleteMessageInputs: [
                 ("", "", #line),
                 ("1", "", #line),


### PR DESCRIPTION
Don’t crash. Throw parsing error.
