### PR TITLE
Cleanup CustomDebugStringConvertible conformance

### DIFF
--- a/Sources/NIOIMAPCore/CommandEncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/CommandEncodeBuffer.swift
@@ -51,3 +51,20 @@ extension CommandEncodeBuffer {
         self.encodedAtLeastOneCatenateElement = encodedAtLeastOneCatenateElement
     }
 }
+
+extension CommandEncodeBuffer {
+    /// Call the closure with a buffer, return the result as a String.
+    ///
+    /// Used for implementing ``CustomDebugStringConvertible`` conformance.
+    static func makeDescription(_ closure: (inout CommandEncodeBuffer) -> Void) -> String {
+        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501, loggingMode: false)
+        closure(&buffer)
+        var chunk = buffer.buffer.nextChunk()
+        var result = String(bestEffortDecodingUTF8Bytes: chunk.bytes.readableBytesView)
+        while chunk.waitForContinuation {
+            chunk = buffer.buffer.nextChunk()
+            result += String(bestEffortDecodingUTF8Bytes: chunk.bytes.readableBytesView)
+        }
+        return result
+    }
+}

--- a/Sources/NIOIMAPCore/EncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/EncodeBuffer.swift
@@ -76,6 +76,21 @@ extension EncodeBuffer {
 }
 
 extension EncodeBuffer {
+    /// Call the closure with a buffer, return the result as a String.
+    ///
+    /// Used for implementing ``CustomDebugStringConvertible`` conformance.
+    static func makeDescription(_ closure: (inout EncodeBuffer) -> Void) -> String {
+        var options = CommandEncodingOptions.rfc3501
+        options.useQuotedString = true
+        options.useSynchronizingLiteral = false
+        options.useNonSynchronizingLiteralPlus = true
+        var buffer = EncodeBuffer.clientEncodeBuffer(buffer: ByteBuffer(), options: options, loggingMode: false)
+        closure(&buffer)
+        return String(bestEffortDecodingUTF8Bytes: buffer.buffer.readableBytesView)
+    }
+}
+
+extension EncodeBuffer {
     /// Represents a piece of data that is ready to be written to the network.
     public struct Chunk: Hashable {
         /// The data that is ready to be written.

--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -194,15 +194,9 @@ public enum Command: Hashable {
 
 extension Command: CustomDebugStringConvertible {
     public var debugDescription: String {
-        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501, loggingMode: true)
-        buffer.writeCommand(self)
-        var chunk = buffer.buffer.nextChunk()
-        var result = String(buffer: chunk.bytes)
-        while chunk.waitForContinuation {
-            chunk = buffer.buffer.nextChunk()
-            result += String(buffer: chunk.bytes)
+        CommandEncodeBuffer.makeDescription {
+            $0.writeCommand(self)
         }
-        return result
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/Command/CommandStreamPart.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/CommandStreamPart.swift
@@ -126,15 +126,9 @@ public enum CommandStreamPart: Hashable {
 
 extension CommandStreamPart: CustomDebugStringConvertible {
     public var debugDescription: String {
-        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501, loggingMode: true)
-        buffer.writeCommandStream(self)
-        var chunk = buffer.buffer.nextChunk()
-        var result = String(buffer: chunk.bytes)
-        while chunk.waitForContinuation {
-            chunk = buffer.buffer.nextChunk()
-            result += String(buffer: chunk.bytes)
+        CommandEncodeBuffer.makeDescription {
+            $0.writeCommandStream(self)
         }
-        return result
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/Command/TaggedCommand.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/TaggedCommand.swift
@@ -33,15 +33,9 @@ public struct TaggedCommand: Hashable {
 
 extension TaggedCommand: CustomDebugStringConvertible {
     public var debugDescription: String {
-        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501, loggingMode: true)
-        buffer.writeCommand(self)
-        var chunk = buffer.buffer.nextChunk()
-        var result = String(buffer: chunk.bytes)
-        while chunk.waitForContinuation {
-            chunk = buffer.buffer.nextChunk()
-            result += String(buffer: chunk.bytes)
+        CommandEncodeBuffer.makeDescription {
+            $0.writeCommand(self)
         }
-        return result
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
@@ -85,13 +85,9 @@ extension Array where Element == FetchAttribute {
 
 extension FetchAttribute: CustomDebugStringConvertible {
     public var debugDescription: String {
-        var options = CommandEncodingOptions.rfc3501
-        options.useQuotedString = true
-        options.useSynchronizingLiteral = false
-        options.useNonSynchronizingLiteralPlus = true
-        var buffer = EncodeBuffer.clientEncodeBuffer(buffer: ByteBuffer(), options: options, loggingMode: true)
-        buffer.writeFetchAttribute(self)
-        return String(bestEffortDecodingUTF8Bytes: buffer.buffer.readableBytesView)
+        EncodeBuffer.makeDescription {
+            $0.writeFetchAttribute(self)
+        }
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
@@ -56,6 +56,14 @@ public enum MessageAttribute: Hashable {
     case gmailLabels([GmailLabel])
 }
 
+extension MessageAttribute: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        EncodeBuffer.makeDescription {
+            $0.writeMessageAttribute(self)
+        }
+    }
+}
+
 // MARK: - Encoding
 
 extension EncodeBuffer {

--- a/Sources/NIOIMAPCore/Grammar/Response/Response.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/Response.swift
@@ -134,3 +134,11 @@ extension StreamingKind {
         }
     }
 }
+
+extension StreamingKind: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        ResponseEncodeBuffer.makeDescription {
+            $0.writeStreamingKind(self)
+        }
+    }
+}

--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseText.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseText.swift
@@ -54,9 +54,8 @@ extension EncodeBuffer {
 
 extension ResponseText: CustomDebugStringConvertible {
     public var debugDescription: String {
-        var encoder = EncodeBuffer
-            .serverEncodeBuffer(buffer: ByteBuffer(), options: ResponseEncodingOptions(), loggingMode: true)
-        _ = encoder.writeResponseText(self)
-        return String(bestEffortDecodingUTF8Bytes: encoder.buffer.readableBytesView)
+        EncodeBuffer.makeDescription {
+            $0.writeResponseText(self)
+        }
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponseTextCode.swift
@@ -402,9 +402,8 @@ extension EncodeBuffer {
 
 extension ResponseTextCode: CustomDebugStringConvertible {
     public var debugDescription: String {
-        var encoder = EncodeBuffer
-            .serverEncodeBuffer(buffer: ByteBuffer(), options: ResponseEncodingOptions(), loggingMode: true)
-        _ = encoder.writeResponseTextCode(self)
-        return String(bestEffortDecodingUTF8Bytes: encoder.buffer.readableBytesView)
+        EncodeBuffer.makeDescription {
+            $0.writeResponseTextCode(self)
+        }
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
+++ b/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
@@ -80,22 +80,9 @@ extension SectionSpecifier: CustomDebugStringConvertible {
     /// A textual representation of the `SectionSpecifier` that is inline with the IMAP RFC.
     /// E.g. *.MIME*.
     public var debugDescription: String {
-        let kind: String
-        switch self.kind {
-        case .complete:
-            kind = ""
-        case .header:
-            kind = ".HEADER"
-        case .headerFields(let fields):
-            kind = ".HEADER.FIELDS (\(fields.joined(separator: ","))"
-        case .headerFieldsNot(let fields):
-            kind = ".HEADER.FIELDS.NOT (\(fields.joined(separator: ","))"
-        case .MIMEHeader:
-            kind = ".MIME"
-        case .text:
-            kind = ".TEXT"
+        EncodeBuffer.makeDescription {
+            $0.writeSectionSpecifier(self)
         }
-        return "\(part)\(kind)"
     }
 }
 
@@ -179,7 +166,9 @@ extension SectionSpecifier.Part: Comparable {
 extension SectionSpecifier.Part: CustomDebugStringConvertible {
     /// Produces a textual representation as period-separated numbers (as defined in the IMAP RFC).
     public var debugDescription: String {
-        self.array.map { "\($0)" }.joined(separator: ".")
+        EncodeBuffer.makeDescription {
+            $0.writeSectionPart(self)
+        }
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifier.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifier.swift
@@ -45,10 +45,8 @@ extension MessageIdentifier {
     /// Creates a human-readable `String` representation of the `MessageIdentifier`.
     /// `*` if `self = UInt32.max`, otherwise `self.rawValue` as a `String`.
     public var debugDescription: String {
-        if self == .max {
-            return "*"
-        } else {
-            return "\(self.rawValue)"
+        EncodeBuffer.makeDescription {
+            $0.writeMessageIdentifier(self)
         }
     }
 

--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierRange.swift
@@ -43,10 +43,8 @@ public struct MessageIdentifierRange<IdentifierType: MessageIdentifier>: Hashabl
 extension MessageIdentifierRange: CustomDebugStringConvertible {
     /// Creates a human-readable representation of the range.
     public var debugDescription: String {
-        if self.range.lowerBound < self.range.upperBound {
-            return "\(self.range.lowerBound):\(self.range.upperBound)"
-        } else {
-            return "\(self.range.lowerBound)"
+        EncodeBuffer.makeDescription {
+            $0.writeMessageIdentifierRange(self)
         }
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -208,10 +208,9 @@ extension MessageIdentifierSet {
 extension MessageIdentifierSet: CustomDebugStringConvertible {
     /// Creates a human-readable text representation of the set by joined ranges with a comma.
     public var debugDescription: String {
-        _ranges
-            .ranges
-            .map { "\(MessageIdentifierRange<IdentifierType>($0))" }
-            .joined(separator: ",")
+        EncodeBuffer.makeDescription {
+            _ = self.writeIntoBuffer(&$0)
+        }
     }
 }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/FetchAttributeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/FetchAttributeTests.swift
@@ -64,7 +64,7 @@ extension FetchAttributeTests {
             (.bodyStructure(extensions: true), "BODYSTRUCTURE", #line),
             (.bodySection(peek: false, .init(kind: .header), nil), "BODY[HEADER]", #line),
             (.bodySection(peek: false, .init(kind: .header), nil), "BODY[HEADER]", #line),
-            (.bodySection(peek: true, .init(kind: .headerFields(["message-id", "in-reply-to"])), nil), #"BODY.PEEK[HEADER.FIELDS ("∅" "∅")]"#, #line),
+            (.bodySection(peek: true, .init(kind: .headerFields(["message-id", "in-reply-to"])), nil), #"BODY.PEEK[HEADER.FIELDS ("message-id" "in-reply-to")]"#, #line),
             (.binarySize(section: [1]), "BINARY.SIZE[1]", #line),
             (.binary(peek: true, section: [1, 2, 3], partial: nil), "BINARY.PEEK[1.2.3]", #line),
             (.binary(peek: false, section: [3, 4, 5], partial: nil), "BINARY[3.4.5]", #line),

--- a/Tests/NIOIMAPCoreTests/Grammar/Message/MessageAtributesTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Message/MessageAtributesTests.swift
@@ -64,3 +64,18 @@ extension MessageAttributesTests {
         }
     }
 }
+
+// MARK: - CustomDebugStringConvertible
+
+extension MessageAttributesTests {
+    func testCustomDebugStringConvertible() {
+        let inputs: [(MessageAttribute, String, UInt)] = [
+            (.rfc822Size(123), "RFC822.SIZE 123", #line),
+            (.flags([.draft]), "FLAGS (\\Draft)", #line),
+            (.gmailLabels([GmailLabel("\\Inbox"), GmailLabel("\\Sent"), GmailLabel("Important"), GmailLabel("Muy Importante")]), "X-GM-LABELS (\\Inbox \\Sent \"Important\" \"Muy Importante\")", #line),
+        ]
+        inputs.forEach { (part, expected, line) in
+            XCTAssertEqual("\(part)", expected, line: line)
+        }
+    }
+}

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/Response+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/Response+Tests.swift
@@ -69,3 +69,21 @@ extension Response_Tests {
         }
     }
 }
+
+// MARK: - CustomDebugStringConvertible
+
+extension Response_Tests {
+    func testCustomDebugStringConvertible_StreamingKind() {
+        let inputs: [(StreamingKind, String, UInt)] = [
+            (.body(section: .init(), offset: nil), "BODY[]", #line),
+            (.body(section: .init(), offset: 1234), "BODY[]<1234>", #line),
+            (.body(section: .init(part: [2, 3], kind: .header), offset: 1234), "BODY[2.3.HEADER]<1234>", #line),
+            (.rfc822, "RFC822", #line),
+            (.rfc822Text, "RFC822.TEXT", #line),
+            (.rfc822Header, "RFC822.HEADER", #line),
+        ]
+        inputs.forEach { (part, expected, line) in
+            XCTAssertEqual("\(part)", expected, line: line)
+        }
+    }
+}


### PR DESCRIPTION
With this PR the implementation of `CustomDebugStringConvertible` generally uses new `makeDescription` convenience methods on the three encode buffers, e.g.:
```swift
extension ResponseEncodeBuffer {
    static func makeDescription(_ closure: (inout ResponseEncodeBuffer) -> Void) -> String
}
```
such that conformance can be implemented as e.g.
```swift
extension Command: CustomDebugStringConvertible {
    public var debugDescription: String {
        CommandEncodeBuffer.makeDescription {
            $0.writeCommand(self)
        }
    }
}
```

This also adds `CustomDebugStringConvertible` to `MessageAttribute` and `StreamingKind`.
