### PR TITLE
Fix BodyStructure’s RandomAccessCollection conformance

### DIFF
--- a/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
@@ -44,52 +44,66 @@ extension BodyStructure_Tests {
 // MARK: - RandomAccessCollection
 
 extension BodyStructure_Tests {
-    func testRandomeAccessCollection_startIndex() {
-        let inputs: [(BodyStructure, SectionSpecifier.Part, UInt)] = [
+    func testRansomAccessCollection_indexBeforeAfter() {
+        // This checks that
+        //  * startIndex
+        //  * endIndex
+        //  * index(before:)
+        //  * index(after:)
+        // are all correct.
+        let inputs: [(BodyStructure, [SectionSpecifier.Part], UInt)] = [
             (
                 .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
-                [1],
+                [
+                    [],
+                    [1],
+                ],
+                #line
+            ),
+            (
+                .singlepart(
+                    .init(
+                        kind: .message(
+                            .init(
+                                message: .rfc822,
+                                envelope: Envelope(date: nil, subject: nil, from: [], sender: [], reply: [], to: [], cc: [], bcc: [], inReplyTo: nil, messageID: nil),
+                                body: .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))
+                                ),
+                                lineCount: 1
+                            )
+                        ),
+                        fields: BodyStructure.Fields(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 99)
+                    )
+                ),
+                [
+                    [],
+                    [1],
+                ],
                 #line
             ),
             (
                 .multipart(.init(parts: [
                     .singlepart(.init(kind: .basic(.init(kind: .application, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 1))),
                 ], mediaSubtype: .mixed)),
-                [1],
-                #line
-            ),
-        ]
-        inputs.forEach { (input, expected, line) in
-            XCTAssertEqual(input.startIndex, expected, line: line)
-        }
-    }
-
-    func testRandomeAccessCollection_endIndex() {
-        let inputs: [(BodyStructure, SectionSpecifier.Part, UInt)] = [
-            (
-                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
-                [2],
+                [
+                    [],
+                    [1],
+                    [2],
+                ],
                 #line
             ),
             (
-                .singlepart(.init(kind: .message(.init(
-                    message: .rfc822,
-                    envelope: .init(date: nil, subject: nil, from: [], sender: [], reply: [], to: [], cc: [], bcc: [], inReplyTo: nil, messageID: nil),
-                    body: .singlepart(.init(
-                        kind: .basic(.init(kind: .application, subtype: .mixed)),
-                        fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0)
-                    )
-                    ),
-                    lineCount: 3
-                )), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
-                [2],
-                #line
-            ),
-            (
-                .multipart(BodyStructure.Multipart(parts: [
-                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))),
+                .multipart(.init(parts: [
+                    .multipart(.init(parts: [
+                        .singlepart(.init(kind: .basic(.init(kind: .application, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 1))),
+                    ], mediaSubtype: .mixed)),
                 ], mediaSubtype: .mixed)),
-                [2],
+                [
+                    [],
+                    [1],
+                    [1, 1],
+                    [2],
+                ],
                 #line
             ),
             (
@@ -98,73 +112,110 @@ extension BodyStructure_Tests {
                     .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))),
                     .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))),
                 ], mediaSubtype: .mixed)),
-                [4],
+                [
+                    [],
+                    [1],
+                    [2],
+                    [3],
+                    [4],
+                ],
+                #line
+            ),
+            (
+                .multipart(.init(parts: [
+                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                    .multipart(.init(parts: [
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                        .multipart(.init(parts: [
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 3))),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 4))),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 5))),
+                        ], mediaSubtype: .init("subtype"))),
+                    ], mediaSubtype: .init("subtype"))),
+                ], mediaSubtype: .init("subtype"))),
+                [
+                    [],
+                    [1],
+                    [2],
+                    [2, 1],
+                    [2, 2],
+                    [2, 2, 1],
+                    [2, 2, 2],
+                    [2, 2, 3],
+                    [3],
+                ],
+                #line
+            ),
+            (
+                .multipart(.init(parts: [
+                    .multipart(.init(parts: [
+                        .multipart(.init(parts: [
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 3))),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 4))),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 5))),
+                        ], mediaSubtype: .init("subtype"))),
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                    ], mediaSubtype: .init("subtype"))),
+                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                ], mediaSubtype: .init("subtype"))),
+                [
+                    [],
+                    [1],
+                    [1, 1],
+                    [1, 1, 1],
+                    [1, 1, 2],
+                    [1, 1, 3],
+                    [1, 2],
+                    [2],
+                    [3],
+                ],
                 #line
             ),
         ]
-        inputs.forEach { (input, expected, line) in
-            XCTAssertEqual(input.endIndex, expected, line: line)
+        for input in inputs {
+            let line = input.2
+            XCTAssertEqual(input.0.startIndex, input.1.first!, "startIndex should be \(String(reflecting: input.1.first))", line: line)
+            XCTAssertEqual(input.0.endIndex, input.1.last!, "endIndex should be \(String(reflecting: input.1.last))", line: line)
+            guard
+                input.0.startIndex == input.1.first!,
+                input.0.endIndex == input.1.last!
+            else { XCTFail(line: line); continue }
+            // Check index(after:)
+            do {
+                var index = input.0.startIndex
+                var result = [index]
+                while index != input.0.endIndex {
+                    let next = input.0.index(after: index)
+                    result.append(next)
+                    index = next
+                }
+                XCTAssertEqual(result, input.1, "index(after:)", line: line)
+            }
+            // Check index(before:)
+            do {
+                var index = input.0.endIndex
+                var result = [index]
+                while index != input.0.startIndex {
+                    let next = input.0.index(before: index)
+                    result.insert(next, at: 0)
+                    index = next
+                }
+                XCTAssertEqual(result, input.1, "index(before:)", line: line)
+            }
         }
     }
 
-    func testRandomeAccessCollection_indexBefore() {
-        let inputs: [(BodyStructure, SectionSpecifier.Part, SectionSpecifier.Part, UInt)] = [
-            (
-                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
-                [2],
-                [1],
-                #line
-            ),
-            (
-                .multipart(BodyStructure.Multipart(parts: [
-                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))),
-                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))),
-                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))),
-                ], mediaSubtype: .mixed)),
-                [3],
-                [2],
-                #line
-            ),
-        ]
-        inputs.forEach { (body, before, expected, line) in
-            XCTAssertEqual(body.index(before: before), expected, line: line)
-        }
-    }
-
-    func testRandomeAccessCollection_indexAfter() {
-        let inputs: [(BodyStructure, SectionSpecifier.Part, SectionSpecifier.Part, UInt)] = [
-            (
-                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
-                [1],
-                [2],
-                #line
-            ),
-            (
-                .multipart(BodyStructure.Multipart(parts: [
-                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))), .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))),
-                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .mixed)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .base64, octetCount: 0))),
-                ], mediaSubtype: .mixed)),
-                [2],
-                [3],
-                #line
-            ),
-        ]
-        inputs.forEach { (body, after, expected, line) in
-            XCTAssertEqual(body.index(after: after), expected, line: line)
-        }
-    }
-
-    func testRandomeAccessCollection_position() {
+    func testRandomAccessCollection_position() {
         let inputs: [(BodyStructure, SectionSpecifier.Part, BodyStructure, UInt)] = [
             (
                 .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
-                [1],
+                [],
                 .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
                 #line
             ),
             (
                 .singlepart(.init(kind: .text(.init(mediaText: "media", lineCount: 3)), fields: BodyStructure.Fields(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 123))),
-                [1],
+                [],
                 .singlepart(.init(kind: .text(.init(mediaText: "media", lineCount: 3)), fields: BodyStructure.Fields(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 123))),
                 #line
             ),
@@ -213,8 +264,52 @@ extension BodyStructure_Tests {
                 .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 3))),
                 #line
             ),
+            (
+                .multipart(.init(parts: [
+                    .singlepart(.init(
+                        kind: .message(BodyStructure.Singlepart.Message(
+                            message: .rfc822,
+                            envelope: Envelope(date: nil, subject: "A", from: [], sender: [], reply: [], to: [], cc: [], bcc: [], inReplyTo: nil, messageID: nil),
+                            body: .multipart(.init(parts: [
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 1))),
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 2))),
+                            ], mediaSubtype: .init("mixed"))),
+                            lineCount: 321
+                        )),
+                        fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)
+                    )),
+                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                ], mediaSubtype: .init("mixed"))),
+                [1, 1],
+                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 1))),
+                #line
+            ),
+            (
+                .multipart(.init(parts: [
+                    .singlepart(.init(
+                        kind: .message(BodyStructure.Singlepart.Message(
+                            message: .rfc822,
+                            envelope: Envelope(date: nil, subject: "A", from: [], sender: [], reply: [], to: [], cc: [], bcc: [], inReplyTo: nil, messageID: nil),
+                            body: .multipart(.init(parts: [
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 1))),
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 2))),
+                            ], mediaSubtype: .init("mixed"))),
+                            lineCount: 321
+                        )),
+                        fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)
+                    )),
+                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                ], mediaSubtype: .init("mixed"))),
+                [1, 1],
+                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 1))),
+                #line
+            ),
         ]
         inputs.forEach { (input, index, expected, line) in
+            guard
+                let sub = input.find(index)
+            else { XCTFail("Invalid part '\(index)'.", line: line); return }
+            XCTAssertEqual(sub, expected, line: line)
             XCTAssertEqual(input[index], expected, line: line)
         }
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
@@ -44,7 +44,7 @@ extension BodyStructure_Tests {
 // MARK: - RandomAccessCollection
 
 extension BodyStructure_Tests {
-    func testRansomAccessCollection_indexBeforeAfter() {
+    func testRandomAccessCollection_indexBeforeAfter() {
         // This checks that
         //  * startIndex
         //  * endIndex


### PR DESCRIPTION
This fixes a few shortcomings of `BodyStructure`’s `RandomAccessCollection` conformance:

`index(before:)` and `index(after:)` now work properly, and there are better tests for these, too.

`startIndex` now starts at the “empty” `SectionSpecifier.Part` i.e. the complete part / structure.

Can iterate into `message/rfc822` sub-parts.

#### Also

Added a failing
```swift
public func find(_ position: SectionSpecifier.Part) -> BodyStructure?
```
to look up a part — and return `nil` if it’s not found / not valid.