### PR TITLE
Allow NIL response for a particular body section

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
@@ -43,6 +43,14 @@ public enum MessageAttribute: Hashable {
     /// - SeeAlso: RFC 3516 “IMAP4 Binary Content Extension”
     case binarySize(section: SectionSpecifier.Part, size: Int)
 
+    /// A `NIL` response to a `StreamingKind`.
+    ///
+    /// This corresponds to e.g. `BODY[4.TEXT] NIL`, i.e. when there’s no data
+    /// for a particular body section. Note that this is different than a
+    /// `.streamingBegin` with a `byteCount` of `0`. The former indicates
+    /// that the section does not exist, the latter than it has zero length.
+    case nilBody(StreamingKind)
+
     /// The modification time of the message.
     case fetchModificationResponse(FetchModificationResponse)
 
@@ -91,6 +99,8 @@ extension EncodeBuffer {
             return self.writeMessageAttribute_binarySize(section: section, number: number)
         case .flags(let flags):
             return self.writeMessageAttributeFlags(flags)
+        case .nilBody(let kind):
+            return self.writeMessageAttributeNilBody(kind)
         case .fetchModificationResponse(let resp):
             return self.writeFetchModificationResponse(resp)
         case .gmailMessageID(let id):
@@ -120,6 +130,12 @@ extension EncodeBuffer {
             self.writeArray(atts) { (element, self) in
                 self.writeFlag(element)
             }
+    }
+
+    @discardableResult mutating func writeMessageAttributeNilBody(_ kind: StreamingKind) -> Int {
+        self.writeStreamingKind(kind) +
+            self.writeSpace() +
+            self.writeNil()
     }
 
     @discardableResult mutating func writeMessageAttribute_envelope(_ env: Envelope) -> Int {

--- a/Sources/NIOIMAPCore/Grammar/Response/Response.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/Response.swift
@@ -137,7 +137,7 @@ extension StreamingKind {
 
 extension StreamingKind: CustomDebugStringConvertible {
     public var debugDescription: String {
-        ResponseEncodeBuffer.makeDescription {
+        EncodeBuffer.makeDescription {
             $0.writeStreamingKind(self)
         }
     }

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
@@ -262,6 +262,13 @@ extension GrammarParser {
             return .quotedStreamingBegin(kind: type, byteCount: quoted.readableBytes)
         }
 
+        func parseFetchResponse_nilBody(buffer: inout ParseBuffer, tracker: StackTracker) throws -> _FetchResponse {
+            let type = try self.parseFetchStreamingResponse(buffer: &buffer, tracker: tracker)
+            try PL.parseSpaces(buffer: &buffer, tracker: tracker)
+            try parseNil(buffer: &buffer, tracker: tracker)
+            return .simpleAttribute(.nilBody(type))
+        }
+
         func parseFetchResponse_finish(buffer: inout ParseBuffer, tracker: StackTracker) throws -> _FetchResponse {
             try PL.parseFixedString(")", buffer: &buffer, tracker: tracker)
             try PL.parseNewline(buffer: &buffer, tracker: tracker)
@@ -271,6 +278,7 @@ extension GrammarParser {
         return try PL.parseOneOf([
             parseFetchResponse_streamingBegin,
             parseFetchResponse_streamingBeginQuoted,
+            parseFetchResponse_nilBody,
             parseFetchResponse_simpleAttribute,
             parseFetchResponse_finish,
         ], buffer: &buffer, tracker: tracker)

--- a/Sources/NIOIMAPCore/ResponseEncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/ResponseEncodeBuffer.swift
@@ -146,27 +146,29 @@ extension ResponseEncodeBuffer {
     }
 
     @discardableResult mutating func writeStreamingKind(_ kind: StreamingKind, size: Int) -> Int {
-        self.writeStreamingKind(kind) +
+        self.buffer.writeStreamingKind(kind) +
             self.buffer.writeSpace() +
             self.buffer.writeString("{\(size)}\r\n")
     }
+}
 
+extension EncodeBuffer {
     @discardableResult mutating func writeStreamingKind(_ kind: StreamingKind) -> Int {
         switch kind {
         case .binary:
-            return self.buffer.writeString("BINARY")
+            return self.writeString("BINARY")
         case .body(let section, let offset):
-            return self.buffer.writeString("BODY") +
-                self.buffer.writeSection(section) +
-                self.buffer.writeIfExists(offset) { offset in
-                    self.buffer.writeString("<\(offset)>")
+            return self.writeString("BODY") +
+                self.writeSection(section) +
+                self.writeIfExists(offset) { offset in
+                    self.writeString("<\(offset)>")
                 }
         case .rfc822:
-            return self.buffer.writeString("RFC822")
+            return self.writeString("RFC822")
         case .rfc822Text:
-            return self.buffer.writeString("RFC822.TEXT")
+            return self.writeString("RFC822.TEXT")
         case .rfc822Header:
-            return self.buffer.writeString("RFC822.HEADER")
+            return self.writeString("RFC822.HEADER")
         }
     }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/Response+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/Response+Tests.swift
@@ -55,6 +55,11 @@ extension Response_Tests {
                 "* 3 FETCH (UID 123 RFC822.HEADER {0}\r\n UID 456)\r\n",
                 #line
             ),
+            (
+                [.start(87), .simpleAttribute(.nilBody(.body(section: .init(part: [4], kind: .text), offset: nil))), .simpleAttribute(.uid(123)), .finish],
+                "* 87 FETCH (BODY[4.TEXT] NIL UID 123)\r\n",
+                #line
+            ),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Message+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Message+Tests.swift
@@ -28,6 +28,7 @@ extension GrammarParser_Message_Tests {
         self.iterateTests(
             testFunction: GrammarParser().parseMessageAttribute,
             validInputs: [
+                (#"FLAGS (\seen)"#, " ", .flags([.seen]), #line),
                 ("UID 1234", " ", .uid(1234), #line),
                 ("RFC822.SIZE 1234", " ", .rfc822Size(1234), #line),
                 ("BINARY.SIZE[3] 4", " ", .binarySize(section: [3], size: 4), #line),
@@ -49,6 +50,18 @@ extension GrammarParser_Message_Tests {
                     )),
                     #line
                 ),
+                (#"BODY (("TEXT" "PLAIN" ("CHARSET" "utf-8") NIL NIL "QUOTED-PRINTABLE" 1772 47 NIL NIL NIL NIL)("TEXT" "HTML" ("CHARSET" "utf-8") NIL NIL "QUOTED-PRINTABLE" 2778 40 NIL NIL NIL NIL) "ALTERNATIVE" ("BOUNDARY" "Apple-Mail=_0D97185D-4FF1-42FE-9B8F-A0759D299015") NIL NIL NIL)"#, " ", .body(.multipart(.init(parts: [
+                    .singlepart(.init(kind: .text(.init(mediaSubtype: "PLAIN", lineCount: 47)), fields: .init(parameters: ["CHARSET": "utf-8"], id: nil, contentDescription: nil, encoding: .quotedPrintable, octetCount: 1772), extension: .init(digest: nil, dispositionAndLanguage: .init(disposition: nil, language: .init(languages: [], location: .init(location: nil, extensions: [])))))),
+                    .singlepart(.init(kind: .text(.init(mediaSubtype: "HTML", lineCount: 40)), fields: .init(parameters: ["CHARSET": "utf-8"], id: nil, contentDescription: nil, encoding: .quotedPrintable, octetCount: 2778), extension: .init(digest: nil, dispositionAndLanguage: .init(disposition: nil, language: .init(languages: [], location: .init(location: nil, extensions: [])))))),
+                ], mediaSubtype: .alternative, extension: .init(parameters: ["BOUNDARY": "Apple-Mail=_0D97185D-4FF1-42FE-9B8F-A0759D299015"], dispositionAndLanguage: .init(disposition: nil, language: .init(languages: [], location: .init(location: nil, extensions: [])))))), hasExtensionData: false), #line),
+                (#"BODYSTRUCTURE (("TEXT" "PLAIN" ("CHARSET" "utf-8") NIL NIL "QUOTED-PRINTABLE" 1772 47 NIL NIL NIL NIL)("TEXT" "HTML" ("CHARSET" "utf-8") NIL NIL "QUOTED-PRINTABLE" 2778 40 NIL NIL NIL NIL) "ALTERNATIVE" ("BOUNDARY" "Apple-Mail=_0D97185D-4FF1-42FE-9B8F-A0759D299015") NIL NIL NIL)"#, " ", .body(.multipart(.init(parts: [
+                    .singlepart(.init(kind: .text(.init(mediaSubtype: "PLAIN", lineCount: 47)), fields: .init(parameters: ["CHARSET": "utf-8"], id: nil, contentDescription: nil, encoding: .quotedPrintable, octetCount: 1772), extension: .init(digest: nil, dispositionAndLanguage: .init(disposition: nil, language: .init(languages: [], location: .init(location: nil, extensions: [])))))),
+                    .singlepart(.init(kind: .text(.init(mediaSubtype: "HTML", lineCount: 40)), fields: .init(parameters: ["CHARSET": "utf-8"], id: nil, contentDescription: nil, encoding: .quotedPrintable, octetCount: 2778), extension: .init(digest: nil, dispositionAndLanguage: .init(disposition: nil, language: .init(languages: [], location: .init(location: nil, extensions: [])))))),
+                ], mediaSubtype: .alternative, extension: .init(parameters: ["BOUNDARY": "Apple-Mail=_0D97185D-4FF1-42FE-9B8F-A0759D299015"], dispositionAndLanguage: .init(disposition: nil, language: .init(languages: [], location: .init(location: nil, extensions: [])))))), hasExtensionData: true), #line),
+                ("RFC822.TEXT NIL", " ", .nilBody(.rfc822Text), #line),
+                ("RFC822.HEADER NIL", " ", .nilBody(.rfc822Header), #line),
+                ("BINARY[4]<5> NIL", " ", .nilBody(.binary(section: [4], offset: 5)), #line),
+                ("BODY[4.TEXT]<5> NIL", " ", .nilBody(.body(section: .init(part: [4], kind: .text), offset: 5)), #line),
                 ("MODSEQ (3)", " ", .fetchModificationResponse(.init(modifierSequenceValue: 3)), #line),
                 ("X-GM-MSGID 1278455344230334865", " ", .gmailMessageID(1278455344230334865), #line),
                 ("X-GM-THRID 1278455344230334865", " ", .gmailThreadID(1278455344230334865), #line),

--- a/Tests/NIOIMAPCoreTests/ResponseStreamingTests.swift
+++ b/Tests/NIOIMAPCoreTests/ResponseStreamingTests.swift
@@ -73,6 +73,19 @@ extension ResponseStreamingTests {
             (.fetch(.finish), #line),
         ])
 
+        self.AssertFetchResponses("* 3 FETCH (BODY[5.2.MIME] NIL)\r\n", [
+            (.fetch(.start(3)), #line),
+            (.fetch(.simpleAttribute(.nilBody(.body(section: .init(part: [5, 2], kind: .MIMEHeader), offset: nil)))), #line),
+            (.fetch(.finish), #line),
+        ])
+
+        self.AssertFetchResponses("* 3 FETCH (BODY[3] NIL UID 456)\r\n", [
+            (.fetch(.start(3)), #line),
+            (.fetch(.simpleAttribute(.nilBody(.body(section: .init(part: [3]), offset: nil)))), #line),
+            (.fetch(.simpleAttribute(.uid(456))), #line),
+            (.fetch(.finish), #line),
+        ])
+
         self.AssertFetchResponses("* 4 FETCH (BODY[4.TEXT]<4> {3}\r\nabc FLAGS (\\seen \\answered))\r\n", [
             (.fetch(.start(4)), #line),
             (.fetch(.streamingBegin(kind: .body(section: .init(part: [4], kind: .text), offset: 4), byteCount: 3)), #line),


### PR DESCRIPTION
Allow `NIL` response for a particular body section

### Motivation:

The [RFC 3501 section 7.4.2][3501FetchResponse] `FETCH` response for a `BODY[<section>]<<origin octet>>` (or the corresponding `BINARY` from [RFC 3516][3516]) is allowed to be `NIL` (it’s an `nstring`), corresponding to a non-existing body section.

For example, if the client requests `BODY.PEEK[4.2]` and there’s no 4.2 for that particular message, the server will respond with `BODY[4.2] NIL`.

### Modifications:

Add a `MessageAttribute` corresponding to this `NIL` value.

Note that the non-nil version uses `FetchResponse.streamingBegin(…)`, `.streamingBytes(…)`, and `.streamingEnd`, whereas the `NIL` variant uses `FetchResponse.simpleAttribute` since it won’t be streaming any data.

Added test cases for encoding and parsing.


[3501FetchResponse]: https://www.rfc-editor.org/rfc/rfc3501#section-7.4.2
[3516]: https://www.rfc-editor.org/rfc/rfc3516