### PR TITLE
More BodyStructure / SectionSpec convenience

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
+++ b/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
@@ -255,6 +255,42 @@ extension SectionSpecifier.Kind: Comparable {
     }
 }
 
+// MARK: - Helpers
+
+extension SectionSpecifier.Part {
+    /// Returns a `Part` containing all but the initial part number.
+    ///
+    /// If the `Part` is empty (i.e. the complete message), it returns the empty
+    /// `Part` / complete message specifier.
+    public func dropFirst() -> SectionSpecifier.Part {
+        SectionSpecifier.Part(Array(self.array.dropFirst()))
+    }
+
+    /// Returns a `Part` containing all but the last part number.
+    ///
+    /// If the `Part` is empty (i.e. the complete message), it returns the empty
+    /// `Part` / complete message specifier.
+    public func dropLast() -> SectionSpecifier.Part {
+        SectionSpecifier.Part(Array(self.array.dropLast()))
+    }
+
+    /// Returns a `Part` that has the given part number appended.
+    public func appending(_ element: Int) -> SectionSpecifier.Part {
+        SectionSpecifier.Part(self.array + [element])
+    }
+
+    /// Returns `true` if the `other` part is nested inside this `Part`. Returns `false` otherwise.
+    public func isSubPart(of other: SectionSpecifier.Part) -> Bool {
+        let a = Array(self)
+        let b = Array(other)
+        guard
+            b.count < a.count,
+            b != a
+        else { return false }
+        return zip(a, b).allSatisfy { $0.0 == $0.1 }
+    }
+}
+
 // MARK: - Encoding
 
 extension EncodeBuffer {

--- a/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
@@ -313,4 +313,161 @@ extension BodyStructure_Tests {
             XCTAssertEqual(input[index], expected, line: line)
         }
     }
+
+    func testEnueratingParts() {
+        let inputs: [(BodyStructure, [(SectionSpecifier.Part, BodyStructure)], UInt)] = [
+            (
+                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                [
+                    (
+                        [],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)))
+                    ),
+                ],
+                #line
+            ),
+            (
+                .multipart(.init(parts: [
+                    .singlepart(.init(
+                        kind: .message(BodyStructure.Singlepart.Message(
+                            message: .rfc822,
+                            envelope: Envelope(date: nil, subject: "A", from: [], sender: [], reply: [], to: [], cc: [], bcc: [], inReplyTo: nil, messageID: nil),
+                            body: .multipart(.init(parts: [
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 1))),
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 2))),
+                            ], mediaSubtype: .init("mixed"))),
+                            lineCount: 321
+                        )),
+                        fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)
+                    )),
+                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                ], mediaSubtype: .init("mixed"))),
+                [
+                    (
+                        [],
+                        .multipart(.init(parts: [
+                            .singlepart(.init(
+                                kind: .message(BodyStructure.Singlepart.Message(
+                                    message: .rfc822,
+                                    envelope: Envelope(date: nil, subject: "A", from: [], sender: [], reply: [], to: [], cc: [], bcc: [], inReplyTo: nil, messageID: nil),
+                                    body: .multipart(.init(parts: [
+                                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 1))),
+                                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 2))),
+                                    ], mediaSubtype: .init("mixed"))),
+                                    lineCount: 321
+                                )),
+                                fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)
+                            )),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                        ], mediaSubtype: .init("mixed")))
+                    ),
+                    (
+                        [1],
+                        .singlepart(.init(
+                            kind: .message(BodyStructure.Singlepart.Message(
+                                message: .rfc822,
+                                envelope: Envelope(date: nil, subject: "A", from: [], sender: [], reply: [], to: [], cc: [], bcc: [], inReplyTo: nil, messageID: nil),
+                                body: .multipart(.init(parts: [
+                                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 1))),
+                                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 2))),
+                                ], mediaSubtype: .init("mixed"))),
+                                lineCount: 321
+                            )),
+                            fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)
+                        ))
+                    ),
+                    (
+                        [1, 1],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 1)))
+                    ),
+                    (
+                        [1, 2],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 2)))
+                    ),
+                    (
+                        [2],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)))
+                    ),
+                ],
+                #line
+            ),
+            (
+                .multipart(.init(parts: [
+                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                    .multipart(.init(parts: [
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                        .multipart(.init(parts: [
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 3))),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 4))),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 5))),
+                        ], mediaSubtype: .init("subtype"))),
+                    ], mediaSubtype: .init("subtype"))),
+                ], mediaSubtype: .init("subtype"))),
+                [
+                    (
+                        [],
+                        .multipart(.init(parts: [
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                            .multipart(.init(parts: [
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                                .multipart(.init(parts: [
+                                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 3))),
+                                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 4))),
+                                    .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 5))),
+                                ], mediaSubtype: .init("subtype"))),
+                            ], mediaSubtype: .init("subtype"))),
+                        ], mediaSubtype: .init("subtype")))
+                    ),
+                    (
+                        [1],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)))
+                    ),
+                    (
+                        [2],
+                        .multipart(.init(parts: [
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0))),
+                            .multipart(.init(parts: [
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 3))),
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 4))),
+                                .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 5))),
+                            ], mediaSubtype: .init("subtype"))),
+                        ], mediaSubtype: .init("subtype")))
+                    ),
+                    (
+                        [2, 1],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 0)))
+                    ),
+                    (
+                        [2, 2],
+                        .multipart(.init(parts: [
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 3))),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 4))),
+                            .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 5))),
+                        ], mediaSubtype: .init("subtype")))
+                    ),
+                    (
+                        [2, 2, 1],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 3)))
+                    ),
+                    (
+                        [2, 2, 2],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 4)))
+                    ),
+                    (
+                        [2, 2, 3],
+                        .singlepart(.init(kind: .basic(.init(kind: .audio, subtype: .alternative)), fields: .init(parameters: [:], id: nil, contentDescription: nil, encoding: .binary, octetCount: 5)))
+                    ),
+                ],
+                #line
+            ),
+        ]
+        inputs.forEach { (input, expected, line) in
+            var result: [(SectionSpecifier.Part, BodyStructure)] = []
+            input.enumerateParts {
+                result.append(($0, $1))
+            }
+            XCTAssertEqual(result.map(\.0), expected.map(\.0), line: line)
+            XCTAssertEqual(result.map(\.1), expected.map(\.1), line: line)
+        }
+    }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/Section/SectionSpecTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Section/SectionSpecTests.swift
@@ -127,6 +127,60 @@ extension SectionSpecifierTests {
     }
 }
 
+// MARK: - Helpers
+
+extension SectionSpecifierTests {
+    func testDropFirst() {
+        let inputs: [(SectionSpecifier.Part, SectionSpecifier.Part, UInt)] = [
+            ([], [], #line),
+            ([5], [], #line),
+            ([5, 3], [3], #line),
+            ([5, 3, 8], [3, 8], #line),
+        ]
+        inputs.forEach { (part, expected, line) in
+            XCTAssertEqual(part.dropFirst(), expected, line: line)
+        }
+    }
+
+    func testDropLast() {
+        let inputs: [(SectionSpecifier.Part, SectionSpecifier.Part, UInt)] = [
+            ([], [], #line),
+            ([5], [], #line),
+            ([5, 3], [5], #line),
+            ([5, 3, 8], [5, 3], #line),
+        ]
+        inputs.forEach { (part, expected, line) in
+            XCTAssertEqual(part.dropLast(), expected, line: line)
+        }
+    }
+
+    func testAppending() {
+        let inputs: [(SectionSpecifier.Part, Int, SectionSpecifier.Part, UInt)] = [
+            ([], 1, [1], #line),
+            ([5, 3, 8], 4, [5, 3, 8, 4], #line),
+        ]
+        inputs.forEach { (part, new, expected, line) in
+            XCTAssertEqual(part.appending(new), expected, line: line)
+        }
+    }
+
+    func testIsSubPartOf() {
+        let inputs: [(SectionSpecifier.Part, SectionSpecifier.Part, Bool, UInt)] = [
+            ([], [], false, #line),
+            ([2, 3], [2, 3], false, #line),
+            ([2, 3, 1], [2, 3], true, #line),
+            ([2, 3], [2, 3, 1], false, #line),
+            ([2, 3, 1, 7], [2, 3], true, #line),
+            ([2, 3, 1, 7], [2, 3, 1], true, #line),
+            ([2, 4, 1, 7], [2, 3], false, #line),
+            ([5, 3, 1, 7], [2, 3], false, #line),
+        ]
+        inputs.forEach { (part, other, expected, line) in
+            XCTAssertEqual(part.isSubPart(of: other), expected, line: line)
+        }
+    }
+}
+
 // MARK: - CustomDebugStringConvertible
 
 extension SectionSpecifierTests {


### PR DESCRIPTION
Add convenience methods to `BodyStructure` and `SectionSpecifier.Part`.

### Motivation:

Simplifies some common operations on `BodyStructure` and `SectionSpecifier.Part`.

### Modifications:

Adds these convenience methods:

```swift
extension BodyStructure {
    public func enumerateParts(_ closure: (SectionSpecifier.Part, BodyStructure) throws -> Void) rethrows
}
```

```swift
extension SectionSpecifier.Part {
    public func dropFirst()
    public func dropLast() -> SectionSpecifier.Part
    public func appending(_ element: Int) -> SectionSpecifier.Part
    public func isSubPart(of other: SectionSpecifier.Part) -> Bool
}
```
