### PR TITLE
Fix parser error with continuation responses

### DIFF
--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -635,6 +635,9 @@ extension ParserUnitTests {
             validInputs: [
                 ("+ OK\r\n", " ", .responseText(.init(code: nil, text: "OK")), #line),
                 ("+ YQ==\r\n", " ", .data("a"), #line),
+                ("+ IDLE accepted, awaiting DONE command.\r\n", " ", .responseText(.init(code: nil, text: "IDLE accepted, awaiting DONE command.")), #line),
+                ("+ \r\n", " ", .responseText(.init(code: nil, text: "")), #line),
+                ("+\r\n", " ", .responseText(.init(code: nil, text: "")), #line),
             ],
             parserErrorInputs: [],
             incompleteMessageInputs: []


### PR DESCRIPTION
When the response text of a continuation response began with base64 characters, the response would be interpreted as base64. Any remaining characters would cause a parser error.

Rework the parser to only interpret the text as base64 if all of the text is base64 characters.

### Motivation:

Valid IMAP response from the server would cause a parser error.
