### PR TITLE
Add MessageIdentifierRange convenience

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierRange.swift
@@ -137,6 +137,28 @@ extension MessageIdentifierRange {
     @inlinable public var count: Int {
         range.count
     }
+
+    /// A Boolean value indicating whether the range is empty.
+    @inlinable public var isEmpty: Bool {
+        range.isEmpty
+    }
+
+    /// Returns a copy of this range clamped to the given limiting range.
+    @inlinable public func clamped(to limits: MessageIdentifierRange) -> MessageIdentifierRange {
+        Self(range.clamped(to: limits.range))
+    }
+
+    /// Returns a Boolean value indicating whether this range and the given range
+    /// contain an element in common.
+    @inlinable public func overlaps(_ other: MessageIdentifierRange) -> Bool {
+        range.overlaps(other.range)
+    }
+
+    /// Returns a Boolean value indicating whether the given element is contained
+    /// within the range.
+    @inlinable public func contains(_ element: IdentifierType) -> Bool {
+        range.contains(element)
+    }
 }
 
 // MARK: - Encoding

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDRangeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDRangeTests.swift
@@ -60,7 +60,10 @@ extension UIDRangeTests {
 
 extension UIDRangeTests {
     func testCount() {
+        XCTAssertEqual(MessageIdentifierRange<UID>(654 ... 654).count, 1)
         XCTAssertEqual(MessageIdentifierRange<UID>(654).count, 1)
+        XCTAssertEqual(MessageIdentifierRange<UID>(654 ... 655).count, 2)
+        XCTAssertEqual(MessageIdentifierRange<UID>(UID.min ... UID.max).count, 4_294_967_295)
         XCTAssertEqual(MessageIdentifierRange<UID>(777 ... 999).count, 223)
     }
 
@@ -70,6 +73,62 @@ extension UIDRangeTests {
 
         XCTAssertEqual(MessageIdentifierRange<UID>(777 ... 999).lowerBound, 777)
         XCTAssertEqual(MessageIdentifierRange<UID>(777 ... 999).upperBound, 999)
+    }
+
+    func testIsEmpty() {
+        XCTAssertFalse(MessageIdentifierRange<UID>(654 ... 654).isEmpty)
+        XCTAssertFalse(MessageIdentifierRange<UID>(654).isEmpty)
+        XCTAssertFalse(MessageIdentifierRange<UID>(654 ... 655).isEmpty)
+        XCTAssertFalse(MessageIdentifierRange<UID>(UID.min ... UID.max).isEmpty)
+    }
+
+    func testClamping() {
+        XCTAssertEqual(
+            MessageIdentifierRange<UID>(654 ... 655)
+                .clamped(to: MessageIdentifierRange<UID>(654 ... 655)),
+            MessageIdentifierRange<UID>(654 ... 655)
+        )
+        XCTAssertEqual(
+            MessageIdentifierRange<UID>(654 ... 655)
+                .clamped(to: MessageIdentifierRange<UID>(UID.min ... UID.max)),
+            MessageIdentifierRange<UID>(654 ... 655)
+        )
+        XCTAssertEqual(
+            MessageIdentifierRange<UID>(UID.min ... UID.max)
+                .clamped(to: MessageIdentifierRange<UID>(654 ... 655)),
+            MessageIdentifierRange<UID>(654 ... 655)
+        )
+        XCTAssertEqual(
+            MessageIdentifierRange<UID>(654 ... 655)
+                .clamped(to: MessageIdentifierRange<UID>(100 ... 200)),
+            MessageIdentifierRange<UID>(200)
+        )
+    }
+
+    func testOverlaps() {
+        XCTAssert(MessageIdentifierRange<UID>(654 ... 655)
+            .overlaps(MessageIdentifierRange<UID>(654 ... 655)))
+        XCTAssert(MessageIdentifierRange<UID>(654 ... 655)
+            .overlaps(MessageIdentifierRange<UID>(600 ... 700)))
+        XCTAssert(MessageIdentifierRange<UID>(654 ... 655)
+            .overlaps(MessageIdentifierRange<UID>(600 ... 654)))
+        XCTAssert(MessageIdentifierRange<UID>(600 ... 700)
+            .overlaps(MessageIdentifierRange<UID>(654 ... 655)))
+        XCTAssert(MessageIdentifierRange<UID>(654 ... 655)
+            .overlaps(MessageIdentifierRange<UID>(UID.min ... UID.max)))
+        XCTAssertFalse(MessageIdentifierRange<UID>(100 ... 600)
+            .overlaps(MessageIdentifierRange<UID>(654 ... 655)))
+        XCTAssertFalse(MessageIdentifierRange<UID>(654 ... 655)
+            .overlaps(MessageIdentifierRange<UID>(100 ... 600)))
+    }
+
+    func testContains() {
+        XCTAssert(MessageIdentifierRange<UID>(654 ... 655).contains(654))
+        XCTAssert(MessageIdentifierRange<UID>(654 ... 655).contains(654))
+        XCTAssertFalse(MessageIdentifierRange<UID>(654 ... 655).contains(653))
+        XCTAssertFalse(MessageIdentifierRange<UID>(654 ... 655).contains(656))
+        XCTAssertFalse(MessageIdentifierRange<UID>(654 ... 655).contains(UID.min))
+        XCTAssertFalse(MessageIdentifierRange<UID>(654 ... 655).contains(UID.max))
     }
 }
 


### PR DESCRIPTION
Add `MessageIdentifierRange` convenience

```swift
public var isEmpty: Bool
public func clamped(to limits: MessageIdentifierRange) -> MessageIdentifierRange
public func overlaps(_ other: MessageIdentifierRange) -> Bool
public func contains(_ element: IdentifierType) -> Bool
```