### PR TITLE
Add SectionSpecifier.Part.isChildPart(of:)

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
+++ b/Sources/NIOIMAPCore/Grammar/SectionSpec.swift
@@ -321,6 +321,16 @@ extension SectionSpecifier.Part {
         else { return false }
         return zip(a, b).allSatisfy { $0.0 == $0.1 }
     }
+
+    /// Returns `true` if the `other` part is a directly below this `Part`, e.g. `2.1` is a child of `2`, and `2` is a child of the top-level part. Returns `false` otherwise.
+    public func isChildPart(of other: SectionSpecifier.Part) -> Bool {
+        guard
+            self.array.count == other.array.count + 1
+        else { return false }
+        let a = Array(self).dropLast(1)
+        let b = Array(other)[...]
+        return b == a
+    }
 }
 
 // MARK: - Encoding

--- a/Tests/NIOIMAPCoreTests/Grammar/Section/SectionSpecTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Section/SectionSpecTests.swift
@@ -179,6 +179,29 @@ extension SectionSpecifierTests {
             XCTAssertEqual(part.isSubPart(of: other), expected, line: line)
         }
     }
+
+    func testIsChildPartOf() {
+        let inputs: [(SectionSpecifier.Part, SectionSpecifier.Part, Bool, UInt)] = [
+            ([], [], false, #line),
+            ([], [1], false, #line),
+            ([], [8], false, #line),
+            ([1], [], true, #line),
+            ([8], [], true, #line),
+            ([2, 3], [2, 3], false, #line),
+            ([2, 3, 1], [2, 3], true, #line),
+            ([2, 3, 1], [4, 3], false, #line),
+            ([2, 3, 1], [2, 7], false, #line),
+            ([2, 3, 1, 4], [2, 3], false, #line),
+            ([2, 3], [2, 3, 1], false, #line),
+            ([2, 3, 1, 7], [2, 3], false, #line),
+            ([2, 3, 1, 7], [2, 3, 1], true, #line),
+            ([2, 4, 1, 7], [2, 3], false, #line),
+            ([5, 3, 1, 7], [2, 3], false, #line),
+        ]
+        inputs.forEach { (part, other, expected, line) in
+            XCTAssertEqual(part.isChildPart(of: other), expected, line: line)
+        }
+    }
 }
 
 // MARK: - CustomDebugStringConvertible


### PR DESCRIPTION
### Motivation:

Add check if a MIME part (specifier) is a (direct) child node of another, e.g. if `2.1` is a child node of `2`.

This is a common operation when working with `SectionSpecifier.Part`.

### Modifications:

Follows the pattern of `isSubPart(of:)`.
