### PR TITLE
Include actual and limit values in errors

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -20,7 +20,15 @@ import Glibc
 let badOS = { fatalError("unsupported OS") }()
 #endif
 
-public struct ExceededLiteralSizeLimitError: Error {}
+public struct ExceededLiteralSizeLimitError: Error {
+    public var actualCount: Int
+    public var maximumCount: Int
+
+    public init(actualCount: Int, maximumCount: Int) {
+        self.actualCount = actualCount
+        self.maximumCount = maximumCount
+    }
+}
 
 import struct NIO.ByteBuffer
 import struct OrderedCollections.OrderedDictionary
@@ -1293,7 +1301,10 @@ extension GrammarParser {
     func parseLiteralLength(buffer: inout ParseBuffer, tracker: StackTracker, maxLength: Int) throws -> Int {
         let length = try self.parseNumber(buffer: &buffer, tracker: tracker)
         guard length <= maxLength else {
-            throw ExceededLiteralSizeLimitError()
+            throw ExceededLiteralSizeLimitError(
+                actualCount: length,
+                maximumCount: maxLength
+            )
         }
         return length
     }

--- a/Sources/NIOIMAPCore/Parser/ResponseParser.swift
+++ b/Sources/NIOIMAPCore/Parser/ResponseParser.swift
@@ -15,11 +15,23 @@
 import struct NIO.ByteBuffer
 
 public struct ExceededMaximumMessageAttributesError: Error {
-    public init() {}
+    public var actualCount: Int
+    public var maximumCount: Int
+
+    public init(actualCount: Int, maximumCount: Int) {
+        self.actualCount = actualCount
+        self.maximumCount = maximumCount
+    }
 }
 
 public struct ExceededMaximumBodySizeError: Error {
-    public init() {}
+    public var actualCount: UInt64
+    public var maximumCount: UInt64
+
+    public init(actualCount: UInt64, maximumCount: UInt64) {
+        self.actualCount = actualCount
+        self.maximumCount = maximumCount
+    }
 }
 
 /// A parser to be used by Clients in order to parse responses sent from a server.
@@ -177,14 +189,20 @@ extension ResponseParser {
             preconditionFailure("We should be in fetch middle: \(self.mode)")
         }
         guard attributeCount < self.messageAttributeLimit else {
-            throw ExceededMaximumMessageAttributesError()
+            throw ExceededMaximumMessageAttributesError(
+                actualCount: attributeCount,
+                maximumCount: self.messageAttributeLimit
+            )
         }
         return attributeCount
     }
 
     private func guardStreamingSizeLimit(size: Int) throws {
         guard size < self.bodySizeLimit else {
-            throw ExceededMaximumBodySizeError()
+            throw ExceededMaximumBodySizeError(
+                actualCount: UInt64(exactly: size) ?? 0,
+                maximumCount: self.bodySizeLimit
+            )
         }
     }
 


### PR DESCRIPTION
When hitting a limit and throwing an error, include the limited and maximum value.

### Modifications:

`ExceededLiteralSizeLimitError`,
`ExceededMaximumMessageAttributesError`, and
`ExceededMaximumBodySizeError` now include _actual_ and _maximum_ values.

This makes it easier to reason about those errors, particularly in logs.