### PR TITLE
2nd part of renaming Partial → ByteRange

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/ByteRange/ByteRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/ByteRange/ByteRange.swift
@@ -34,11 +34,11 @@ public struct ByteRange: Hashable {
 // MARK: - Encoding
 
 extension EncodeBuffer {
-    @discardableResult mutating func writePartial(_ num: ClosedRange<UInt32>) -> Int {
+    @discardableResult mutating func writeByteRange(_ num: ClosedRange<UInt32>) -> Int {
         self.writeString("<\(num.lowerBound).\(num.count)>")
     }
 
-    @discardableResult mutating func writePartialRange(_ data: ByteRange) -> Int {
+    @discardableResult mutating func writeByteRange(_ data: ByteRange) -> Int {
         self.writeString("\(data.offset)") +
             self.writeIfExists(data.length) { length in
                 self.writeString(".\(length)")

--- a/Sources/NIOIMAPCore/Grammar/ByteRange/MessagePathByteRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/ByteRange/MessagePathByteRange.swift
@@ -31,11 +31,11 @@ extension MessagePath {
 extension EncodeBuffer {
     @discardableResult mutating func writeMessagePathByteRange(_ data: MessagePath.ByteRange) -> Int {
         self.writeString("/;PARTIAL=") +
-            self.writePartialRange(data.range)
+            self.writeByteRange(data.range)
     }
 
     @discardableResult mutating func writeMessagePathByteRangeOnly(_ data: MessagePath.ByteRange) -> Int {
         self.writeString(";PARTIAL=") +
-            self.writePartialRange(data.range)
+            self.writeByteRange(data.range)
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/FetchAttribute.swift
@@ -194,7 +194,7 @@ extension EncodeBuffer {
         self.writeString(peek ? "BODY.PEEK" : "BODY") +
             self.writeSection(section) +
             self.writeIfExists(partial) { (partial) -> Int in
-                self.writePartial(partial)
+                self.writeByteRange(partial)
             }
     }
 
@@ -210,7 +210,7 @@ extension EncodeBuffer {
             } +
             self.writeSectionBinary(section) +
             self.writeIfExists(partial) { (partial) -> Int in
-                self.writePartial(partial)
+                self.writeByteRange(partial)
             }
     }
 

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -784,7 +784,7 @@ extension GrammarParser {
     func parseMessagePathByteRangeOnly(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessagePath.ByteRange {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> MessagePath.ByteRange in
             try PL.parseFixedString(";PARTIAL=", buffer: &buffer, tracker: tracker)
-            return .init(range: try self.parsePartialRange(buffer: &buffer, tracker: tracker))
+            return .init(range: try self.parseByteRange(buffer: &buffer, tracker: tracker))
         }
     }
 
@@ -1736,15 +1736,15 @@ extension GrammarParser {
         }
     }
 
-    func parsePartialRange(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteRange {
-        func parsePartialRange_length(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
+    func parseByteRange(buffer: inout ParseBuffer, tracker: StackTracker) throws -> ByteRange {
+        func parseByteRange_length(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Int {
             try PL.parseFixedString(".", buffer: &buffer, tracker: tracker)
             return try self.parseNumber(buffer: &buffer, tracker: tracker)
         }
 
         return try PL.composite(buffer: &buffer, tracker: tracker) { (buffer, tracker) -> ByteRange in
             let offset = try self.parseNumber(buffer: &buffer, tracker: tracker)
-            let length = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: parsePartialRange_length)
+            let length = try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: parseByteRange_length)
             return .init(offset: offset, length: length)
         }
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/ByteRange/ByteRange+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/ByteRange/ByteRange+Tests.swift
@@ -34,7 +34,7 @@ extension ByteRange_Tests {
 
         for (test, expectedString, line) in inputs {
             self.testBuffer.clear()
-            let size = self.testBuffer.writePartial(test)
+            let size = self.testBuffer.writeByteRange(test)
             XCTAssertEqual(size, expectedString.utf8.count, line: line)
             XCTAssertEqual(self.testBufferString, expectedString, line: line)
         }
@@ -45,6 +45,6 @@ extension ByteRange_Tests {
             (.init(offset: 1, length: nil), "1", #line),
             (.init(offset: 1, length: 2), "1.2", #line),
         ]
-        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writePartialRange($0) })
+        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeByteRange($0) })
     }
 }

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -2092,7 +2092,7 @@ extension ParserUnitTests {
 extension ParserUnitTests {
     func testParsePartialRange() {
         self.iterateTests(
-            testFunction: GrammarParser().parsePartialRange,
+            testFunction: GrammarParser().parseByteRange,
             validInputs: [
                 ("1", " ", .init(offset: 1, length: nil), #line),
                 ("1.2", " ", .init(offset: 1, length: 2), #line),


### PR DESCRIPTION
### Motivation:

This is a follow up to #736 — a few more things needed renaming.

The [IMAP Paged SEARCH & FETCH Extension ](https://datatracker.ietf.org/doc/draft-ietf-extra-imap-partial/) is also called “Partial”, and thus renaming the existing `Partial` type(s) would make it less confusing to implement that RFC.
