### PR TITLE
Fix envelope multiple addresses parsing

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
@@ -80,6 +80,7 @@ extension GrammarParser {
     //                   addr-host ")"
     func parseEmailAddress(buffer: inout ParseBuffer, tracker: StackTracker) throws -> EmailAddress {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> EmailAddress in
+            try PL.parseOptional(buffer: &buffer, tracker: tracker, parser: PL.parseSpaces)
             try PL.parseFixedString("(", buffer: &buffer, tracker: tracker)
             let name = try self.parseNString(buffer: &buffer, tracker: tracker)
             try PL.parseFixedString(" ", buffer: &buffer, tracker: tracker)

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
@@ -153,7 +153,7 @@ extension GrammarParser_Envelope_Tests {
 
 extension GrammarParser_Envelope_Tests {
     func testParseEnvelopeTo_valid() {
-        TestUtilities.withParseBuffer(#"("date" "subject" (("name1" "adl1" "mailbox1" "host1")) (("name2" "adl2" "mailbox2" "host2")) (("name3" "adl3" "mailbox3" "host3")) (("name4" "adl4" "mailbox4" "host4")("name5" "adl5" "mailbox5" "host5")) (("name6" "adl6" "mailbox6" "host6")("name7" "adl7" "mailbox7" "host7")) (("name8" "adl8" "mailbox8" "host8")) "someone" "messageid")"#) { (buffer) in
+        TestUtilities.withParseBuffer(#"("date" "subject" (("name1" "adl1" "mailbox1" "host1")) (("name2" "adl2" "mailbox2" "host2")) (("name3" "adl3" "mailbox3" "host3")) (("name4" "adl4" "mailbox4" "host4") ("name5" "adl5" "mailbox5" "host5")) (("name6" "adl6" "mailbox6" "host6")("name7" "adl7" "mailbox7" "host7")) (("name8" "adl8" "mailbox8" "host8")) "someone" "messageid")"#) { (buffer) in
             let envelope = try GrammarParser().parseEnvelope(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(envelope.date, "date")
             XCTAssertEqual(envelope.subject, "subject")

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
@@ -153,16 +153,22 @@ extension GrammarParser_Envelope_Tests {
 
 extension GrammarParser_Envelope_Tests {
     func testParseEnvelopeTo_valid() {
-        TestUtilities.withParseBuffer(#"("date" "subject" (("name1" "adl1" "mailbox1" "host1")) (("name2" "adl2" "mailbox2" "host2")) (("name3" "adl3" "mailbox3" "host3")) (("name4" "adl4" "mailbox4" "host4")) (("name5" "adl5" "mailbox5" "host5")) (("name6" "adl6" "mailbox6" "host6")) "someone" "messageid")"#) { (buffer) in
+        TestUtilities.withParseBuffer(#"("date" "subject" (("name1" "adl1" "mailbox1" "host1")) (("name2" "adl2" "mailbox2" "host2")) (("name3" "adl3" "mailbox3" "host3")) (("name4" "adl4" "mailbox4" "host4")("name5" "adl5" "mailbox5" "host5")) (("name6" "adl6" "mailbox6" "host6")("name7" "adl7" "mailbox7" "host7")) (("name8" "adl8" "mailbox8" "host8")) "someone" "messageid")"#) { (buffer) in
             let envelope = try GrammarParser().parseEnvelope(buffer: &buffer, tracker: .testTracker)
             XCTAssertEqual(envelope.date, "date")
             XCTAssertEqual(envelope.subject, "subject")
             XCTAssertEqual(envelope.from, [.singleAddress(.init(personName: "name1", sourceRoot: "adl1", mailbox: "mailbox1", host: "host1"))])
             XCTAssertEqual(envelope.sender, [.singleAddress(.init(personName: "name2", sourceRoot: "adl2", mailbox: "mailbox2", host: "host2"))])
             XCTAssertEqual(envelope.reply, [.singleAddress(.init(personName: "name3", sourceRoot: "adl3", mailbox: "mailbox3", host: "host3"))])
-            XCTAssertEqual(envelope.to, [.singleAddress(.init(personName: "name4", sourceRoot: "adl4", mailbox: "mailbox4", host: "host4"))])
-            XCTAssertEqual(envelope.cc, [.singleAddress(.init(personName: "name5", sourceRoot: "adl5", mailbox: "mailbox5", host: "host5"))])
-            XCTAssertEqual(envelope.bcc, [.singleAddress(.init(personName: "name6", sourceRoot: "adl6", mailbox: "mailbox6", host: "host6"))])
+            XCTAssertEqual(envelope.to, [
+                .singleAddress(.init(personName: "name4", sourceRoot: "adl4", mailbox: "mailbox4", host: "host4")),
+                .singleAddress(.init(personName: "name5", sourceRoot: "adl5", mailbox: "mailbox5", host: "host5"))
+            ])
+            XCTAssertEqual(envelope.cc, [
+                .singleAddress(.init(personName: "name6", sourceRoot: "adl6", mailbox: "mailbox6", host: "host6")),
+                .singleAddress(.init(personName: "name7", sourceRoot: "adl7", mailbox: "mailbox7", host: "host7"))
+            ])
+            XCTAssertEqual(envelope.bcc, [.singleAddress(.init(personName: "name8", sourceRoot: "adl8", mailbox: "mailbox8", host: "host8"))])
             XCTAssertEqual(envelope.inReplyTo, "someone")
             XCTAssertEqual(envelope.messageID, "messageid")
         }

--- a/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/Grammar/GrammarParser+Envelope+Tests.swift
@@ -162,11 +162,11 @@ extension GrammarParser_Envelope_Tests {
             XCTAssertEqual(envelope.reply, [.singleAddress(.init(personName: "name3", sourceRoot: "adl3", mailbox: "mailbox3", host: "host3"))])
             XCTAssertEqual(envelope.to, [
                 .singleAddress(.init(personName: "name4", sourceRoot: "adl4", mailbox: "mailbox4", host: "host4")),
-                .singleAddress(.init(personName: "name5", sourceRoot: "adl5", mailbox: "mailbox5", host: "host5"))
+                .singleAddress(.init(personName: "name5", sourceRoot: "adl5", mailbox: "mailbox5", host: "host5")),
             ])
             XCTAssertEqual(envelope.cc, [
                 .singleAddress(.init(personName: "name6", sourceRoot: "adl6", mailbox: "mailbox6", host: "host6")),
-                .singleAddress(.init(personName: "name7", sourceRoot: "adl7", mailbox: "mailbox7", host: "host7"))
+                .singleAddress(.init(personName: "name7", sourceRoot: "adl7", mailbox: "mailbox7", host: "host7")),
             ])
             XCTAssertEqual(envelope.bcc, [.singleAddress(.init(personName: "name8", sourceRoot: "adl8", mailbox: "mailbox8", host: "host8"))])
             XCTAssertEqual(envelope.inReplyTo, "someone")


### PR DESCRIPTION
Fix envelope parsing for multi-address fields in IMAP

### Motivation:

The current implementation of the envelope parsing logic fails to correctly handle multiple addresses in fields like FROM, TO, CC, and BCC. This is due to the parser not accounting for potential spaces between addresses, leading to failures when encountering envelope fields with more than one address.

### Modifications:

- Updated the email address parsing logic to correctly handle spaces between addresses in multi-address scenarios.
- Updated unit test to cover scenarios with multiple addresses in envelope fields.

### Result:

After this change, envelope fields containing multiple addresses, such as the TO, FROM, CC, and BCC fields, are correctly parsed, regardless of the spacing between addresses.
