### PR TITLE
Fix for stray `+` in response.

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -698,7 +698,12 @@ extension GrammarParser {
     func parseIDResponse(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OrderedDictionary<String, String?> {
         try PL.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
             try PL.parseFixedString("ID ", buffer: &buffer, tracker: tracker)
-            return try parseIDParamsList(buffer: &buffer, tracker: tracker)
+            let result = try parseIDParamsList(buffer: &buffer, tracker: tracker)
+            // datamail.in appends a `+` here for some reason.
+            try PL.parseOptional(buffer: &buffer, tracker: tracker) { (buffer, tracker) in
+                try PL.parseFixedByte("+", buffer: &buffer, tracker: tracker)
+            }
+            return result
         }
     }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/ID/ID+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/ID/ID+Tests.swift
@@ -17,7 +17,7 @@ import NIO
 import OrderedCollections
 import XCTest
 
-class ID_Tests: EncodeTestClass {}
+class ID_Tests: EncodeTestClass, _ParserTestHelpers {}
 
 // MARK: - Encoding
 
@@ -28,5 +28,21 @@ extension ID_Tests {
             (["key": "value"], #"("key" "value")"#, #line),
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeIDParameters($0) })
+    }
+
+    func testParse() {
+        self.iterateTests(
+            testFunction: GrammarParser().parseResponsePayload,
+            validInputs: [
+                (#"ID NIL"#, "\r", .id([:]), #line),
+                (#"ID ("key" NIL)"#, "\r", .id(["key": nil]), #line),
+                (#"ID ("name" "Imap" "version" "1.5")"#, "\r", .id(["name": "Imap", "version": "1.5"]), #line),
+                (#"ID ("name" "Imap" "version" "1.5" "os" "centos" "os-version" "5.5" "support-url" "mailto:admin@xgen.in")"#, "\r", .id(["name": "Imap", "version": "1.5", "os": "centos", "os-version": "5.5", "support-url": "mailto:admin@xgen.in"]), #line),
+                // datamail.in appends a `+` to the ID response:
+                (#"ID ("name" "Imap" "version" "1.5" "os" "centos" "os-version" "5.5" "support-url" "mailto:admin@xgen.in")+"#, "\r", .id(["name": "Imap", "version": "1.5", "os": "centos", "os-version": "5.5", "support-url": "mailto:admin@xgen.in"]), #line),
+            ],
+            parserErrorInputs: [],
+            incompleteMessageInputs: []
+        )
     }
 }


### PR DESCRIPTION
Fix for stray `+` in response.

### Motivation:

`datamail.in` returns
```text
* ID ("name" "Imap" "version" "1.5" "os" "centos" "os-version" "5.5" "support-url" "mailto:admin@xgen.in")+
```
(note the trailing `+`)

### Modifications:

Skip tailing `+` for `ID` response.
