### PR TITLE
Ability to create decription from Response

### DIFF
--- a/Sources/NIOIMAPCore/EncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/EncodeBuffer.swift
@@ -154,7 +154,11 @@ extension EncodeBuffer {
     @discardableResult
     @inlinable
     public mutating func writeBytes<Bytes: Sequence>(_ bytes: Bytes) -> Int where Bytes.Element == UInt8 {
-        self.buffer.writeBytes(bytes)
+        if loggingMode {
+            return self.buffer.writeString("[\(Array(bytes).count) bytes]")
+        } else {
+            return self.buffer.writeBytes(bytes)
+        }
     }
 
     /// Writes a `ByteBuffer` to the buffer.
@@ -163,7 +167,11 @@ extension EncodeBuffer {
     @discardableResult
     @inlinable
     public mutating func writeBuffer(_ buffer: inout ByteBuffer) -> Int {
-        self.buffer.writeBuffer(&buffer)
+        if loggingMode {
+            return self.buffer.writeString("[\(buffer.readableBytes) bytes]")
+        } else {
+            return self.buffer.writeBuffer(&buffer)
+        }
     }
 
     /// Erases all data from the buffer.

--- a/Sources/NIOIMAPCore/Grammar/Response/Response.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/Response.swift
@@ -57,6 +57,25 @@ public enum Response: Hashable {
     }
 }
 
+extension Response: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        ResponseEncodeBuffer.makeDescription(loggingMode: false) {
+            $0.writeResponse(self)
+        }
+    }
+
+    /// Creates a string from the array of `Response` with all _personally identifiable information_ redacted.
+    ///
+    /// This is equivalent to joining `debugDescription` of all elements.
+    public static func descriptionWithoutPII(_ responses: some Sequence<Response>) -> String {
+        ResponseEncodeBuffer.makeDescription(loggingMode: true) {
+            for response in responses {
+                $0.writeResponse(response)
+            }
+        }
+    }
+}
+
 /// The first event will always be `start`
 /// The last event will always be `finish`
 /// Every `start` has exactly one corresponding `finish`

--- a/Sources/NIOIMAPCore/ResponseEncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/ResponseEncodeBuffer.swift
@@ -47,10 +47,10 @@ extension ResponseEncodeBuffer {
     /// Call the closure with a buffer, return the result as a String.
     ///
     /// Used for implementing ``CustomDebugStringConvertible`` conformance.
-    static func makeDescription(_ closure: (inout ResponseEncodeBuffer) -> Void) -> String {
+    static func makeDescription(loggingMode: Bool, _ closure: (inout ResponseEncodeBuffer) -> Void) -> String {
         var options = ResponseEncodingOptions()
         options.useQuotedString = true
-        var buffer = ResponseEncodeBuffer(buffer: ByteBuffer(), options: options, loggingMode: false)
+        var buffer = ResponseEncodeBuffer(buffer: ByteBuffer(), options: options, loggingMode: loggingMode)
         closure(&buffer)
         return String(bestEffortDecodingUTF8Bytes: buffer.buffer.buffer.readableBytesView)
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/Response+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/Response+Tests.swift
@@ -91,4 +91,42 @@ extension Response_Tests {
             XCTAssertEqual("\(part)", expected, line: line)
         }
     }
+
+    func testCustomDebugStringConvertible_Response() {
+        let inputs: [(Response, String, UInt)] = [
+            (.idleStarted, "+ idling\r\n", #line),
+            (.authenticationChallenge("hello"), "+ aGVsbG8=\r\n", #line),
+            (.fatal(.init(text: "Oh no you're dead")), "* BYE Oh no you're dead\r\n", #line),
+            (.tagged(.init(tag: "A1", state: .ok(.init(text: "NOOP complete")))), "A1 OK NOOP complete\r\n", #line),
+            (.untagged(.id([:])), "* ID NIL\r\n", #line),
+            (.fetch(.start(1)), "* 1 FETCH (", #line),
+            (.fetch(.simpleAttribute(.uid(123))), "UID 123", #line),
+            (.fetch(.streamingBegin(kind: .rfc822Text, byteCount: 0)), "RFC822.TEXT {0}\r\n", #line),
+            (.fetch(.streamingBytes(ByteBuffer(string: "hello"))), "hello", #line),
+            (.fetch(.finish), ")\r\n", #line),
+        ]
+
+        for (test, expectedString, line) in inputs {
+            XCTAssertEqual(String(reflecting: test), expectedString, line: line)
+        }
+    }
+
+    func testDescriptionWithoutPII_Response() {
+        let inputs: [(Response, String, UInt)] = [
+            (.idleStarted, "+ idling\r\n", #line),
+            (.authenticationChallenge("hello"), "+ [8 bytes]\r\n", #line),
+            (.fatal(.init(text: "Oh no you're dead")), "* BYE Oh no you're dead\r\n", #line),
+            (.tagged(.init(tag: "A1", state: .ok(.init(text: "NOOP complete")))), "A1 OK NOOP complete\r\n", #line),
+            (.untagged(.id([:])), "* ID NIL\r\n", #line),
+            (.fetch(.start(1)), "* 1 FETCH (", #line),
+            (.fetch(.simpleAttribute(.uid(123))), "UID 123", #line),
+            (.fetch(.streamingBegin(kind: .rfc822Text, byteCount: 0)), "RFC822.TEXT {0}\r\n", #line),
+            (.fetch(.streamingBytes(ByteBuffer(string: "hello"))), "[5 bytes]", #line),
+            (.fetch(.finish), ")\r\n", #line),
+        ]
+
+        for (test, expectedString, line) in inputs {
+            XCTAssertEqual(Response.descriptionWithoutPII([test]), expectedString, line: line)
+        }
+    }
 }


### PR DESCRIPTION
Ability to create decription from `Response`

### Motivation:

This allows creating a (debug) `String` from a `Response` — either with or without PII (personally identifiable information).
