### PR TITLE
IMAP Paged SEARCH & FETCH Support

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/FetchModifier.swift
+++ b/Sources/NIOIMAPCore/Grammar/FetchModifier.swift
@@ -18,6 +18,9 @@ public enum FetchModifier: Hashable {
     /// metadata items have changed since the given reference point.
     case changedSince(ChangedSinceModifier)
 
+    /// Tells the server to only return FETCH results for messages in the specified range
+    case partial(PartialRange)
+
     /// Implemented as a catch-all to support modifiers defined in future extensions.
     case other(KeyValue<String, ParameterValue?>)
 }
@@ -29,6 +32,8 @@ extension EncodeBuffer {
         switch val {
         case .changedSince(let changedSince):
             return self.writeChangedSinceModifier(changedSince)
+        case .partial(let range):
+            return self.writeString("PARTIAL ") + self.writePartialRange(range)
         case .other(let param):
             return self.writeParameter(param)
         }

--- a/Sources/NIOIMAPCore/Grammar/FetchModifier.swift
+++ b/Sources/NIOIMAPCore/Grammar/FetchModifier.swift
@@ -18,7 +18,9 @@ public enum FetchModifier: Hashable {
     /// metadata items have changed since the given reference point.
     case changedSince(ChangedSinceModifier)
 
-    /// Tells the server to only return FETCH results for messages in the specified range
+    /// Tells the server to only return FETCH results for messages in the specified range.
+    ///
+    /// Part of https://datatracker.ietf.org/doc/draft-ietf-extra-imap-partial/
     case partial(PartialRange)
 
     /// Implemented as a catch-all to support modifiers defined in future extensions.

--- a/Sources/NIOIMAPCore/Grammar/Partial/PartialRange.swift
+++ b/Sources/NIOIMAPCore/Grammar/Partial/PartialRange.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A range for `draft-ietf-extra-imap-partial-04` aka. “Paged SEARCH & FETCH”
+///
+/// Aka. `partial-range`.
+public enum PartialRange: Hashable {
+    /// A range relative to the oldest (lowest UID) message.
+    ///
+    /// Aka. `partial-range-first`.
+    case first(SequenceRange)
+    /// A range relative to the newest (highest UID) message.
+    ///
+    /// This is encoded as negative number.
+    ///
+    /// Aka. `partial-range-last`.
+    case last(SequenceRange)
+}
+
+// MARK: - Encoding
+
+extension EncodeBuffer {
+    @discardableResult mutating func writePartialRange(_ range: PartialRange) -> Int {
+        switch range {
+        case .first(let r):
+            return self.writeSequenceNumberOrWildcard(r.range.lowerBound) +
+                self.writeString(":") +
+                self.writeSequenceNumberOrWildcard(r.range.upperBound)
+        case .last(let r):
+            return self.writeString("-") +
+                self.writeSequenceNumberOrWildcard(r.range.lowerBound) +
+                self.writeString(":-") +
+                self.writeSequenceNumberOrWildcard(r.range.upperBound)
+        }
+    }
+}

--- a/Sources/NIOIMAPCore/Grammar/Partial/SearchReturnData+Partial.swift
+++ b/Sources/NIOIMAPCore/Grammar/Partial/SearchReturnData+Partial.swift
@@ -19,8 +19,6 @@ extension SearchReturnData {
         /// The requested range.
         public var range: PartialRange
         /// The matching messages.
-        ///
-        /// `nil` indicates no results correspond to the requested range.
-        public var messageNumbers: MessageIdentifierSet<UnknownMessageIdentifier>?
+        public var messageNumbers: MessageIdentifierSet<UnknownMessageIdentifier>
     }
 }

--- a/Sources/NIOIMAPCore/Grammar/Partial/SearchReturnData+Partial.swift
+++ b/Sources/NIOIMAPCore/Grammar/Partial/SearchReturnData+Partial.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct NIO.ByteBuffer
+
+extension SearchReturnData {
+    public struct Partial: Hashable {
+        /// The requested range.
+        public var range: PartialRange
+        /// The matching messages.
+        ///
+        /// `nil` indicates no results correspond to the requested range.
+        public var messageNumbers: MessageIdentifierSet<UnknownMessageIdentifier>?
+    }
+}

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchReturnData.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchReturnData.swift
@@ -33,6 +33,8 @@ public enum SearchReturnData: Hashable {
 
     /// The message numbers/UIDs that satisfy the SEARCH criteria for a
     /// partial (paged) search.
+    ///
+    /// Part of https://datatracker.ietf.org/doc/draft-ietf-extra-imap-partial/
     case partial(PartialRange, MessageIdentifierSet<UnknownMessageIdentifier>)
 
     /// Implemented as a catch-all to support any return data options defined in future extensions.

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchReturnOption.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchReturnOption.swift
@@ -32,6 +32,9 @@ public enum SearchReturnOption: Hashable {
     /// SEARCH, e.g., SORT and THREAD [SORT]) and store it
     case save
 
+    /// Request a subset of the results.
+    case partial(PartialRange)
+
     /// Implemented as a catch-all to support future extensions.
     case optionExtension(KeyValue<String, ParameterValue?>)
 }
@@ -51,6 +54,8 @@ extension EncodeBuffer {
             return self.writeString("COUNT")
         case .save:
             return self.writeString("SAVE")
+        case .partial(let range):
+            return self.writeString("PARTIAL ") + self.writePartialRange(range)
         case .optionExtension(let option):
             return self.writeSearchReturnOptionExtension(option)
         }

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchReturnOption.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchReturnOption.swift
@@ -33,6 +33,8 @@ public enum SearchReturnOption: Hashable {
     case save
 
     /// Request a subset of the results.
+    ///
+    /// Part of https://datatracker.ietf.org/doc/draft-ietf-extra-imap-partial/
     case partial(PartialRange)
 
     /// Implemented as a catch-all to support future extensions.

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
@@ -206,12 +206,19 @@ extension GrammarParser {
             .changedSince(try self.parseChangedSinceModifier(buffer: &buffer, tracker: tracker))
         }
 
+        func parseFetchModifier_partial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchModifier {
+            try PL.parseFixedString("PARTIAL", buffer: &buffer, tracker: tracker)
+            try PL.parseSpaces(buffer: &buffer, tracker: tracker)
+            return .partial(try self.parsePartialRange(buffer: &buffer, tracker: tracker))
+        }
+
         func parseFetchModifier_other(buffer: inout ParseBuffer, tracker: StackTracker) throws -> FetchModifier {
             .other(try self.parseParameter(buffer: &buffer, tracker: tracker))
         }
 
         return try PL.parseOneOf(
             parseFetchModifier_changedSince,
+            parseFetchModifier_partial,
             parseFetchModifier_other,
             buffer: &buffer,
             tracker: tracker

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Partial.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Partial.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+let badOS = { fatalError("unsupported OS") }()
+#endif
+
+import struct NIO.ByteBuffer
+import struct NIO.ByteBufferView
+
+extension GrammarParser {
+    /// ```
+    /// partial-range       = partial-range-first / partial-range-last
+    /// partial-range-first = nz-number ":" nz-number
+    ///     ;; Request to search from oldest (lowest UIDs) to
+    ///     ;; more recent messages.
+    ///     ;; A range 500:400 is the same as 400:500.
+    ///     ;; This is similar to <seq-range> from [RFC3501],
+    ///     ;; but cannot contain "*".
+    ///
+    /// partial-range-last  = MINUS nz-number ":" MINUS nz-number
+    ///     ;; Request to search from newest (highest UIDs) to
+    ///     ;; oldest messages.
+    ///     ;; A range -500:-400 is the same as -400:-500.
+    /// ```
+    func parsePartialRange(buffer: inout ParseBuffer, tracker: StackTracker) throws -> PartialRange {
+        func parseFirst(buffer: inout ParseBuffer, tracker: StackTracker) throws -> PartialRange {
+            let a: SequenceNumber = try parseMessageIdentifier(buffer: &buffer, tracker: tracker)
+            try PL.parseFixedString(":", buffer: &buffer, tracker: tracker)
+            let b: SequenceNumber = try parseMessageIdentifier(buffer: &buffer, tracker: tracker)
+            let range = (a <= b) ? SequenceRange(a ... b) : SequenceRange(b ... a)
+            return .first(range)
+        }
+
+        func parseLast(buffer: inout ParseBuffer, tracker: StackTracker) throws -> PartialRange {
+            try PL.parseFixedString("-", buffer: &buffer, tracker: tracker)
+            let a: SequenceNumber = try parseMessageIdentifier(buffer: &buffer, tracker: tracker)
+            try PL.parseFixedString(":-", buffer: &buffer, tracker: tracker)
+            let b: SequenceNumber = try parseMessageIdentifier(buffer: &buffer, tracker: tracker)
+            let range = (a <= b) ? SequenceRange(a ... b) : SequenceRange(b ... a)
+            return .last(range)
+        }
+
+        return try PL.parseOneOf(
+            parseFirst,
+            parseLast,
+            buffer: &buffer,
+            tracker: tracker
+        )
+    }
+
+    /// ```
+    /// ret-data-partial    = "PARTIAL"
+    ///                       SP "(" partial-range SP partial-results ")"
+    ///     ;; <partial-range> is the requested range.
+    ///
+    /// partial-results     = sequence-set / "NIL"
+    ///     ;; <sequence-set> from [RFC3501].
+    ///     ;; NIL indicates no results correspond to the requested range.
+    /// ```
+    func parseSearchReturnData_partial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
+        func parseSearchReturnData_partial_nil(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierSet<UnknownMessageIdentifier> {
+            try PL.parseFixedString("NIL", buffer: &buffer, tracker: tracker)
+            return MessageIdentifierSet()
+        }
+        func parseSearchReturnData_partial_set(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierSet<UnknownMessageIdentifier> {
+            let set: LastCommandSet<MessageIdentifierSet<UnknownMessageIdentifier>>
+            set = try parseMessageIdentifierSet(buffer: &buffer, tracker: tracker)
+            guard case .set(let result) = set else {
+                throw ParserError(hint: "PARTIAL set invalid")
+            }
+            return result
+        }
+
+        try PL.parseFixedString("PARTIAL", buffer: &buffer, tracker: tracker)
+        try PL.parseSpaces(buffer: &buffer, tracker: tracker)
+        try PL.parseFixedString("(", buffer: &buffer, tracker: tracker)
+        let range = try parsePartialRange(buffer: &buffer, tracker: tracker)
+        try PL.parseSpaces(buffer: &buffer, tracker: tracker)
+        let set = try PL.parseOneOf(
+            parseSearchReturnData_partial_nil,
+            parseSearchReturnData_partial_set,
+            buffer: &buffer,
+            tracker: tracker
+        )
+        try PL.parseFixedString(")", buffer: &buffer, tracker: tracker)
+
+        return .partial(range, set)
+    }
+}

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
@@ -394,6 +394,7 @@ extension GrammarParser {
     //                     "MAX" SP nz-number /
     //                     "ALL" SP sequence-set /
     //                     "COUNT" SP number /
+    //                     "PARTIAL" SP "(" partial-range SP partial-results ")"
     //                     search-ret-data-ext
     func parseSearchReturnData(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
         func parseSearchReturnData_min(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnData {
@@ -454,6 +455,7 @@ extension GrammarParser {
 
     // search-return-opt  = "MIN" / "MAX" / "ALL" / "COUNT" /
     //                      "SAVE" /
+    //                      "PARTIAL" SP partial-range
     //                      search-ret-opt-ext
     func parseSearchReturnOption(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
         func parseSearchReturnOption_min(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
@@ -481,6 +483,13 @@ extension GrammarParser {
             return .save
         }
 
+        func parseSearchReturnOption_partial(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
+            try PL.parseFixedString("PARTIAL", buffer: &buffer, tracker: tracker)
+            try PL.parseSpaces(buffer: &buffer, tracker: tracker)
+            let range = try parsePartialRange(buffer: &buffer, tracker: tracker)
+            return .partial(range)
+        }
+
         func parseSearchReturnOption_extension(buffer: inout ParseBuffer, tracker: StackTracker) throws -> SearchReturnOption {
             let optionExtension = try self.parseSearchReturnOptionExtension(buffer: &buffer, tracker: tracker)
             return .optionExtension(optionExtension)
@@ -492,6 +501,7 @@ extension GrammarParser {
             parseSearchReturnOption_all,
             parseSearchReturnOption_count,
             parseSearchReturnOption_save,
+            parseSearchReturnOption_partial,
             parseSearchReturnOption_extension,
         ], buffer: &buffer, tracker: tracker)
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/FetchModifier+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/FetchModifier+Tests.swift
@@ -24,6 +24,7 @@ extension FetchModifier_Tests {
     func testEncode() {
         let inputs: [(FetchModifier, String, UInt)] = [
             (.changedSince(.init(modificationSequence: 4)), "CHANGEDSINCE 4", #line),
+            (.partial(.last(735 ... 88_032)), "PARTIAL -735:-88032", #line),
             (.other(.init(key: "test", value: nil)), "test", #line),
             (.other(.init(key: "test", value: .sequence(.set([4])))), "test 4", #line),
         ]
@@ -32,7 +33,8 @@ extension FetchModifier_Tests {
 
     func testEncodeArray() {
         let inputs: [([FetchModifier], String, UInt)] = [
-            ([.changedSince(.init(modificationSequence: 3665089505007763456))], " (CHANGEDSINCE 3665089505007763456)", #line),
+            ([.partial(.last(1 ... 30)), .changedSince(.init(modificationSequence: 3665089505007763456))], " (PARTIAL -1:-30 CHANGEDSINCE 3665089505007763456)", #line),
+            ([.changedSince(.init(modificationSequence: 98305))], " (CHANGEDSINCE 98305)", #line),
             ([.other(.init(key: "test", value: nil)), .other(.init(key: "test", value: .sequence(.set([4]))))], " (test test 4)", #line),
             ([], "", #line),
         ]

--- a/Tests/NIOIMAPCoreTests/Grammar/Partial/PartialRange+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Partial/PartialRange+Tests.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+@_spi(NIOIMAPInternal) @testable import NIOIMAPCore
+import XCTest
+
+class PartialRange_Tests: EncodeTestClass, _ParserTestHelpers {}
+
+// MARK: - Encoding
+
+extension PartialRange_Tests {
+    func testEncode() {
+        let inputs: [(PartialRange, String, UInt)] = [
+            (.first(1 ... 1), "1:1", #line),
+            (.first(100 ... 200), "100:200", #line),
+            (.last(1 ... 1), "-1:-1", #line),
+            (.last(100 ... 200), "-100:-200", #line),
+        ]
+        self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writePartialRange($0) })
+    }
+
+    func testParse() {
+        self.iterateTests(
+            testFunction: GrammarParser().parsePartialRange,
+            validInputs: [
+                ("1:2", " ", .first(1 ... 2), #line),
+                ("1:1", " ", .first(1 ... 1), #line),
+                ("100:200", " ", .first(100 ... 200), #line),
+                ("200:100", " ", .first(100 ... 200), #line),
+                ("333:333", " ", .first(333 ... 333), #line),
+                ("1234567:2345678", " ", .first(1234567 ... 2345678), #line),
+                ("-1:-2", " ", .last(1 ... 2), #line),
+                ("-1:-1", " ", .last(1 ... 1), #line),
+                ("-100:-200", " ", .last(100 ... 200), #line),
+                ("-200:-100", " ", .last(100 ... 200), #line),
+                ("-333:-333", " ", .last(333 ... 333), #line),
+                ("-1234567:-2345678", " ", .last(1234567 ... 2345678), #line),
+            ],
+            parserErrorInputs: [
+                ("1", " ", #line),
+                ("1:", " ", #line),
+                ("10:-20", " ", #line),
+                ("-10:20", " ", #line),
+                ("1:*", " ", #line),
+                ("*", " ", #line),
+                ("a", " ", #line),
+            ],
+            incompleteMessageInputs: [
+                ("1", "", #line),
+                ("1:", "", #line),
+                ("1:2", "", #line),
+            ]
+        )
+    }
+}

--- a/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnData+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnData+Tests.swift
@@ -28,6 +28,8 @@ extension SearchReturnData_Tests {
             (.all(LastCommandSet.set(MessageIdentifierSet<UnknownMessageIdentifier>(1 ... 3))), "ALL 1:3", #line),
             (.count(1), "COUNT 1", #line),
             (.modificationSequence(1), "MODSEQ 1", #line),
+            (.partial(.first(23_500 ... 24_000), [67, 100 ... 102]), "PARTIAL (23500:24000 67,100:102)", #line),
+            (.partial(.last(55 ... 700), []), "PARTIAL (-55:-700 NIL)", #line),
             (.dataExtension(.init(key: "modifier", value: .sequence(.set([3])))), "modifier 3", #line),
         ]
         self.iterateInputs(inputs: inputs, encoder: { self.testBuffer.writeSearchReturnData($0) })

--- a/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnOption+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnOption+Tests.swift
@@ -29,6 +29,8 @@ extension SearchReturnOption_Tests {
             (.count, "COUNT", #line),
             (.save, "SAVE", #line),
             (.optionExtension(.init(key: "modifier", value: nil)), "modifier", #line),
+            (.partial(.first(23_500 ... 24_000)), "PARTIAL 23500:24000", #line),
+            (.partial(.last(1 ... 100)), "PARTIAL -1:-100", #line),
         ]
 
         for (test, expectedString, line) in inputs {
@@ -46,6 +48,7 @@ extension SearchReturnOption_Tests {
             ([.all], " RETURN ()", #line),
             ([.min, .all], " RETURN (MIN ALL)", #line),
             ([.min, .max, .count], " RETURN (MIN MAX COUNT)", #line),
+            ([.min, .partial(.last(400 ... 1_000))], " RETURN (MIN PARTIAL -400:-1000)", #line),
         ]
 
         for (test, expectedString, line) in inputs {

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Fetch+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Fetch+Tests.swift
@@ -99,6 +99,7 @@ extension GrammarParser_Fetch_Tests {
             testFunction: GrammarParser().parseFetchModifier,
             validInputs: [
                 ("CHANGEDSINCE 2", " ", .changedSince(.init(modificationSequence: 2)), #line),
+                ("PARTIAL -735:-88032", " ", .partial(.last(735 ... 88_032)), #line),
                 ("test", "\r", .other(.init(key: "test", value: nil)), #line),
                 ("test 1", " ", .other(.init(key: "test", value: .sequence(.set([1])))), #line),
             ],
@@ -109,6 +110,19 @@ extension GrammarParser_Fetch_Tests {
                 ("CHANGEDSINCE 1", "", #line),
                 ("test 1", "", #line),
             ]
+        )
+    }
+
+    func testParseFetchModifiers() {
+        self.iterateTests(
+            testFunction: GrammarParser().parseFetchModifiers,
+            validInputs: [
+                (" (CHANGEDSINCE 2)", " ", [.changedSince(.init(modificationSequence: 2))], #line),
+                (" (PARTIAL -735:-88032)", " ", [.partial(.last(735 ... 88_032))], #line),
+                (" (PARTIAL -1:-30 CHANGEDSINCE 98305)", " ", [.partial(.last(1 ... 30)), .changedSince(.init(modificationSequence: 98305))], #line),
+            ],
+            parserErrorInputs: [],
+            incompleteMessageInputs: []
         )
     }
 }

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Search+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Search+Tests.swift
@@ -210,6 +210,22 @@ extension GrammarParser_Search_Tests {
     }
 }
 
+// MARK: - `ret-data-partial` parseSearchReturnData_partial
+
+extension GrammarParser_Search_Tests {
+    func testParseSearchReturnDataPartial() {
+        self.iterateTests(
+            testFunction: GrammarParser().parseSearchReturnData_partial,
+            validInputs: [
+                ("PARTIAL (23500:24000 67,100:102)", "\r", .partial(.first(23_500 ... 24_000), [67, 100 ... 102]), #line),
+                ("PARTIAL (-55:-700 NIL)", "\r", .partial(.last(55 ... 700), []), #line),
+            ],
+            parserErrorInputs: [],
+            incompleteMessageInputs: []
+        )
+    }
+}
+
 // MARK: - `search-ret-opt` parseSearchReturnOption
 
 extension GrammarParser_Search_Tests {
@@ -232,6 +248,8 @@ extension GrammarParser_Search_Tests {
                 ("SAVE", "\r", .save, #line),
                 ("save", "\r", .save, #line),
                 ("saVE", "\r", .save, #line),
+                ("PARTIAL 23500:24000", "\r", .partial(.first(23_500 ... 24_000)), #line),
+                ("partial -1:-100", "\r", .partial(.last(1 ... 100)), #line),
                 ("modifier", "\r", .optionExtension(.init(key: "modifier", value: nil)), #line),
             ],
             parserErrorInputs: [],
@@ -253,6 +271,8 @@ extension GrammarParser_Search_Tests {
                     .optionExtension(.init(key: "m1", value: nil)),
                     .optionExtension(.init(key: "m2", value: nil)),
                 ], #line),
+                (" RETURN (PARTIAL 23500:24000)", "\r", [.partial(.first(23_500 ... 24_000))], #line),
+                (" RETURN (MIN PARTIAL -1:-100 MAX)", "\r", [.min, .partial(.last(1 ... 100)), .max], #line),
             ],
             parserErrorInputs: [],
             incompleteMessageInputs: []

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
+    sed -e 's/20[12][7890123]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
IMAP Paged SEARCH & FETCH Support

### Motivation:

This adds support for the [IMAP Paged SEARCH & FETCH Extension ](https://datatracker.ietf.org/doc/draft-ietf-extra-imap-partial/) — also called “Partial”.

This extension allows clients to limit the number of SEARCH results or FETCH results returned by the server.

### Modifications:

Add support for encoding & parsing for

1. `PARTIAL` as part of a `SEARCH` command, e.g.
```
A02 UID SEARCH RETURN (PARTIAL 23500:24000) UNDELETED
```

2. `PARTIAL` as part of the response to a `SEARCH` command, e.g.
```
* ESEARCH (TAG "A02") UID PARTIAL (-1:-4 67,100:102)
```

3. `PARTIAL` as of a `FETCH`, e.g.
```
A101 UID FETCH 25900:26600 (UID FLAGS) (PARTIAL -1:-30 CHANGEDSINCE 98305)
```
