### PR TITLE
Reduce size of MailboxName and MailboxPath

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
@@ -51,7 +51,7 @@ public struct MailboxPath: Hashable {
     /// The path separator, e.g. */* in *foo/bar*
     @inlinable
     public var pathSeparator: Character? {
-        (_pathSeparator == 0) ? nil : Unicode.Scalar(UInt32(_pathSeparator)).map { Character($0) }
+        (self._pathSeparator == 0) ? nil : Unicode.Scalar(UInt32(self._pathSeparator)).map { Character($0) }
     }
 
     /// Creates a new `MailboxPath` with the given data.
@@ -61,7 +61,7 @@ public struct MailboxPath: Hashable {
     /// - throws: `InvalidPathSeparatorError` if the `pathSeparator` is not a valid ascii value.
     public init(name: MailboxName, pathSeparator: Character? = nil) throws {
         // if a path separator is given, it must be a valid ascii character
-        if let pathSeparator = pathSeparator, !pathSeparator.isASCII {
+        if let pathSeparator, !pathSeparator.isASCII {
             throw InvalidPathSeparatorError(description: "The path separator must be an ascii value")
         }
 
@@ -122,8 +122,8 @@ extension MailboxPath {
     /// - throws: `InvalidMailboxNameError` if the `displayName` contains a `pathSeparator`.
     /// - returns: A new `MailboxPath` containing the given name and separator.
     public static func makeRootMailbox(displayName: String, pathSeparator: Character? = nil) throws -> MailboxPath {
-        guard displayName.utf8.count <= maximumMailboxSize else {
-            throw MailboxTooBigError(maximumSize: maximumMailboxSize, actualSize: displayName.utf8.count)
+        guard displayName.utf8.count <= self.maximumMailboxSize else {
+            throw MailboxTooBigError(maximumSize: self.maximumMailboxSize, actualSize: displayName.utf8.count)
         }
 
         if let separator = pathSeparator {
@@ -202,17 +202,18 @@ public struct MailboxName {
     /// We store a pre-calculated hash value to make `Hashable` conformance fast.
     @inlinable
     public var hashValue: Int {
-        _hashValue.value
+        self._hashValue.value
     }
+
     @usableFromInline
     let _hashValue: HashValue
 
     /// `true` if the internal storage reads "INBOX"
     /// otherwise `false`
     public var isInbox: Bool {
-        hashValue == MailboxName.inboxHashValue &&
-            bytes.count == 5 &&
-            bytes.map { $0 & 0xDF }.elementsEqual("INBOX".utf8)
+        self.hashValue == MailboxName.inboxHashValue &&
+            self.bytes.count == 5 &&
+            self.bytes.map { $0 & 0xDF }.elementsEqual("INBOX".utf8)
     }
 
     private static let inboxHashValue: Int = MailboxName.inbox.hashValue
@@ -248,7 +249,7 @@ extension MailboxName {
         init(_ value: Int) {
             let a = UInt(bitPattern: value)
             let b = a ^ (a >> 32)
-            _value = UInt32(truncatingIfNeeded: b)
+            self._value = UInt32(truncatingIfNeeded: b)
         }
 
         @inlinable
@@ -279,7 +280,7 @@ extension MailboxName: Hashable {
 
     @inlinable
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(hashValue)
+        hasher.combine(self.hashValue)
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
@@ -43,13 +43,21 @@ public struct MailboxPath: Hashable {
     /// The full mailbox name, e.g. *foo/bar*
     public let name: MailboxName
 
+    // Using this instead of `Character?` to reduce the size of this type.
+    // A value of `0` denotes no path separator (i.e. `nil`).
+    @usableFromInline
+    let _pathSeparator: UInt8
+
     /// The path separator, e.g. */* in *foo/bar*
-    public let pathSeparator: Character?
+    @inlinable
+    public var pathSeparator: Character? {
+        (_pathSeparator == 0) ? nil : Unicode.Scalar(UInt32(_pathSeparator)).map { Character($0) }
+    }
 
     /// Creates a new `MailboxPath` with the given data.
     /// - Note: Do not use this initialiser to create a root/sub mailbox that requires validation. Instead use `makeRootMailbox(displayName:pathSeparator:)`
     /// - parameter name: The `MailboxName` containing UTF-7 encoded bytes
-    /// - parameter pathSeparator: An optional `Character` used to delimit sub-mailboxes.
+    /// - parameter pathSeparator: An optional `Character` used to delimit sub-mailboxes. Note that this needs to be an ASCII character.
     /// - throws: `InvalidPathSeparatorError` if the `pathSeparator` is not a valid ascii value.
     public init(name: MailboxName, pathSeparator: Character? = nil) throws {
         // if a path separator is given, it must be a valid ascii character
@@ -58,7 +66,7 @@ public struct MailboxPath: Hashable {
         }
 
         self.name = name
-        self.pathSeparator = pathSeparator
+        self._pathSeparator = pathSeparator?.asciiValue ?? 0
     }
 }
 
@@ -192,7 +200,12 @@ public struct MailboxName {
     /// The hash value.
     ///
     /// We store a pre-calculated hash value to make `Hashable` conformance fast.
-    public let hashValue: Int
+    @inlinable
+    public var hashValue: Int {
+        _hashValue.value
+    }
+    @usableFromInline
+    let _hashValue: HashValue
 
     /// `true` if the internal storage reads "INBOX"
     /// otherwise `false`
@@ -220,7 +233,29 @@ public struct MailboxName {
         b.withUnsafeBytes { buffer in
             hasher.combine(bytes: buffer)
         }
-        self.hashValue = hasher.finalize()
+        self._hashValue = HashValue(hasher.finalize())
+    }
+}
+
+extension MailboxName {
+    /// A helper to store a hash value (for `Hashable` conformance) inside
+    /// a `UInt32` (i.e. 4 bytes) even on platforms where `Int` is 64 bit.
+    @usableFromInline
+    struct HashValue {
+        @usableFromInline
+        let _value: UInt32
+
+        init(_ value: Int) {
+            let a = UInt(bitPattern: value)
+            let b = a ^ (a >> 32)
+            _value = UInt32(truncatingIfNeeded: b)
+        }
+
+        @inlinable
+        var value: Int {
+            let a = UInt64(_value)
+            return Int(truncatingIfNeeded: Int64(bitPattern: (a << 32) | a))
+        }
     }
 }
 


### PR DESCRIPTION
Reduce `MemoryLayout<MailboxPath>.size` and `MemoryLayout<MailboxName>.size`.

### Motivation:

Some users have a lot of mailboxes, and reducing the size of these helps.

### Modifications:

1. `MailboxName`: Instead of storing `hashValue: Int` (8 bytes on 64 bit), store `_hashValue: UInt32` (4 bytes).
2. `MailboxPath `: Instead of storing `pathSeparator: Character?` (16 bytes on 64 bit), store `_pathSeparator: UInt8` (1 bytes).

### Result:

The size of `MailboxPath` drops from 32 bytes to 13 bytes (on 64 bit).
