### PR TITLE
Implement RFC 7889 `APPENDLIMIT`

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -4,6 +4,7 @@ NIOIMAP supports a variety of known IMAP [extensions](https://www.iana.org/assig
 
 | Capability | RFC |
 | --- | --- |
+APPENDLIMIT|[RFC7889]((https://www.iana.org/go/rfc7889)
 AUTH=|[RFC3501](https://www.iana.org/go/rfc3501)
 BINARY|[RFC3516](https://www.iana.org/go/rfc3516)
 CATENATE|[RFC4469](https://www.iana.org/go/rfc4469)

--- a/Sources/NIOIMAPCore/Grammar/Capability.swift
+++ b/Sources/NIOIMAPCore/Grammar/Capability.swift
@@ -270,6 +270,9 @@ extension Capability {
     /// Allow clients to transparently connect to an alternate IMAP4 server, if their home IMAP4 server has changed - RFC 2221.
     public static let loginReferrals = Self(unchecked: "LOGIN-REFERRALS")
 
+    /// RFC 7889 “Mailbox-Specific APPENDLIMIT” — maximum upload size.
+    public static let mailboxSpecificAppendLimit = Self(unchecked: "APPENDLIMIT")
+
     /// Permits clients and servers to maintain "annotations" or "metadata" on IMAP servers - RFC 5464.
     public static let metadata = Self(unchecked: "METADATA")
 
@@ -360,6 +363,13 @@ extension Capability {
     ///
     /// Message numbers are not returned in responses and cannot be used in requests once this extension is enabled.
     public static let uidOnly = Self(unchecked: "UIDONLY")
+
+    /// RFC 7889 `APPENDLIMIT` — maximum upload size.
+    ///
+    /// See also: ``mailboxSpecificAppendLimit``
+    public static func appendLimit(_ count: Int) -> Self {
+        Self("APPENDLIMIT=\(count)")
+    }
 
     /// MESSAGELIMIT
     ///

--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxAttribute.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxAttribute.swift
@@ -45,6 +45,11 @@ public enum MailboxAttribute: String, CaseIterable, Sendable {
     /// RFC 7162
     /// The highest mod-sequence value of all messages in the mailbox.
     case highestModificationSequence = "HIGHESTMODSEQ"
+
+    /// `APPENDLIMIT`
+    ///
+    /// RFC 7889. Maximum upload size.
+    case appendLimit = "APPENDLIMIT"
 }
 
 /// The (aggregated) information about a mailbox that the server reports as part of the response to e.g. a `SELECT` command.
@@ -75,6 +80,11 @@ public struct MailboxStatus: Hashable, Sendable {
     /// The highest mod-sequence value of all messages in the mailbox.
     public var highestModificationSequence: ModificationSequenceValue?
 
+    /// `APPENDLIMIT`
+    ///
+    /// RFC 7889 per-mailbox `APPENDLIMIT`, i.e. maximum message upload size.
+    public var appendLimit: Int?
+
     /// Creates a new `MailboxStatus`. All parameters default to `nil`.
     /// - parameter messageCount: RFC 3501: `MESSAGES` - The number of messages in the mailbox.
     /// - parameter recentCount: RFC 3501: `RECENT` - The number of messages with the \Recent flag set.
@@ -83,6 +93,7 @@ public struct MailboxStatus: Hashable, Sendable {
     /// - parameter unseenCount: RFC 3501: `UNSEEN` - The number of messages which do not have the `\Seen` flag set.
     /// - parameter size: RFC 8438: `SIZE` - The number of messages which do not have the `\Seen` flag set.
     /// - parameter highestModificationSequence: RFC 7162: `SIZE` - The total size of the mailbox in octets.
+    /// - parameter appendLimit: RFC 7889 per-mailbox `APPENDLIMIT`, i.e. maximum message upload size.
     public init(
         messageCount: Int? = nil,
         recentCount: Int? = nil,
@@ -90,7 +101,8 @@ public struct MailboxStatus: Hashable, Sendable {
         uidValidity: UIDValidity? = nil,
         unseenCount: Int? = nil,
         size: Int? = nil,
-        highestModificationSequence: ModificationSequenceValue? = nil
+        highestModificationSequence: ModificationSequenceValue? = nil,
+        appendLimit: Int? = nil
     ) {
         self.messageCount = messageCount
         self.recentCount = recentCount
@@ -99,6 +111,7 @@ public struct MailboxStatus: Hashable, Sendable {
         self.unseenCount = unseenCount
         self.size = size
         self.highestModificationSequence = highestModificationSequence
+        self.appendLimit = appendLimit
     }
 }
 
@@ -137,6 +150,7 @@ extension EncodeBuffer {
         append(\.unseenCount, "UNSEEN")
         append(\.size, "SIZE")
         append(\.highestModificationSequence, "HIGHESTMODSEQ")
+        append(\.appendLimit, "APPENDLIMIT")
 
         return self.writeArray(array, parenthesis: false) { (element, self) -> Int in
             self.writeString("\(element.0) \(element.1)")

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
@@ -241,6 +241,7 @@ extension GrammarParser {
             case size(Int)
             case recent(Int)
             case highestModifierSequence(ModificationSequenceValue)
+            case appendLimit(Int)
         }
 
         func parseStatusAttributeValue_messages(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxValue {
@@ -278,6 +279,11 @@ extension GrammarParser {
             return .recent(try self.parseNumber(buffer: &buffer, tracker: tracker))
         }
 
+        func parseStatusAttributeValue_appendLimit(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxValue {
+            try PL.parseFixedString("APPENDLIMIT ", buffer: &buffer, tracker: tracker)
+            return .appendLimit(try self.parseNumber(buffer: &buffer, tracker: tracker))
+        }
+
         func parseStatusAttributeValue(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxValue {
             try PL.parseOneOf([
                 parseStatusAttributeValue_messages,
@@ -287,6 +293,7 @@ extension GrammarParser {
                 parseStatusAttributeValue_size,
                 parseStatusAttributeValue_modificationSequence,
                 parseStatusAttributeValue_recent,
+                parseStatusAttributeValue_appendLimit,
             ], buffer: &buffer, tracker: tracker)
         }
 
@@ -315,6 +322,8 @@ extension GrammarParser {
                     status.unseenCount = unseen
                 case .recent(let recent):
                     status.recentCount = recent
+                case .appendLimit(let limit):
+                    status.appendLimit = limit
                 }
             }
             return status

--- a/Tests/NIOIMAPCoreTests/Grammar/Capability+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Capability+Tests.swift
@@ -40,6 +40,7 @@ extension Capability_Tests {
         let tests: [(Capability, String, UInt)] = [
             (.acl, "ACL", #line),
             (.annotateExperiment1, "ANNOTATE-EXPERIMENT-1", #line),
+            (.appendLimit(11_206_521), "APPENDLIMIT=11206521", #line),
             (.authenticate(.pToken), "AUTH=PTOKEN", #line),
             (.authenticate(.plain), "AUTH=PLAIN", #line),
             (.authenticate(.token), "AUTH=TOKEN", #line),
@@ -66,6 +67,7 @@ extension Capability_Tests {
             (.literalMinus, "LITERAL-", #line),
             (.literalPlus, "LITERAL+", #line),
             (.loginReferrals, "LOGIN-REFERRALS", #line),
+            (.mailboxSpecificAppendLimit, "APPENDLIMIT", #line),
             (.messageLimit(1_234), "MESSAGELIMIT=1234", #line),
             (.metadata, "METADATA", #line),
             (.metadataServer, "METADATA-SERVER", #line),

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxAttribute+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxAttribute+Tests.swift
@@ -25,6 +25,9 @@ extension MailboxAttribute_Tests {
         let inputs: [([MailboxAttribute], String, UInt)] = [
             ([], "", #line),
             ([MailboxAttribute.messageCount, .recentCount, .unseenCount], "MESSAGES RECENT UNSEEN", #line),
+            ([MailboxAttribute.appendLimit, .uidNext, .uidValidity], "APPENDLIMIT UIDNEXT UIDVALIDITY", #line),
+            ([MailboxAttribute.size], "SIZE", #line),
+            ([MailboxAttribute.highestModificationSequence, .messageCount], "HIGHESTMODSEQ MESSAGES", #line),
         ]
 
         for (test, expectedString, line) in inputs {
@@ -39,8 +42,18 @@ extension MailboxAttribute_Tests {
         let inputs: [(MailboxStatus, String, UInt)] = [
             (.init(), "", #line),
             (
-                .init(messageCount: 1, recentCount: 2, nextUID: 3, uidValidity: 4, unseenCount: 5, size: 6, highestModificationSequence: 7),
-                "MESSAGES 1 RECENT 2 UIDNEXT 3 UIDVALIDITY 4 UNSEEN 5 SIZE 6 HIGHESTMODSEQ 7",
+                .init(messageCount: 133701, recentCount: 255813, nextUID: 377003, uidValidity: 427421, unseenCount: 528028, size: 680543, highestModificationSequence: 797237, appendLimit: 86254193),
+                "MESSAGES 133701 RECENT 255813 UIDNEXT 377003 UIDVALIDITY 427421 UNSEEN 528028 SIZE 680543 HIGHESTMODSEQ 797237 APPENDLIMIT 86254193",
+                #line
+            ),
+            (
+                .init(messageCount: 133701, nextUID: 377003, uidValidity: 427421, appendLimit: 86254193),
+                "MESSAGES 133701 UIDNEXT 377003 UIDVALIDITY 427421 APPENDLIMIT 86254193",
+                #line
+            ),
+            (
+                .init(nextUID: 377003),
+                "UIDNEXT 377003",
                 #line
             ),
         ]

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -2353,8 +2353,11 @@ extension ParserUnitTests {
         self.iterateTests(
             testFunction: GrammarParser().parseMailboxStatus,
             validInputs: [
-                ("MESSAGES 1", "\r", .init(messageCount: 1), #line),
-                ("MESSAGES 1 RECENT 2 UIDNEXT 3 UIDVALIDITY 4 UNSEEN 5 SIZE 6 HIGHESTMODSEQ 7", "\r", .init(messageCount: 1, recentCount: 2, nextUID: 3, uidValidity: 4, unseenCount: 5, size: 6, highestModificationSequence: 7), #line),
+                ("MESSAGES 1", ")", .init(messageCount: 1), #line),
+                ("MESSAGES 1 RECENT 2 UIDNEXT 3 UIDVALIDITY 4 UNSEEN 5 SIZE 6 HIGHESTMODSEQ 7", ")", .init(messageCount: 1, recentCount: 2, nextUID: 3, uidValidity: 4, unseenCount: 5, size: 6, highestModificationSequence: 7), #line),
+                ("APPENDLIMIT 257890", ")", .init(appendLimit: 257_890), #line),
+                ("SIZE 81630", ")", .init(size: 81_630), #line),
+                ("UIDNEXT 95604  HIGHESTMODSEQ 35227 APPENDLIMIT 81818  UIDVALIDITY 33682", ")", .init(nextUID: 95604, uidValidity: 33682, highestModificationSequence: 35227, appendLimit: 81818), #line),
             ],
             parserErrorInputs: [
                 ("MESSAGES UNSEEN 3 RECENT 4", "\r", #line),


### PR DESCRIPTION
Implement RFC 7889 `APPENDLIMIT`

### Motivation:

Support for RFC 7889 “maximum message upload sizes”.

### Modifications:

Added both the (normal) `CAPABILITY` part and the mailbox-specific limit through `STATUS` response.
