### PR TITLE
Fix IMAP Proxy channel pipeline handlers - fixes #764

### DIFF
--- a/Sources/Proxy/MailClientToProxyHandler.swift
+++ b/Sources/Proxy/MailClientToProxyHandler.swift
@@ -18,7 +18,7 @@ import NIOIMAPCore
 import NIOSSL
 
 class MailClientToProxyHandler: ChannelInboundHandler {
-    typealias InboundIn = SynchronizedCommand
+    typealias InboundIn = CommandStreamPart
 
     var parser = CommandParser()
     var clientChannel: Channel?
@@ -56,10 +56,7 @@ class MailClientToProxyHandler: ChannelInboundHandler {
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let data = self.unwrapInboundIn(data)
-        guard let command = data.commandPart else {
-            return
-        }
+        let command = self.unwrapInboundIn(data)
         self.clientChannel?.writeAndFlush(command, promise: nil)
     }
 

--- a/Sources/Proxy/ProxyToMailServerHandler.swift
+++ b/Sources/Proxy/ProxyToMailServerHandler.swift
@@ -34,7 +34,7 @@ class ProxyToMailServerHandler: ChannelInboundHandler {
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        var stream = self.unwrapInboundIn(data)
+        let stream = self.unwrapInboundIn(data)
         self.mailAppToProxyChannel.writeAndFlush(stream, promise: nil)
     }
 

--- a/Sources/Proxy/ProxyToMailServerHandler.swift
+++ b/Sources/Proxy/ProxyToMailServerHandler.swift
@@ -34,11 +34,8 @@ class ProxyToMailServerHandler: ChannelInboundHandler {
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let stream = self.unwrapInboundIn(data)
-        let buffer = context.channel.allocator.buffer(capacity: 1024)
-        var encodeBuffer = ResponseEncodeBuffer(buffer: buffer, capabilities: self.capabilities, loggingMode: false)
-        encodeBuffer.writeResponse(stream)
-        self.mailAppToProxyChannel.writeAndFlush(encodeBuffer.readBytes(), promise: nil)
+        var stream = self.unwrapInboundIn(data)
+        self.mailAppToProxyChannel.writeAndFlush(stream, promise: nil)
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {

--- a/Sources/Proxy/main.swift
+++ b/Sources/Proxy/main.swift
@@ -56,6 +56,7 @@ try ServerBootstrap(group: eventLoopGroup).childChannelInitializer { channel -> 
     channel.pipeline.addHandlers([
         InboundPrintHandler(type: "CLIENT (Original)"),
         OutboundPrintHandler(type: "SERVER (Decoded)"),
+        ByteToMessageHandler(FrameDecoder()),
         IMAPServerHandler(),
         MailClientToProxyHandler(serverHost: serverHost, serverPort: serverPort),
     ])


### PR DESCRIPTION
This changes the channel handlers for the Proxy to match what the IMAPServerHandler and IMAPClientHandler now expect.

### Motivation:

The Proxy command currently is unable to proxy IMAP connections.

### Modifications:

This modifies the MailClientToProxyHandler's InboundIn to expect CommandStreamPart rather than SynchronizedCommand, modfiies ProxyToMailServerHandler.channelRead to write a Response rather than a ByteBuffer and modifies Proxy/main to add the ByteToMessageHandler(FrameDecoder()) channel handler before the IMAPServerHandler(), so it gets a FramingResult as input.

### Result:

Proxy should successfully proxy IMAP connections.

fixes #764
