### PR TITLE
Fix response parsing when response starts with a newline

### DIFF
--- a/Sources/NIOIMAPCore/Parser/ResponseParser.swift
+++ b/Sources/NIOIMAPCore/Parser/ResponseParser.swift
@@ -130,6 +130,8 @@ extension ResponseParser {
 
         return try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
             try? PL.parseSpaces(buffer: &buffer, tracker: tracker)
+            try? PL.parseNewline(buffer: &buffer, tracker: tracker)
+            
             do {
                 let response = try PL.parseOneOf(
                     parseResponse_fetch, parseResponse_normal,

--- a/Tests/NIOIMAPCoreTests/Parser/ResponseParser+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/ResponseParser+Tests.swift
@@ -251,6 +251,15 @@ extension ResponseParser_Tests {
         }
     }
 
+    func testResponseStartingWithNewline() {
+        var parser = ResponseParser()
+        var buffer: ByteBuffer = "\n* 145 FETCH (UID 12024 INTERNALDATE \"07-Feb-2024 12:42:19 +0000\")"
+
+        XCTAssertEqual(try parser.parseResponseStream(buffer: &buffer), .response(.fetch(.start(145))))
+        XCTAssertEqual(try parser.parseResponseStream(buffer: &buffer), .response(.fetch(.simpleAttribute(.uid(12024)))))
+        XCTAssertEqual(try parser.parseResponseStream(buffer: &buffer), .response(.fetch(.simpleAttribute(.internalDate(.init(.init(year: 2024, month: 2, day: 7, hour: 12, minute: 42, second: 19, timeZoneMinutes: 0)!))))))
+    }
+    
     func testAttributeLimit_failOnStreaming() {
         var parser = ResponseParser(bufferLimit: 1000, messageAttributeLimit: 3)
         var buffer: ByteBuffer = "* 999 FETCH (FLAGS (\\Seen) UID 1 RFC822.SIZE 123 RFC822.TEXT {3}\r\n "

--- a/Tests/NIOIMAPCoreTests/ResponseStreamingTests.swift
+++ b/Tests/NIOIMAPCoreTests/ResponseStreamingTests.swift
@@ -170,4 +170,15 @@ extension ResponseStreamingTests {
             (.fetch(.finish), #line),
         ])
     }
+    
+    func testStreamingStartingWithNewline() {
+        self.AssertFetchResponses("\n* 1 FETCH (BODY[TEXT]<4> {3}\r\nabc FLAGS (\\seen \\answered))\r\n", [
+            (.fetch(.start(1)), #line),
+            (.fetch(.streamingBegin(kind: .body(section: .text, offset: 4), byteCount: 3)), #line),
+            (.fetch(.streamingBytes("abc")), #line),
+            (.fetch(.streamingEnd), #line),
+            (.fetch(.simpleAttribute(.flags([.seen, .answered]))), #line),
+            (.fetch(.finish), #line),
+        ])
+    }
 }


### PR DESCRIPTION
Fix IMAP response parsing when responses are received in fragments.

### Motivation:

The application I'm developing uses NWConnection to communicate with an IMAP server. Occasionally, the server (or NWConnection?) may split the IMAP response into fragments, even when `maximumLength` is set to a high value in the `nwConnection.receive` method, making such fragmentation unnecessary. In these cases, subsequent parts of the response might begin with a new line, causing parsing issues. For example:

First part:
```
* 142 FETCH (UID 12001 INTERNALDATE "03-Feb-2024 10:37:09 +0000")
* 143 FETCH (UID 12022 INTERNALDATE "07-Feb-2024 06:25:44 +0000")
```

Second and final part:
```

* 144 FETCH (UID 12023 INTERNALDATE "07-Feb-2024 10:27:28 +0000")
* 145 FETCH (UID 12024 INTERNALDATE "07-Feb-2024 12:42:19 +0000")
* 146 FETCH (UID 12025 INTERNALDATE "07-Feb-2024 14:17:31 +0000")
TAG4 OK Success
```

While the first part is parsed correctly, the second part results in a parsing error. To address this issue, I have implemented optional parsing for a newline at the beginning of the response.

### Modifications:

- Enhanced the IMAP response parser to optionally ignore a leading newline character when processing fragmented responses. This change ensures that each fragment is correctly parsed as part of the continuous response, regardless of how NWConnection or the server decides to fragment the data.
- Added unit tests that simulate receiving fragmented responses, including cases where fragments start with a newline character.

### Result:

After this change, the application can correctly parse IMAP responses received in fragments, even when a fragment starts with a newline. This improvement prevents parsing errors in fragmented response scenarios, ensuring reliable communication with the IMAP server and enhancing the application's resilience to varying network behaviours.
