### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
+++ b/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
@@ -46,7 +46,7 @@ public struct BadCommand: Error {
 
 /// An error ocurred when parsing an IMAP command or response.
 public struct ParserError: Error {
-    static func invalidUTF8(file: String = (#file), line: Int = #line) -> Self {
+    static func invalidUTF8(file: String = (#fileID), line: Int = #line) -> Self {
         ParserError(hint: "Invalid UTF8", file: file, line: line)
     }
 
@@ -55,7 +55,7 @@ public struct ParserError: Error {
     var file: String
     var line: Int
 
-    init(hint: String = "Unknown", file: String = (#file), line: Int = #line) {
+    init(hint: String = "Unknown", file: String = (#fileID), line: Int = #line) {
         self.hint = hint
         self.file = file
         self.line = line
@@ -77,7 +77,7 @@ public struct TooMuchRecursion: Error {
 extension ParserLibrary {
     /// Throws `ParserError.invalidUTF8` if the given `ByteBuffer` doesn't
     /// contain a valid UTF8 sequence.
-    static func parseBufferAsUTF8(_ buffer: ByteBuffer, file: String = (#file), line: Int = #line) throws -> String {
+    static func parseBufferAsUTF8(_ buffer: ByteBuffer, file: String = (#fileID), line: Int = #line) throws -> String {
         guard let string = String(validatingUTF8Bytes: buffer.readableBytesView) else {
             throw ParserError.invalidUTF8(file: file, line: line)
         }
@@ -236,7 +236,7 @@ extension ParserLibrary {
         }
     }
 
-    static func parseOneOf<T>(_ subParsers: [SubParser<T>], buffer: inout ParseBuffer, tracker: StackTracker, file: String = (#file), line: Int = #line) throws -> T {
+    static func parseOneOf<T>(_ subParsers: [SubParser<T>], buffer: inout ParseBuffer, tracker: StackTracker, file: String = (#fileID), line: Int = #line) throws -> T {
         for parser in subParsers {
             do {
                 return try PL.composite(buffer: &buffer, tracker: tracker, parser)
@@ -252,7 +252,7 @@ extension ParserLibrary {
     static func parseOneOf<T>(_ parser1: SubParser<T>,
                               _ parser2: SubParser<T>,
                               buffer: inout ParseBuffer,
-                              tracker: StackTracker, file: String = (#file), line: Int = #line) throws -> T
+                              tracker: StackTracker, file: String = (#fileID), line: Int = #line) throws -> T
     {
         do {
             return try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
@@ -274,7 +274,7 @@ extension ParserLibrary {
                               _ parser2: SubParser<T>,
                               _ parser3: SubParser<T>,
                               buffer: inout ParseBuffer,
-                              tracker: StackTracker, file: String = (#file), line: Int = #line) throws -> T
+                              tracker: StackTracker, file: String = (#fileID), line: Int = #line) throws -> T
     {
         do {
             return try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in

--- a/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
@@ -44,11 +44,11 @@ class EncodeTestClass: XCTestCase {
         self.testBuffer = nil
     }
 
-    func iterateInputs<T>(inputs: [(T, String, UInt)], encoder: (T) throws -> Int, file: StaticString = #file) {
+    func iterateInputs<T>(inputs: [(T, String, UInt)], encoder: (T) throws -> Int, file: StaticString = #filePath) {
         self.iterateInputs(inputs: inputs.map { ($0.0, ResponseEncodingOptions(), $0.1, $0.2) }, encoder: encoder, file: (file))
     }
 
-    func iterateInputs<T>(inputs: [(T, CommandEncodingOptions, [String], UInt)], encoder: (T) throws -> Int, file: StaticString = #file) {
+    func iterateInputs<T>(inputs: [(T, CommandEncodingOptions, [String], UInt)], encoder: (T) throws -> Int, file: StaticString = #filePath) {
         for (test, options, expectedStrings, line) in inputs {
             self.testBuffer = EncodeBuffer.clientEncodeBuffer(buffer: ByteBufferAllocator().buffer(capacity: 128), options: options, loggingMode: false)
             do {
@@ -61,7 +61,7 @@ class EncodeTestClass: XCTestCase {
         }
     }
 
-    func iterateCommandInputs<T>(inputs: [(T, CommandEncodingOptions, [String], UInt)], encoder: (T) throws -> Int, file: StaticString = #file) {
+    func iterateCommandInputs<T>(inputs: [(T, CommandEncodingOptions, [String], UInt)], encoder: (T) throws -> Int, file: StaticString = #filePath) {
         for (test, options, expectedStrings, line) in inputs {
             do {
                 self.testBuffer.mode = .client(options: options)
@@ -74,7 +74,7 @@ class EncodeTestClass: XCTestCase {
         }
     }
 
-    func iterateInputs<T>(inputs: [(T, ResponseEncodingOptions, String, UInt)], encoder: (T) throws -> Int, file: StaticString = #file) {
+    func iterateInputs<T>(inputs: [(T, ResponseEncodingOptions, String, UInt)], encoder: (T) throws -> Int, file: StaticString = #filePath) {
         for (test, options, expectedString, line) in inputs {
             self.testBuffer = EncodeBuffer.serverEncodeBuffer(buffer: ByteBufferAllocator().buffer(capacity: 128), options: options, loggingMode: false)
             do {

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -32,7 +32,7 @@ protocol _ParserTestHelpers {}
 final class ParserUnitTests: XCTestCase, _ParserTestHelpers {}
 
 extension _ParserTestHelpers {
-    private func iterateTestInputs_generic<T: Equatable>(_ inputs: [(String, String, T, UInt)], file: StaticString = #file, testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
+    private func iterateTestInputs_generic<T: Equatable>(_ inputs: [(String, String, T, UInt)], file: StaticString = #filePath, testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
         for (input, terminator, expected, line) in inputs {
             TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: false, file: file, line: line) { (buffer) in
                 let testValue = try testFunction(&buffer, .testTracker)
@@ -41,7 +41,7 @@ extension _ParserTestHelpers {
         }
     }
 
-    private func iterateInvalidTestInputs_ParserError_generic<T: Equatable>(_ inputs: [(String, String, UInt)], file: StaticString = #file, testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
+    private func iterateInvalidTestInputs_ParserError_generic<T: Equatable>(_ inputs: [(String, String, UInt)], file: StaticString = #filePath, testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
         for (input, terminator, line) in inputs {
             TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: file, line: line) { (buffer) in
                 XCTAssertThrowsError(try testFunction(&buffer, .testTracker), file: file, line: line) { e in
@@ -51,7 +51,7 @@ extension _ParserTestHelpers {
         }
     }
 
-    private func iterateInvalidTestInputs_IncompleteMessage_generic<T: Equatable>(_ inputs: [(String, String, UInt)], file: StaticString = #file, testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
+    private func iterateInvalidTestInputs_IncompleteMessage_generic<T: Equatable>(_ inputs: [(String, String, UInt)], file: StaticString = #filePath, testFunction: (inout ParseBuffer, StackTracker) throws -> T) {
         for (input, terminator, line) in inputs {
             TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: file, line: line) { (buffer) in
                 XCTAssertThrowsError(try testFunction(&buffer, .testTracker), file: file, line: line) { e in
@@ -61,7 +61,7 @@ extension _ParserTestHelpers {
         }
     }
 
-    private func iterateTestInputs(_ inputs: [(String, String, UInt)], file: StaticString = #file, testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
+    private func iterateTestInputs(_ inputs: [(String, String, UInt)], file: StaticString = #filePath, testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
         for (input, terminator, line) in inputs {
             TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: false, file: file, line: line) { (buffer) in
                 try testFunction(&buffer, .testTracker)
@@ -69,7 +69,7 @@ extension _ParserTestHelpers {
         }
     }
 
-    private func iterateInvalidTestInputs_ParserError(_ inputs: [(String, String, UInt)], file: StaticString = #file, testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
+    private func iterateInvalidTestInputs_ParserError(_ inputs: [(String, String, UInt)], file: StaticString = #filePath, testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
         for (input, terminator, line) in inputs {
             TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: file, line: line) { (buffer) in
                 XCTAssertThrowsError(try testFunction(&buffer, .testTracker), file: file, line: line) { e in
@@ -79,7 +79,7 @@ extension _ParserTestHelpers {
         }
     }
 
-    private func iterateInvalidTestInputs_IncompleteMessage(_ inputs: [(String, String, UInt)], file: StaticString = #file, testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
+    private func iterateInvalidTestInputs_IncompleteMessage(_ inputs: [(String, String, UInt)], file: StaticString = #filePath, testFunction: (inout ParseBuffer, StackTracker) throws -> Void) {
         for (input, terminator, line) in inputs {
             TestUtilities.withParseBuffer(input, terminator: terminator, shouldRemainUnchanged: true, file: file, line: line) { (buffer) in
                 XCTAssertThrowsError(try testFunction(&buffer, .testTracker), file: file, line: line) { e in
@@ -99,7 +99,7 @@ extension _ParserTestHelpers {
         validInputs: [(String, String, T, UInt)],
         parserErrorInputs: [(String, String, UInt)],
         incompleteMessageInputs: [(String, String, UInt)],
-        file: StaticString = #file
+        file: StaticString = #filePath
     ) {
         self.iterateTestInputs_generic(validInputs, file: file, testFunction: testFunction)
         self.iterateInvalidTestInputs_ParserError_generic(parserErrorInputs, file: file, testFunction: testFunction)
@@ -116,7 +116,7 @@ extension _ParserTestHelpers {
         validInputs: [(String, String, UInt)],
         parserErrorInputs: [(String, String, UInt)],
         incompleteMessageInputs: [(String, String, UInt)],
-        file: StaticString = #file
+        file: StaticString = #filePath
     ) {
         self.iterateTestInputs(validInputs, file: file, testFunction: testFunction)
         self.iterateInvalidTestInputs_ParserError(parserErrorInputs, file: file, testFunction: testFunction)

--- a/Tests/NIOIMAPCoreTests/Parser/SynchronizingLiteralParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/SynchronizingLiteralParserTests.swift
@@ -211,7 +211,7 @@ final class SynchronizingLiteralParserTests: XCTestCase {
     }
 
     private func assertMultipleParses(_ expectedStrings: [String], continuationsNecessary: Int = 0,
-                                      file: StaticString = (#file),
+                                      file: StaticString = (#filePath),
                                       line: UInt = #line)
     {
         guard expectedStrings.count == self.parses.count else {
@@ -244,7 +244,7 @@ final class SynchronizingLiteralParserTests: XCTestCase {
     }
 
     private func assertOneParse(_ string: String, continuationsNecessary: Int = 0,
-                                file: StaticString = (#file),
+                                file: StaticString = (#filePath),
                                 line: UInt = #line)
     {
         XCTAssertEqual(1, self.parses.count)

--- a/Tests/NIOIMAPCoreTests/TestUtilities.swift
+++ b/Tests/NIOIMAPCoreTests/TestUtilities.swift
@@ -30,7 +30,7 @@ extension TestUtilities {
     static func withParseBuffer(_ string: String,
                                 terminator: String = "",
                                 shouldRemainUnchanged: Bool = false,
-                                file: StaticString = (#file), line: UInt = #line, _ body: (inout ParseBuffer) throws -> Void)
+                                file: StaticString = (#filePath), line: UInt = #line, _ body: (inout ParseBuffer) throws -> Void)
     {
         var inputBuffer = ByteBufferAllocator().buffer(capacity: string.utf8.count + terminator.utf8.count + 10)
         inputBuffer.writeString("hello")

--- a/Tests/NIOIMAPTests/TestUtilities.swift
+++ b/Tests/NIOIMAPTests/TestUtilities.swift
@@ -22,9 +22,9 @@ enum TestUtilities {}
 // MARK: - ByteBuffer
 
 #if swift(>=5.3)
-func magicFile(file: StaticString = (#file)) -> StaticString { file }
+func magicFile(file: StaticString = (#filePath)) -> StaticString { file }
 #else
-func magicFile(file: StaticString = (#file)) -> StaticString { file }
+func magicFile(file: StaticString = (#filePath)) -> StaticString { file }
 #endif
 
 extension TestUtilities {
@@ -43,7 +43,7 @@ extension TestUtilities {
     static func withBuffer(_ string: String,
                            terminator: String = "",
                            shouldRemainUnchanged: Bool = false,
-                           file: StaticString = (#file), line: UInt = #line, _ body: (inout ByteBuffer) throws -> Void)
+                           file: StaticString = (#filePath), line: UInt = #line, _ body: (inout ByteBuffer) throws -> Void)
     {
         var inputBuffer = ByteBufferAllocator().buffer(capacity: string.utf8.count + terminator.utf8.count + 10)
         inputBuffer.writeString("hello")


### PR DESCRIPTION
Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere                                  

Modifications:

Changed #file to #filePath or #fileID depending on situation

