### PR TITLE
Remove MessageAttribute.binary

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
@@ -34,10 +34,6 @@ public enum MessageAttribute: Hashable {
     /// A `BODYSTRUCTURE` response will have `hasExtensionData` set to `true`.
     case body(BodyStructure, hasExtensionData: Bool)
 
-    /// `BINARY<section-binary>[<<number>>]` -- The content of the
-    /// specified section after removing any content-transfer-encoding related encoding.
-    /// - SeeAlso: RFC 3516 “IMAP4 Binary Content Extension”
-    case binary(section: SectionSpecifier.Part, data: ByteBuffer?)
     /// `BINARY.SIZE<section-binary>` -- The size of the section after
     /// removing any content-transfer-encoding related encoding.
     /// - SeeAlso: RFC 3516 “IMAP4 Binary Content Extension”
@@ -85,8 +81,6 @@ extension EncodeBuffer {
             return self.writeMessageAttribute_body(body, hasExtensionData: hasExtensionData)
         case .uid(let uid):
             return self.writeString("UID \(uid.rawValue)")
-        case .binary(section: let section, data: let string):
-            return self.writeMessageAttribute_binaryString(section: section, string: string)
         case .binarySize(section: let section, size: let number):
             return self.writeMessageAttribute_binarySize(section: section, number: number)
         case .flags(let flags):
@@ -100,13 +94,6 @@ extension EncodeBuffer {
         case .gmailLabels(let labels):
             return self.writeMessageAttribute_gmailLabels(labels)
         }
-    }
-
-    @discardableResult mutating func writeMessageAttribute_binaryString(section: SectionSpecifier.Part, string: ByteBuffer?) -> Int {
-        self.writeString("BINARY") +
-            self.writeSectionBinary(section) +
-            self.writeSpace() +
-            self.writeNString(string)
     }
 
     @discardableResult mutating func writeMessageAttribute_binarySize(section: SectionSpecifier.Part, number: Int) -> Int {

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
@@ -126,13 +126,6 @@ extension GrammarParser {
             return .binarySize(section: section, size: number)
         }
 
-        func parseMessageAttribute_binary(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
-            let section = try self.parseSectionBinary(buffer: &buffer, tracker: tracker)
-            try PL.parseSpaces(buffer: &buffer, tracker: tracker)
-            let string = try self.parseNString(buffer: &buffer, tracker: tracker)
-            return .binary(section: section, data: string)
-        }
-
         func parseMessageAttribute_fetchModifierResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageAttribute {
             try PL.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> MessageAttribute in
                 try PL.parseSpaces(buffer: &buffer, tracker: tracker)
@@ -186,7 +179,6 @@ extension GrammarParser {
             "BODYSTRUCTURE": parseMessageAttribute_bodyStructure,
             "UID": parseMessageAttribute_uid,
             "BINARY.SIZE": parseMessageAttribute_binarySize,
-            "BINARY": parseMessageAttribute_binary,
             "X-GM-MSGID": parseMessageAttribute_gmailMessageID,
             "X-GM-THRID": parseMessageAttribute_gmailThreadID,
             "X-GM-LABELS": parseMessageAttribute_gmailLabels,

--- a/Tests/NIOIMAPCoreTests/Grammar/Message/MessageAtributesTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Message/MessageAtributesTests.swift
@@ -31,8 +31,6 @@ extension MessageAttributesTests {
             (.envelope(Envelope(date: "date", subject: "subject", from: [.singleAddress(.init(personName: "name", sourceRoot: "adl", mailbox: "mailbox", host: "host"))], sender: [.singleAddress(.init(personName: "name", sourceRoot: "adl", mailbox: "mailbox", host: "host"))], reply: [.singleAddress(.init(personName: "name", sourceRoot: "adl", mailbox: "mailbox", host: "host"))], to: [.singleAddress(.init(personName: "name", sourceRoot: "adl", mailbox: "mailbox", host: "host"))], cc: [.singleAddress(.init(personName: "name", sourceRoot: "adl", mailbox: "mailbox", host: "host"))], bcc: [.singleAddress(.init(personName: "name", sourceRoot: "adl", mailbox: "mailbox", host: "host"))], inReplyTo: "replyto", messageID: "abc123")), "ENVELOPE (\"date\" \"subject\" ((\"name\" \"adl\" \"mailbox\" \"host\")) ((\"name\" \"adl\" \"mailbox\" \"host\")) ((\"name\" \"adl\" \"mailbox\" \"host\")) ((\"name\" \"adl\" \"mailbox\" \"host\")) ((\"name\" \"adl\" \"mailbox\" \"host\")) ((\"name\" \"adl\" \"mailbox\" \"host\")) \"replyto\" \"abc123\")", #line),
             (.internalDate(date), #"INTERNALDATE "25-Jun-1994 01:02:03 +0000""#, #line),
             (.binarySize(section: [2], size: 3), "BINARY.SIZE[2] 3", #line),
-            (.binary(section: [3], data: nil), "BINARY[3] NIL", #line),
-            (.binary(section: [3], data: "test"), "BINARY[3] \"test\"", #line),
             (.flags([.draft]), "FLAGS (\\Draft)", #line),
             (.flags([.flagged, .draft]), "FLAGS (\\Flagged \\Draft)", #line),
             (.fetchModificationResponse(.init(modifierSequenceValue: 3)), "MODSEQ (3)", #line),

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Message+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Message+Tests.swift
@@ -31,7 +31,6 @@ extension GrammarParser_Message_Tests {
                 ("UID 1234", " ", .uid(1234), #line),
                 ("RFC822.SIZE 1234", " ", .rfc822Size(1234), #line),
                 ("BINARY.SIZE[3] 4", " ", .binarySize(section: [3], size: 4), #line),
-                ("BINARY[3] \"hello\"", " ", .binary(section: [3], data: "hello"), #line),
                 (#"INTERNALDATE "25-jun-1994 01:02:03 +0000""#, " ", .internalDate(date), #line),
                 (
                     #"ENVELOPE ("date" "subject" (("from1" "from2" "from3" "from4")) (("sender1" "sender2" "sender3" "sender4")) (("reply1" "reply2" "reply3" "reply4")) (("to1" "to2" "to3" "to4")) (("cc1" "cc2" "cc3" "cc4")) (("bcc1" "bcc2" "bcc3" "bcc4")) "inreplyto" "messageid")"#,

--- a/Tests/NIOIMAPCoreTests/ResponseStreamingTests.swift
+++ b/Tests/NIOIMAPCoreTests/ResponseStreamingTests.swift
@@ -73,6 +73,14 @@ extension ResponseStreamingTests {
             (.fetch(.finish), #line),
         ])
 
+        self.AssertFetchResponses("* 3 FETCH (BINARY[4] {3}\r\nghi)\r\n", [
+            (.fetch(.start(3)), #line),
+            (.fetch(.streamingBegin(kind: .binary(section: [4], offset: nil), byteCount: 3)), #line),
+            (.fetch(.streamingBytes("ghi")), #line),
+            (.fetch(.streamingEnd), #line),
+            (.fetch(.finish), #line),
+        ])
+
         self.AssertFetchResponses("* 4 FETCH (BODY[4.TEXT]<4> {3}\r\nabc FLAGS (\\seen \\answered))\r\n", [
             (.fetch(.start(4)), #line),
             (.fetch(.streamingBegin(kind: .body(section: .init(part: [4], kind: .text), offset: 4), byteCount: 3)), #line),


### PR DESCRIPTION
This is (already) being handled by `FetchResponse.streamingBegin` / `StreamingKind`.

The `MessageAttribute.binary` case was a left-over from before `.streamingBegin` was added.