### PR TITLE
Allow non-ASCII values in BODYSTRUCTURE parameters

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Body.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Body.swift
@@ -275,8 +275,8 @@ extension GrammarParser {
             let parsedField = try parseString(buffer: &buffer, tracker: tracker)
             let field = try ParserLibrary.parseBufferAsUTF8(parsedField)
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
-            let parsedValue = try parseString(buffer: &buffer, tracker: tracker)
-            let value = try ParserLibrary.parseBufferAsUTF8(parsedValue)
+            let parsedValue = try parseStringAllowingNonASCII(buffer: &buffer, tracker: tracker)
+            let value = String(bestEffortDecodingUTF8Bytes: parsedValue.readableBytesView)
             return (field, value)
         }
 

--- a/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
+++ b/Sources/NIOIMAPCore/Parser/ParserLibrary.swift
@@ -236,6 +236,18 @@ extension ParserLibrary {
         }
     }
 
+    static func parseFixedByte(_ needle: Character, buffer: inout ParseBuffer, tracker: StackTracker) throws {
+        assert(needle.isASCII)
+        let needleByte = needle.asciiValue!
+        try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
+            let byte = try parseByte(buffer: &buffer, tracker: tracker)
+            guard byte == needleByte
+            else {
+                throw ParserError(hint: "looking for \(needleByte) found \(byte)")
+            }
+        }
+    }
+
     static func parseOneOf<T>(_ subParsers: [SubParser<T>], buffer: inout ParseBuffer, tracker: StackTracker, file: String = (#fileID), line: Int = #line) throws -> T {
         for parser in subParsers {
             do {

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Body+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Body+Tests.swift
@@ -117,6 +117,27 @@ extension GrammarParser_Body_Tests {
         )
     }
 
+    func testParseBodyFieldParam_nonASCII() throws {
+        // This has non-ASCII characters in it:
+        let buffer = ByteBuffer(bytes: [
+            0x28, 0x22, 0x4E, 0x41, 0x4D, 0x45, 0x22, 0x20, 0x22, 0x4E, 0x75, 0x74,
+            0x7A, 0x75, 0x6E, 0x67, 0x73, 0x62, 0x65, 0x64, 0x69, 0x6E, 0x67, 0x75,
+            0x6E, 0x67, 0x65, 0x6E, 0x20, 0x66, 0xC3, 0x83, 0xC2, 0x83, 0xC3, 0x82,
+            0xC2, 0xBC, 0x72, 0x20, 0x4D, 0x65, 0x69, 0x6E, 0x65, 0x20, 0x41, 0x6C,
+            0x6C, 0x69, 0x61, 0x6E, 0x7A, 0x2E, 0x70, 0x64, 0x66, 0x22, 0x29,
+            // Add a space at the end
+            0x20,
+        ])
+        var parseBuffer = ParseBuffer(buffer)
+        let result = try GrammarParser().parseBodyFieldParam(
+            buffer: &parseBuffer,
+            tracker: StackTracker(maximumParserStackDepth: 10)
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(Array(result.keys), ["NAME"])
+        XCTAssertEqual(Array(result.values), ["Nutzungsbedingungen fÃÂ¼r Meine Allianz.pdf"])
+    }
+
     func testParseBodyFieldParam_invalid_oneObject() {
         var buffer = TestUtilities.makeParseBuffer(for: #"("p1" "#)
         XCTAssertThrowsError(try GrammarParser().parseBodyFieldParam(buffer: &buffer, tracker: .testTracker)) { e in


### PR DESCRIPTION
Allow non-ASCII values in BODYSTRUCTURE parameters

### Motivation:

This is not allowed by RFC 3501, but some emails have non-ASCII headers, and some servers
end up copying the non-ASCII values into `BODYSTRUCTURE` parameter fields values, and
we still want to be able to be able to parse the overall `BODYSTRUCTURE`.

### Modifications:

This adds a new `parseStringAllowingNonASCII()` which calls into a new `parseQuotedAllowingNonASCII()`.

This is then used by `parseBodyFieldParam_singlePair()` which now also uses `String(bestEffortDecodingUTF8Bytes:)` to do a best-effort decoding of non-ASCII.

### Result:

We don’t do any sensible character-set decoding when seeing non-ASCII, but the goal is merely to not fail parsing, such that we can still handle these responses, i.e _graceful degradation_ when we parse these otherwise invalid responses.

A more long-term goal _could_ be to return the body structure parameter values as `ByteBuffer` instead of `String` and let the client decide how to turn those into `String`.