### PR TITLE
Fix compiler warnings for Swift 5.9

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
@@ -26,12 +26,12 @@ import struct NIO.ByteBufferView
 extension GrammarParser {
     // Sequence Range
     func parseMessageIdentifierRange<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<T> {
-        func parse_wildcard<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> T {
+        func parse_wildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> T {
             try PL.parseFixedString("*", buffer: &buffer, tracker: tracker)
             return .max
         }
 
-        func parse_identifierOrWildcard<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> T {
+        func parse_identifierOrWildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> T {
             try PL.parseOneOf(
                 parse_wildcard,
                 self.parseMessageIdentifier,
@@ -40,7 +40,7 @@ extension GrammarParser {
             )
         }
 
-        func parse_colonAndIdentifierOrWildcard<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> T {
+        func parse_colonAndIdentifierOrWildcard(buffer: inout ParseBuffer, tracker: StackTracker) throws -> T {
             try PL.parseFixedString(":", buffer: &buffer, tracker: tracker)
             return try parse_identifierOrWildcard(buffer: &buffer, tracker: tracker)
         }
@@ -85,11 +85,11 @@ extension GrammarParser {
     // sequence-set       =/ seq-last-command
     // seq-last-command   = "$"
     func parseMessageIdentifierSet<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<MessageIdentifierSet<T>> {
-        func parseMessageIdentifierSet_number<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<T> {
+        func parseMessageIdentifierSet_number(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<T> {
             MessageIdentifierRange<T>(try self.parseMessageIdentifier(buffer: &buffer, tracker: tracker))
         }
 
-        func parseMessageIdentifierSet_element<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<T> {
+        func parseMessageIdentifierSet_element(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MessageIdentifierRange<T> {
             try PL.parseOneOf(
                 self.parseMessageIdentifierRange,
                 parseMessageIdentifierSet_number,
@@ -98,7 +98,7 @@ extension GrammarParser {
             )
         }
 
-        func parseMessageIdentifierSet_base<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<MessageIdentifierSet<T>> {
+        func parseMessageIdentifierSet_base(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<MessageIdentifierSet<T>> {
             try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker in
                 var output: [MessageIdentifierRange<T>] = [try parseMessageIdentifierSet_element(buffer: &buffer, tracker: tracker)]
                 try PL.parseZeroOrMore(buffer: &buffer, into: &output, tracker: tracker) { buffer, tracker in
@@ -112,7 +112,7 @@ extension GrammarParser {
             }
         }
 
-        func parseMessageIdentifierSet_lastCommand<T: MessageIdentifier>(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<MessageIdentifierSet<T>> {
+        func parseMessageIdentifierSet_lastCommand(buffer: inout ParseBuffer, tracker: StackTracker) throws -> LastCommandSet<MessageIdentifierSet<T>> {
             try PL.parseFixedString("$", buffer: &buffer, tracker: tracker)
             return .lastCommand
         }

--- a/Tests/NIOIMAPCoreTests/TestUtilities.swift
+++ b/Tests/NIOIMAPCoreTests/TestUtilities.swift
@@ -62,15 +62,33 @@ extension TestUtilities {
     }
 }
 
-extension ByteBuffer: ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-
-    public init(stringLiteral value: Self.StringLiteralType) {
+#if swift(>=5.8)
+#if hasFeature(RetroactiveAttribute)
+extension ByteBuffer: @retroactive ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
         let allocator = ByteBufferAllocator()
         self = allocator.buffer(capacity: 0)
         self.writeString(value)
     }
 }
+#else
+extension ByteBuffer: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        let allocator = ByteBufferAllocator()
+        self = allocator.buffer(capacity: 0)
+        self.writeString(value)
+    }
+}
+#endif
+#else
+extension ByteBuffer: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        let allocator = ByteBufferAllocator()
+        self = allocator.buffer(capacity: 0)
+        self.writeString(value)
+    }
+}
+#endif
 
 extension TestUtilities {
     static func roundTripCodable<A>(_ value: A) throws -> A where A: Codable {

--- a/Tests/NIOIMAPTests/TestUtilities.swift
+++ b/Tests/NIOIMAPTests/TestUtilities.swift
@@ -75,12 +75,30 @@ extension TestUtilities {
     }
 }
 
-extension ByteBuffer: ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-
-    public init(stringLiteral value: Self.StringLiteralType) {
+#if swift(>=5.8)
+#if hasFeature(RetroactiveAttribute)
+extension ByteBuffer: @retroactive ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
         let allocator = ByteBufferAllocator()
         self = allocator.buffer(capacity: 0)
         self.writeString(value)
     }
 }
+#else
+extension ByteBuffer: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        let allocator = ByteBufferAllocator()
+        self = allocator.buffer(capacity: 0)
+        self.writeString(value)
+    }
+}
+#endif
+#else
+extension ByteBuffer: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        let allocator = ByteBufferAllocator()
+        self = allocator.buffer(capacity: 0)
+        self.writeString(value)
+    }
+}
+#endif


### PR DESCRIPTION
1. Fix warnings about missing `@retroactive` (in tests).
2. Fix warnings about `generic parameter 'T' shadows generic parameter` in code.