### PR TITLE
Need to allow Response.fetch while in IDLE.

### DIFF
--- a/Sources/NIOIMAP/Client/IdleStateMachine.swift
+++ b/Sources/NIOIMAP/Client/IdleStateMachine.swift
@@ -64,9 +64,9 @@ extension ClientStateMachine {
         private func receiveResponse_idlingState(_ response: Response) throws {
             assert(self.state == .idling)
             switch response {
-            case .untagged:
+            case .untagged, .fetch:
                 break
-            case .fetch, .tagged, .fatal, .authenticationChallenge, .idleStarted:
+            case .tagged, .fatal, .authenticationChallenge, .idleStarted:
                 throw UnexpectedResponse(activePromise: nil)
             }
         }


### PR DESCRIPTION
Need to allow Response.fetch while in IDLE.

### Motivation:

While we’re in the `IDLE` state, we need to allow untagged responses. In addition to `Response.untagged`, we need to also allow `Response.fetch` since those are also _untagged_. The `FETCH` related were split out to allow streaming.

### Modifications:

Fixed the `switch` inside `func receiveResponse_idlingState()`.

Added a test case.

Fixes #716
