### PR TITLE
Use enum for `ExtendedSearchResponse` UID vs. sequence number

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Response/ExtendedSearchResponse.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ExtendedSearchResponse.swift
@@ -19,20 +19,30 @@ public struct ExtendedSearchResponse: Hashable {
     /// Identifies the search that resulted in this response.
     public var correlator: SearchCorrelator?
 
-    /// `true` if this was a UID SEARCH, otherwise `false`.
-    public var uid: Bool
+    /// Is this a UID or a sequence number response?
+    public var kind: Kind
 
     /// Data returned from the search.
     public var returnData: [SearchReturnData]
 
     /// Creates a new `ExtendedSearchResponse`.
     /// - parameter correlator: Identifies the search that resulted in this response. Defaults to `nil`.
-    /// - parameter uid: `true` if this was a UID SEARCH, otherwise `false`.
+    /// - parameter kind: Is this a response to `UID SEARCH` or `SEARCH`?
     /// - parameter returnData: Data returned from the search.
-    public init(correlator: SearchCorrelator? = nil, uid: Bool, returnData: [SearchReturnData]) {
+    public init(correlator: SearchCorrelator? = nil, kind: Kind, returnData: [SearchReturnData]) {
         self.correlator = correlator
-        self.uid = uid
+        self.kind = kind
         self.returnData = returnData
+    }
+}
+
+extension ExtendedSearchResponse {
+    /// The kind of search response.
+    ///
+    /// Describes if the `UnknownMessageIdentifier` in the `returnData`’s `SearchReturnData` are `UID` or `SequenceNumber`.
+    public enum Kind: Hashable {
+        case sequenceNumber
+        case uid
     }
 }
 
@@ -44,7 +54,7 @@ extension EncodeBuffer {
             self.writeIfExists(response.correlator) { (correlator) -> Int in
                 self.writeSearchCorrelator(correlator)
             } +
-            self.write(if: response.uid) {
+            self.write(if: response.kind == .uid) {
                 self.writeString(" UID")
             } +
             self.write(if: response.returnData.count > 0) {

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -460,15 +460,15 @@ extension GrammarParser {
         try PL.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             try PL.parseFixedString("ESEARCH", buffer: &buffer, tracker: tracker)
             let correlator = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: self.parseSearchCorrelator)
-            let uid = try PL.parseOptional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+            let kind: ExtendedSearchResponse.Kind = try PL.parseOptional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
                 try PL.parseFixedString(" UID", buffer: &buffer, tracker: tracker)
-                return true
-            } ?? false
+                return .uid
+            } ?? .sequenceNumber
             let searchReturnData = try PL.parseZeroOrMore(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> SearchReturnData in
                 try PL.parseSpaces(buffer: &buffer, tracker: tracker)
                 return try self.parseSearchReturnData(buffer: &buffer, tracker: tracker)
             }
-            return ExtendedSearchResponse(correlator: correlator, uid: uid, returnData: searchReturnData)
+            return ExtendedSearchResponse(correlator: correlator, kind: kind, returnData: searchReturnData)
         }
     }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxData+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxData+Tests.swift
@@ -31,8 +31,8 @@ extension MailboxDataTests {
                 "LSUB (\\draft) \".\" \"Drafts\"",
                 #line
             ),
-            (.extendedSearch(ExtendedSearchResponse(correlator: nil, uid: false, returnData: [.count(1)])), "ESEARCH COUNT 1", #line),
-            (.extendedSearch(ExtendedSearchResponse(correlator: nil, uid: false, returnData: [.count(1), .count(2)])), "ESEARCH COUNT 1 COUNT 2", #line),
+            (.extendedSearch(ExtendedSearchResponse(correlator: nil, kind: .sequenceNumber, returnData: [.count(1)])), "ESEARCH COUNT 1", #line),
+            (.extendedSearch(ExtendedSearchResponse(correlator: nil, kind: .sequenceNumber, returnData: [.count(1), .count(2)])), "ESEARCH COUNT 1 COUNT 2", #line),
             (.status(.inbox, .init(messageCount: 1)), "STATUS \"INBOX\" (MESSAGES 1)", #line),
             (.status(.inbox, .init(messageCount: 1, unseenCount: 2)), "STATUS \"INBOX\" (MESSAGES 1 UNSEEN 2)", #line),
             (.namespace(.init(userNamespace: [], otherUserNamespace: [], sharedNamespace: [])), "NAMESPACE NIL NIL NIL", #line),

--- a/Tests/NIOIMAPCoreTests/Grammar/Response/ESearchResponse+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Response/ESearchResponse+Tests.swift
@@ -23,10 +23,10 @@ class ExtendedSearchResponse_Tests: EncodeTestClass {}
 extension ExtendedSearchResponse_Tests {
     func testEncode() {
         let inputs: [(ExtendedSearchResponse, String, UInt)] = [
-            (.init(correlator: nil, uid: false, returnData: []), "ESEARCH", #line),
-            (.init(correlator: nil, uid: true, returnData: []), "ESEARCH UID", #line),
-            (.init(correlator: nil, uid: false, returnData: [.count(2)]), "ESEARCH COUNT 2", #line),
-            (.init(correlator: SearchCorrelator(tag: "some"), uid: false, returnData: []), #"ESEARCH (TAG "some")"#, #line),
+            (.init(correlator: nil, kind: .sequenceNumber, returnData: []), "ESEARCH", #line),
+            (.init(correlator: nil, kind: .uid, returnData: []), "ESEARCH UID", #line),
+            (.init(correlator: nil, kind: .sequenceNumber, returnData: [.count(2)]), "ESEARCH COUNT 2", #line),
+            (.init(correlator: SearchCorrelator(tag: "some"), kind: .sequenceNumber, returnData: []), #"ESEARCH (TAG "some")"#, #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Mailbox+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Mailbox+Tests.swift
@@ -32,7 +32,7 @@ extension GrammarParser_Mailbox_Tests {
                     .list(.init(attributes: [.init("\\oflag1"), .init("\\oflag2")], path: try! .init(name: .inbox), extensions: [:])),
                     #line
                 ),
-                ("ESEARCH MIN 1 MAX 2", "\r\n", .extendedSearch(.init(correlator: nil, uid: false, returnData: [.min(1), .max(2)])), #line),
+                ("ESEARCH MIN 1 MAX 2", "\r\n", .extendedSearch(.init(correlator: nil, kind: .sequenceNumber, returnData: [.min(1), .max(2)])), #line),
                 ("1234 EXISTS", "\r\n", .exists(1234), #line),
                 ("5678 RECENT", "\r\n", .recent(5678), #line),
                 ("STATUS INBOX ()", "\r\n", .status(.inbox, .init()), #line),

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -1161,11 +1161,11 @@ extension ParserUnitTests {
         self.iterateTests(
             testFunction: GrammarParser().parseExtendedSearchResponse,
             validInputs: [
-                ("ESEARCH", "\r", .init(correlator: nil, uid: false, returnData: []), #line),
-                ("ESEARCH UID", "\r", .init(correlator: nil, uid: true, returnData: []), #line),
-                ("ESEARCH (TAG \"col\") UID", "\r", .init(correlator: SearchCorrelator(tag: "col"), uid: true, returnData: []), #line),
-                ("ESEARCH (TAG \"col\") UID COUNT 2", "\r", .init(correlator: SearchCorrelator(tag: "col"), uid: true, returnData: [.count(2)]), #line),
-                ("ESEARCH (TAG \"col\") UID MIN 1 MAX 2", "\r", .init(correlator: SearchCorrelator(tag: "col"), uid: true, returnData: [.min(1), .max(2)]), #line),
+                ("ESEARCH", "\r", .init(correlator: nil, kind: .sequenceNumber, returnData: []), #line),
+                ("ESEARCH UID", "\r", .init(correlator: nil, kind: .uid, returnData: []), #line),
+                ("ESEARCH (TAG \"col\") UID", "\r", .init(correlator: SearchCorrelator(tag: "col"), kind: .uid, returnData: []), #line),
+                ("ESEARCH (TAG \"col\") UID COUNT 2", "\r", .init(correlator: SearchCorrelator(tag: "col"), kind: .uid, returnData: [.count(2)]), #line),
+                ("ESEARCH (TAG \"col\") UID MIN 1 MAX 2", "\r", .init(correlator: SearchCorrelator(tag: "col"), kind: .uid, returnData: [.min(1), .max(2)]), #line),
             ],
             parserErrorInputs: [],
             incompleteMessageInputs: []


### PR DESCRIPTION
Change
```swift
public var uid: Bool
```
to
```swift
public var kind: Kind

public enum Kind: Hashable {
    case sequenceNumber
    case uid
}
```