### PR TITLE
Update AuthenticationStateMachine.swift to permit XOAUTH2 Gmail connections

### DIFF
--- a/Sources/NIOIMAP/Client/AuthenticationStateMachine.swift
+++ b/Sources/NIOIMAP/Client/AuthenticationStateMachine.swift
@@ -62,9 +62,9 @@ extension ClientStateMachine {
             // the function below.
 
             switch response {
-            case .untagged, .fetch, .fatal, .idleStarted, .authenticationChallenge:
+            case .fetch, .fatal, .idleStarted, .authenticationChallenge:
                 throw UnexpectedResponse(activePromise: nil)
-            case .tagged:
+            case .untagged, .tagged:
                 try self.handleTaggedResponse()
             }
         }


### PR DESCRIPTION
Permit connections via AUTH XOAUTH2 (for Gmail) by having the client continue on responses rather than throwing.

### Motivation:

In the current version, after submitting a `AUTHENTICATE XOAUTH2` command with an `InitialResponse`, the client will hang and never process its result nor continue. This change permits the client to process the response and continue with operations, which lets OAUTH connections to Gmail work.

### Modifications:

I have proposed making the `.untagged` case follow the `.tagged` case, rather than `.fatal` etc.

### Result:

This lets connections to Gmail imap work.

I would like to add that the motivation behind the current system is not completely understood by me and this proposed fix is no doubt not the only way to achieve a fix. I would like to draw attention to this issue (Gmail does not work with swift-nio-imap, as far as I could figure out), and provide one possible solution.
