### PR TITLE
RFC 7377: Use `RETURN (ALL)` instead of `RETURN ()`

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Command/Command.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/Command.swift
@@ -106,8 +106,8 @@ public enum Command: Hashable, Sendable {
     ///
     /// This is a RFC 3501 / RFC 4731 style search. RFC 7377 style searches use `.extendedSearch`.
     ///
-    /// If `returnOptions` is empty, this is a RFC 3501 style search. Notably the empty `RETURN ()`
-    /// maps to `[.all]` — as it’s equivalent to `RETURN (ALL)`.
+    /// If `returnOptions` is empty, this is a RFC 3501 style search. But note that the empty
+    /// RFC 7377 `RETURN ()` maps to `[.all]` — as it’s equivalent to `RETURN (ALL)`.
     ///
     /// * `SEARCH ANSWERED` is `.search(key:. answered, returnOptions: [])`
     /// * `SEARCH RETURN () ANSWERED` is `.search(key:. answered, returnOptions: [.all])`

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchReturnOption.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchReturnOption.swift
@@ -67,9 +67,9 @@ extension EncodeBuffer {
         guard options.count > 0 else {
             return 0
         }
-        if options == [.all] {
-            return self.writeString(" RETURN ()")
-        }
+        // When `options == [.all]`, we _could_ encode this as
+        // `RETURN ()` according to RFC 7377, but many esoteric
+        // servers will fail to parse this correctly.
         return
             self.writeString(" RETURN (") +
             self.writeIfExists(options) { (options) -> Int in

--- a/Tests/NIOIMAPCoreTests/Grammar/ESearch/ESearchOptions+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/ESearch/ESearchOptions+Tests.swift
@@ -40,7 +40,7 @@ extension ExtendedSearchOptions_Tests {
             ),
             (
                 ExtendedSearchOptions(key: .deleted, returnOptions: [.all]),
-                " RETURN () DELETED",
+                " RETURN (ALL) DELETED",
                 #line
             ),
             (

--- a/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnOption+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Search/SearchReturnOption+Tests.swift
@@ -45,7 +45,7 @@ extension SearchReturnOption_Tests {
         let inputs: [([SearchReturnOption], String, UInt)] = [
             ([], "", #line),
             ([.min], " RETURN (MIN)", #line),
-            ([.all], " RETURN ()", #line),
+            ([.all], " RETURN (ALL)", #line),
             ([.min, .all], " RETURN (MIN ALL)", #line),
             ([.min, .max, .count], " RETURN (MIN MAX COUNT)", #line),
             ([.min, .partial(.last(400 ... 1_000))], " RETURN (MIN PARTIAL -400:-1000)", #line),


### PR DESCRIPTION
RFC 7377: Use `RETURN (ALL)` instead of `RETURN ()`

### Motivation:

RFC 7377 allows search options `ALL` to be encoded as `RETURN ()` instead of `RETURN (ALL)`, but some servers fail to properly parse this.

### Modifications:

We will now encode `[SearchReturnOption.all]` as `RETURN (ALL)` instead of `RETURN ()`.
