### PR TITLE
Call through to RangeSet for MessageIdentifierSet’s SetAlgebra conformance where possible

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -400,6 +400,30 @@ extension MessageIdentifierSet: SetAlgebra {
     public mutating func formSymmetricDifference(_ other: MessageIdentifierSet) {
         _ranges.formSymmetricDifference(other._ranges)
     }
+
+    public func subtracting(_ other: Self) -> Self {
+        MessageIdentifierSet(_ranges.subtracting(other._ranges))
+    }
+
+    public func isSubset(of other: Self) -> Bool {
+        _ranges.isSubset(of: other._ranges)
+    }
+
+    public func isSuperset(of other: Self) -> Bool {
+        _ranges.isSuperset(of: other._ranges)
+    }
+
+    public mutating func subtract(_ other: Self) {
+        _ranges.subtract(other._ranges)
+    }
+
+    public func isStrictSuperset(of other: Self) -> Bool {
+        _ranges.isStrictSuperset(of: other._ranges)
+    }
+
+    public func isStrictSubset(of other: Self) -> Bool {
+        _ranges.isStrictSubset(of: other._ranges)
+    }
 }
 
 // MARK: - Conversion

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDSetTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDSetTests.swift
@@ -212,6 +212,109 @@ extension UIDSetTests {
         XCTAssertEqual("\(sut)", "20:29,36:40")
     }
 
+    func testSubtracting() {
+        let sut = MessageIdentifierSet<UID>(20 ... 35)
+        let a = sut.subtracting(MessageIdentifierSet<UID>(21 ... 24))
+        XCTAssertEqual("\(sut)", "20:35")
+        XCTAssertEqual("\(a)", "20,25:35")
+    }
+
+    func testIsSubset() {
+        XCTAssert(MessageIdentifierSet<UID>(20 ... 35)
+            .isSubset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isSubset(of: MessageIdentifierSet<UID>(2 ... 3))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isSubset(of: MessageIdentifierSet<UID>(24 ... 25))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(2 ... 3)
+            .isSubset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssert(MessageIdentifierSet<UID>(24 ... 25)
+            .isSubset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+    }
+
+    func testIsStrictSubset() {
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isStrictSubset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isStrictSubset(of: MessageIdentifierSet<UID>(2 ... 3))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isStrictSubset(of: MessageIdentifierSet<UID>(24 ... 25))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(2 ... 3)
+            .isStrictSubset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssert(MessageIdentifierSet<UID>(24 ... 25)
+            .isStrictSubset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+    }
+
+    func testIsDisjoint() {
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isDisjoint(with: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssert(MessageIdentifierSet<UID>(20 ... 35)
+            .isDisjoint(with: MessageIdentifierSet<UID>(2 ... 3))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isDisjoint(with: MessageIdentifierSet<UID>(24 ... 25))
+        )
+        XCTAssert(MessageIdentifierSet<UID>(2 ... 3)
+            .isDisjoint(with: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(24 ... 25)
+            .isDisjoint(with: MessageIdentifierSet<UID>(20 ... 35))
+        )
+    }
+
+    func testIsSuperset() {
+        XCTAssert(MessageIdentifierSet<UID>(20 ... 35)
+            .isSuperset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isSuperset(of: MessageIdentifierSet<UID>(2 ... 3))
+        )
+        XCTAssert(MessageIdentifierSet<UID>(20 ... 35)
+            .isSuperset(of: MessageIdentifierSet<UID>(24 ... 25))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(2 ... 3)
+            .isSuperset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(24 ... 25)
+            .isSuperset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+    }
+
+    func testIsStrictSuperset() {
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isStrictSuperset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(20 ... 35)
+            .isStrictSuperset(of: MessageIdentifierSet<UID>(2 ... 3))
+        )
+        XCTAssert(MessageIdentifierSet<UID>(20 ... 35)
+            .isStrictSuperset(of: MessageIdentifierSet<UID>(24 ... 25))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(2 ... 3)
+            .isStrictSuperset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+        XCTAssertFalse(MessageIdentifierSet<UID>(24 ... 25)
+            .isStrictSuperset(of: MessageIdentifierSet<UID>(20 ... 35))
+        )
+    }
+
+    func testSubtract() {
+        var sut = MessageIdentifierSet<UID>(20 ... 35)
+        sut.subtract(MessageIdentifierSet<UID>(21 ... 24))
+        XCTAssertEqual("\(sut)", "20,25:35")
+    }
+
     func testEmptyCollection() {
         XCTAssertEqual(MessageIdentifierSet<UID>().map { "\($0)" }, [])
         XCTAssertEqual(MessageIdentifierSet<UID>().count, 0)


### PR DESCRIPTION
Call through to `RangeSet` for `MessageIdentifierSet`’s `SetAlgebra` conformance where possible

### Motivation:

`MessageIdentifierSet` conforms to `SetAlgebra`, but some methods were relying on the default protocol implementations instead of using the underlying `RangeSet`’s implementation. This could lead to poor performance.
