### PR TITLE
Use `let` for static constants, not `var`

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/AttributeFlag.swift
+++ b/Sources/NIOIMAPCore/Grammar/AttributeFlag.swift
@@ -22,19 +22,19 @@ public struct AttributeFlag: Hashable {
 
     // yep, we need 4, because the spec requires 2 literal \\ characters
     /// "\\Answered"
-    public static var answered = Self("\\\\Answered")
+    public static let answered = Self("\\\\Answered")
 
     /// "\\Flagged"
-    public static var flagged = Self("\\\\Flagged")
+    public static let flagged = Self("\\\\Flagged")
 
     /// "\\Deleted"
-    public static var deleted = Self("\\\\Deleted")
+    public static let deleted = Self("\\\\Deleted")
 
     /// "\\Seen"
-    public static var seen = Self("\\\\Seen")
+    public static let seen = Self("\\\\Seen")
 
     /// "\\Draft"
-    public static var draft = Self("\\\\Draft")
+    public static let draft = Self("\\\\Draft")
 
     /// Creates a new `AttributeFlag` from the give raw `String`.
     /// - parameter rawValue: The raw `String` to use as the flag. Will be lower-cased.

--- a/Sources/NIOIMAPCore/Grammar/Entry/EntryKindRequest.swift
+++ b/Sources/NIOIMAPCore/Grammar/Entry/EntryKindRequest.swift
@@ -19,14 +19,14 @@ public struct EntryKindRequest: Hashable {
     fileprivate var backing: String
 
     /// Search private metadata items.
-    public static var `private` = Self(backing: "priv")
+    public static let `private` = Self(backing: "priv")
 
     /// Search shared metadata items.
-    public static var shared = Self(backing: "shared")
+    public static let shared = Self(backing: "shared")
 
     /// The server should use the largest value among `.private` and `.shared` mod-sequences
     /// for the metadata item.
-    public static var all = Self(backing: "all")
+    public static let all = Self(backing: "all")
 }
 
 // MARK: - Encoding

--- a/Sources/NIOIMAPCore/Grammar/Entry/EntryTypeResponse.swift
+++ b/Sources/NIOIMAPCore/Grammar/Entry/EntryTypeResponse.swift
@@ -19,10 +19,10 @@ public struct EntryKindResponse: Hashable {
     fileprivate var backing: String
 
     /// `priv` - Private metadata item type.
-    public static var `private` = Self(backing: "priv")
+    public static let `private` = Self(backing: "priv")
 
     /// `shared` - Shared metadata item type.
-    public static var shared = Self(backing: "shared")
+    public static let shared = Self(backing: "shared")
 }
 
 // MARK: - Encoding

--- a/Sources/NIOIMAPCore/Grammar/InitialResponse.swift
+++ b/Sources/NIOIMAPCore/Grammar/InitialResponse.swift
@@ -18,7 +18,7 @@ import struct NIO.ByteBuffer
 /// up the process.
 public struct InitialResponse: Hashable {
     /// Creates a new empty `InitialResponse` that will be encoded as `=`.
-    public static var empty: Self = .init(ByteBuffer())
+    public static let empty: Self = .init(ByteBuffer())
 
     /// The data to be base-64 encoded.
     public var data: ByteBuffer

--- a/Sources/NIOIMAPCore/Grammar/Media/Media.swift
+++ b/Sources/NIOIMAPCore/Grammar/Media/Media.swift
@@ -108,10 +108,10 @@ extension Media {
         public static let related = Self("related")
 
         /// When used with a `multipart` type, specifies a generic set of mixed data types.
-        public static var mixed = Self("mixed")
+        public static let mixed = Self("mixed")
 
         /// `message` sub-type.
-        public static var rfc822 = Self("rfc822")
+        public static let rfc822 = Self("rfc822")
 
         /// The subtype as a lowercased string
         internal let stringValue: String


### PR DESCRIPTION
Use `let` for static constants, which shouldn't be mutable.

### Motivation:

These will be errors with Swift 6.