### PR TITLE
Make generic functions that are public inlinable

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Modifier/ModificationSequenceValue.swift
+++ b/Sources/NIOIMAPCore/Grammar/Modifier/ModificationSequenceValue.swift
@@ -33,13 +33,14 @@ public struct ModificationSequenceValue: Hashable {
     /// Creates a `ModificationSequenceValue` from some `BinaryInteger`, ensuring that the given value fits within the valid range `0...Int64.max`.
     /// - parameter source: The raw value to use.
     /// - returns: `nil` if `source` is not within the valid range.
+    @inlinable
     public init?<T>(exactly source: T) where T: BinaryInteger {
         guard
             source >= 0,
             let value = UInt64(exactly: source),
             value <= UInt64(Int64.max)
         else { return nil }
-        self.value = value
+        self.init(value)
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifier.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifier.swift
@@ -32,6 +32,7 @@ extension MessageIdentifier {
     /// Creates a `MessageIdentifier` from some `BinaryInteger`, ensuring that the given value fits within a `UInt32`.
     /// - parameter source: The raw value to use.
     /// - returns: `nil` if `source` does not fit within a `UInt32`, otherwise a `UID`.
+    @inlinable
     public init?<T>(exactly source: T) where T: BinaryInteger {
         guard source > 0, let rawValue = UInt32(exactly: source) else { return nil }
         self.init(rawValue: rawValue)
@@ -116,7 +117,8 @@ extension MessageIdentifier {
 // MARK: - Encoding
 
 extension EncodeBuffer {
-    @discardableResult mutating func writeMessageIdentifier<IdentifierType: MessageIdentifier>(_ id: IdentifierType) -> Int {
+    @discardableResult
+    mutating func writeMessageIdentifier<IdentifierType: MessageIdentifier>(_ id: IdentifierType) -> Int {
         if id == .max {
             return self.writeString("*")
         } else {

--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -30,13 +30,15 @@ public struct MessageIdentifierSet<IdentifierType: MessageIdentifier>: Hashable 
     }
 
     /// A non-empty array of `MessageIdentifier` ranges.
-    fileprivate var _ranges: RangeSet<MessageIdentificationShiftWrapper>
+    @usableFromInline
+    var _ranges: RangeSet<MessageIdentificationShiftWrapper>
 
     fileprivate init(_ ranges: RangeSet<MessageIdentificationShiftWrapper>) {
         self._ranges = ranges
     }
 
     /// Creates a new `MessageIdentifierSet` containing the `MessageIdentifier`s in the given ranges.
+    @inlinable
     public init<S: Sequence>(_ ranges: S) where S.Element == MessageIdentifierRange<IdentifierType> {
         self.init()
         ranges.forEach {
@@ -58,6 +60,7 @@ public struct MessageIdentifierSet<IdentifierType: MessageIdentifier>: Hashable 
 /// UIDs/SequenceNumbers shifted by 1, such that 1 -> 0, and `type`.max -> UInt32.max - 1
 /// This allows us to store `type`.max + 1 inside a UInt32.
 /// This applies for both UIDs and SequenceNumbers.
+@usableFromInline
 struct MessageIdentificationShiftWrapper: Hashable {
     var rawValue: UInt32
 
@@ -72,17 +75,20 @@ struct MessageIdentificationShiftWrapper: Hashable {
 }
 
 extension MessageIdentificationShiftWrapper: Strideable {
+    @usableFromInline
     func distance(to other: MessageIdentificationShiftWrapper) -> Int64 {
         Int64(other.rawValue) - Int64(self.rawValue)
     }
 
+    @usableFromInline
     func advanced(by n: Int64) -> MessageIdentificationShiftWrapper {
         MessageIdentificationShiftWrapper(rawValue: UInt32(Int64(rawValue) + n))
     }
 }
 
 extension Range where Element == MessageIdentificationShiftWrapper {
-    fileprivate init<IdentifierType: MessageIdentifier>(_ r: MessageIdentifierRange<IdentifierType>) {
+    @usableFromInline
+    init<IdentifierType: MessageIdentifier>(_ r: MessageIdentifierRange<IdentifierType>) {
         self = MessageIdentificationShiftWrapper(r.range.lowerBound) ..< MessageIdentificationShiftWrapper(r.range.upperBound).advanced(by: 1)
     }
 

--- a/Sources/NIOIMAPCore/Grammar/UID/UIDValidity.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/UIDValidity.swift
@@ -15,12 +15,14 @@
 /// The unique identifier validity value of a mailbox. Combined with a message UID to form a 64-bit identifier.
 public struct UIDValidity: Hashable {
     /// The underlying raw value.
+    @usableFromInline
     let rawValue: UInt32
 
     /// Creates a `UIDValidity` from some `BinaryInteger` after checking
     /// that the given value fits within a `UInt32`.
     /// - parameter source: Some `BinaryInteger`.
     /// - returns: `nil` if the given value cannot fit within a `UInt32`, otherwise a new `UIDValidity`.
+    @inlinable
     public init?<T>(exactly source: T) where T: BinaryInteger {
         guard source > 0, let rawValue = UInt32(exactly: source) else { return nil }
         self.rawValue = rawValue


### PR DESCRIPTION
Make generic functions that are public inlinable

### Motivation:

Allow for optimizations of client library using these generic functions.

### Modifications:

Added `@inlinable` (and `@usableFromInline`).
