### PR TITLE
Mark more types as `Sendable`

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Body/Body.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Body.swift
@@ -23,7 +23,7 @@ extension MessageAttribute {
     /// A server has to parse a MIME message to build up the RFC 3501 `body` data, and since there are a lot of
     /// badly formatted messages in the wild, servers can sometimes end up generating “bad” `body` data.
     /// The most common source is from junk messages, that are more-or-less intentionally ill-formated.
-    public enum BodyStructure: Hashable {
+    public enum BodyStructure: Hashable, Sendable {
         /// A normal, valid RFC 3501 `body` (aka. body structure).
         case valid(NIOIMAPCore.BodyStructure)
         /// We failed to parse the body structure.
@@ -33,7 +33,7 @@ extension MessageAttribute {
 
 /// A parsed representation of the MIME-IMB body structure information of the message.
 /// Recomended reading: RFC 3501 § 2.6.3 and 7.4.2.
-public enum BodyStructure: Hashable {
+public enum BodyStructure: Hashable, Sendable {
     /// A message that at the top level contains only one part. Note that a "message" body contains a nested
     /// body, which may itself be multipart.
     case singlepart(Singlepart)

--- a/Sources/NIOIMAPCore/Grammar/Body/BodyExtension.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/BodyExtension.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 /// Provides support for future extensions. Any future extensions to body fields must
 /// match one case of this enum, either an `nstring` or `number`.
-public enum BodyExtension: Hashable {
+public enum BodyExtension: Hashable, Sendable {
     /// A generic `nstring` field.
     case string(ByteBuffer?)
 

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/Disposition.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/Disposition.swift
@@ -29,7 +29,7 @@ extension BodyStructure {
 
     /// A parsed representation of a parenthesized list containing a type string, and attribute/value pairs.
     /// Recomended reading: RFC 3501 § 7.4.2 and RFC 2183
-    public struct Disposition: Hashable {
+    public struct Disposition: Hashable, Sendable {
         /// The disposition type string.
         public var kind: DispositionKind
 

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/DispositionAndLanguage.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/DispositionAndLanguage.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 extension BodyStructure {
     /// Pairs a body `Disposition` with a `LanguageLocation`. An abstraction from RFC 3501
     /// to make the API slightly easier to work with and enforce validity.
-    public struct DispositionAndLanguage: Hashable {
+    public struct DispositionAndLanguage: Hashable, Sendable {
         /// Some body `Disposition`
         public var disposition: Disposition?
 

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/Encoding.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/Encoding.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 extension BodyStructure {
     /// Represents the body transfer encoding as defined in MIME-IMB.
     /// Recommended reading: RFC 2045
-    public struct Encoding: CustomDebugStringConvertible, Hashable {
+    public struct Encoding: CustomDebugStringConvertible, Hashable, Sendable {
         /// Represents 7-bit encoding, octets with a value larger than 127 are forbidden.
         public static var sevenBit: Self { Self("7BIT") }
 

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/Fields.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/Fields.swift
@@ -17,7 +17,7 @@ import struct OrderedCollections.OrderedDictionary
 
 extension BodyStructure {
     /// Contains fields that are common across bodies of all types (*basic*, *message*, and *text*)
-    public struct Fields: Hashable {
+    public struct Fields: Hashable, Sendable {
         /// An array of *attribute/value* pairs
         public var parameters: OrderedDictionary<String, String>
 

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/LanguageLocation.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/LanguageLocation.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 extension BodyStructure {
     /// Pairs languages with a `Location`. An abstraction from RFC 3501
     /// to make the API slightly easier to work with and enforce validity.
-    public struct LanguageLocation: Hashable {
+    public struct LanguageLocation: Hashable, Sendable {
         /// The body language value(s) as defined in BCP 47 and RFC 3066.
         public var languages: [String]
         /// A string list giving the body content URI as defined in RFC 2557.

--- a/Sources/NIOIMAPCore/Grammar/Body/Field/LocationAndExtensions.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Field/LocationAndExtensions.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 extension BodyStructure {
     /// Pairs a location with `BodyExtensions`s. An abstraction from RFC 3501
     /// to make the API slightly easier to work with and enforce validity.
-    public struct LocationAndExtensions: Hashable {
+    public struct LocationAndExtensions: Hashable, Sendable {
         /// A string giving the body content URI. Defined in LOCATION.
         public var location: String?
 

--- a/Sources/NIOIMAPCore/Grammar/Body/Multipart.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Multipart.swift
@@ -18,7 +18,7 @@ import struct OrderedCollections.OrderedDictionary
 extension BodyStructure {
     /// Represents a *multipart* body as defined in RFC 3501.
     /// Recommended reading: RFC 3501 § 6.4.5.
-    public struct Multipart: Hashable {
+    public struct Multipart: Hashable, Sendable {
         /// The parts of the body. Each part is assigned a consecutive part number.
         public var parts: [BodyStructure]
 
@@ -43,7 +43,7 @@ extension BodyStructure {
 extension BodyStructure.Multipart {
     /// Optional fields that are not required to form a valid `Multipart`. Links an array of `ParameterPair` with a `DispositionAndLanguage.
     /// Partially simplified to make the API nice, for example `DispositionAndLanguage` pairs a disposition and a language.
-    public struct Extension: Hashable {
+    public struct Extension: Hashable, Sendable {
         /// An array of *key/value* pairs.
         public var parameters: OrderedDictionary<String, String>
 

--- a/Sources/NIOIMAPCore/Grammar/Body/Singlepart.swift
+++ b/Sources/NIOIMAPCore/Grammar/Body/Singlepart.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 extension BodyStructure {
     /// Represents a single-part body as defined in RFC 3501.
-    public struct Singlepart: Hashable {
+    public struct Singlepart: Hashable, Sendable {
         /// The type of single-part. Note that "message" types may contain a multi-part.
         public var kind: Kind
 
@@ -42,7 +42,7 @@ extension BodyStructure {
 
 extension BodyStructure.Singlepart {
     /// Represents the type of a single-part message.
-    public indirect enum Kind: Hashable {
+    public indirect enum Kind: Hashable, Sendable {
         /// A simple message containing only one kind of data.
         case basic(Media.MediaType)
 
@@ -54,7 +54,7 @@ extension BodyStructure.Singlepart {
     }
 
     /// Represents a typical "full" email message, containing an envelope and a child message.
-    public struct Message: Hashable {
+    public struct Message: Hashable, Sendable {
         /// The RFC 2045 sub-type. This will usually be `rfc822`.
         public var message: Media.Subtype
 
@@ -81,7 +81,7 @@ extension BodyStructure.Singlepart {
     }
 
     /// Represents a text-based message body.
-    public struct Text: Hashable {
+    public struct Text: Hashable, Sendable {
         /// The media sub-type of a text part, e.g. `html` or `plain` for `text/html` and `text/plain` respectively.
         public var mediaSubtype: Media.Subtype
 
@@ -98,7 +98,7 @@ extension BodyStructure.Singlepart {
     }
 
     /// Optional extension fields, initially pairing an MD5 body digest with a `DispositionAndLanguage`.
-    public struct Extension: Hashable {
+    public struct Extension: Hashable, Sendable {
         /// A string giving the body MD5 value.
         public let digest: String?
 

--- a/Sources/NIOIMAPCore/Grammar/EmailAddress.swift
+++ b/Sources/NIOIMAPCore/Grammar/EmailAddress.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 /// An address structure is a parenthesized list that describes an
 /// electronic mail address.
-public struct EmailAddress: Hashable {
+public struct EmailAddress: Hashable, Sendable {
     /// The addressee's personal name (may be an alias).
     public var personName: ByteBuffer?
 

--- a/Sources/NIOIMAPCore/Grammar/Envelope.swift
+++ b/Sources/NIOIMAPCore/Grammar/Envelope.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 /// The envelope of a message contains various fields, all of which may be empty or `nil`.
 /// It's entirely possible for an envelope to be completely empty, though this will be rare.
-public struct Envelope: Hashable {
+public struct Envelope: Hashable, Sendable {
     /// The local time and date that the message was written.
     public var date: InternetMessageDate?
 

--- a/Sources/NIOIMAPCore/Grammar/FetchModificationResponse.swift
+++ b/Sources/NIOIMAPCore/Grammar/FetchModificationResponse.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Wraps the modification time of a message that is returned as part of a `.fetch` command.
-public struct FetchModificationResponse: Hashable {
+public struct FetchModificationResponse: Hashable, Sendable {
     /// The date that the message was last modified.
     public var modificationSequenceValue: ModificationSequenceValue
 

--- a/Sources/NIOIMAPCore/Grammar/InternetMessageDate.swift
+++ b/Sources/NIOIMAPCore/Grammar/InternetMessageDate.swift
@@ -17,7 +17,7 @@
 /// See RFC-2822 section 3.3. “Date and Time Specification”.
 ///
 /// Use `String(init(_: InternetMessageDate)` to get the underlying string representation.
-public struct InternetMessageDate: Hashable {
+public struct InternetMessageDate: Hashable, Sendable {
     var value: String
 
     /// Creates a new `InternetMessageDate` from a given `String`.

--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxData.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxData.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// Mailbox attributes with associated data, part of a fetch response.
-public enum MailboxData: Hashable {
+public enum MailboxData: Hashable, Sendable {
     /// The flags associated with a mailbox.
     case flags([Flag])
 
@@ -49,7 +49,7 @@ public enum MailboxData: Hashable {
 
 extension MailboxData {
     /// A container for an array of message identifiers, and a sequence.
-    public struct SearchSort: Hashable {
+    public struct SearchSort: Hashable, Sendable {
         /// An array of message identifiers that were matched in a search.
         public var identifiers: [Int]
 

--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxGroup.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxGroup.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// A group of addresses.
-public struct EmailAddressGroup: Hashable {
+public struct EmailAddressGroup: Hashable, Sendable {
     /// The name of the group.
     public var groupName: ByteBuffer
 
@@ -37,7 +37,7 @@ public struct EmailAddressGroup: Hashable {
 }
 
 /// Used inside `Envelope` to distinguish between either a single address, or a group of addresses.
-public indirect enum EmailAddressListElement: Hashable {
+public indirect enum EmailAddressListElement: Hashable, Sendable {
     /// A single address with no children.
     case singleAddress(EmailAddress)
 

--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxInfo.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxInfo.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 import struct OrderedCollections.OrderedDictionary
 
 /// A collection of mailbox attributes defined in the supported IMAP4 RFCs.
-public struct MailboxInfo: Hashable {
+public struct MailboxInfo: Hashable, Sendable {
     /// An array of mailbox attributes.
     public var attributes: [Attribute]
 
@@ -41,7 +41,7 @@ public struct MailboxInfo: Hashable {
 
 extension MailboxInfo {
     /// A single attribute of a Mailbox
-    public struct Attribute: Hashable {
+    public struct Attribute: Hashable, Sendable {
         /// It is not possible to use this name as a selectable mailbox.
         public static var noSelect: Self { Self(#"\Noselect"#) }
 

--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxName.swift
@@ -39,7 +39,7 @@ public struct InvalidPathSeparatorError: Error, Equatable {
 /// Represents a complete mailbox path, delimited by the `pathSeparator`.
 /// For example, *foo/bar* is the `MailboxName`, and so "/" would be the `pathSeparator`.
 /// Path separators are optional, and so the simple `MailboxName` *foo* has `pathSeparator = nil`.
-public struct MailboxPath: Hashable {
+public struct MailboxPath: Hashable, Sendable {
     /// The full mailbox name, e.g. *foo/bar*
     public let name: MailboxName
 

--- a/Sources/NIOIMAPCore/Grammar/Media/Media.swift
+++ b/Sources/NIOIMAPCore/Grammar/Media/Media.swift
@@ -17,7 +17,7 @@ public enum Media {}
 
 extension Media {
     /// An RFC 2045 media type, also known as MIME type.
-    public struct MediaType: Hashable {
+    public struct MediaType: Hashable, Sendable {
         public var topLevel: TopLevelType
         public var sub: Subtype
 

--- a/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/MessageAttributes.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 /// These are the individual parts of a `FETCH` response.
 ///
 /// - SeeAlso: RFC 3501 section 7.4.2
-public enum MessageAttribute: Hashable {
+public enum MessageAttribute: Hashable, Sendable {
     /// `FLAGS` -- A list of flags that are set for this message.
     case flags([Flag])
     /// `ENVELOPE` -- A list that describes the envelope structure of a message.

--- a/Sources/NIOIMAPCore/Grammar/Message/MessageData.swift
+++ b/Sources/NIOIMAPCore/Grammar/Message/MessageData.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// A piece of data regarding a message, returned as an untagged server response.
-public enum MessageData: Hashable {
+public enum MessageData: Hashable, Sendable {
     /// The specified message sequence number has been permanently removed from the mailbox
     case expunge(SequenceNumber)
 

--- a/Sources/NIOIMAPCore/Grammar/MessageID.swift
+++ b/Sources/NIOIMAPCore/Grammar/MessageID.swift
@@ -18,7 +18,7 @@
 /// `<B27397-0100000@cac.washington.edu>`.
 ///
 /// See RFC 2822 section 3.6.4.
-public struct MessageID: Hashable {
+public struct MessageID: Hashable, Sendable {
     /// The `String` message identifier.
     var rawValue: String
 

--- a/Sources/NIOIMAPCore/Grammar/MetadataResponse.swift
+++ b/Sources/NIOIMAPCore/Grammar/MetadataResponse.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 import struct OrderedCollections.OrderedDictionary
 
 /// Sent by the server as a response to a `.getMetdata` command.
-public enum MetadataResponse: Hashable {
+public enum MetadataResponse: Hashable, Sendable {
     /// Provides an array of values for the specified mailbox.
     case values(values: OrderedDictionary<MetadataEntryName, MetadataValue>, mailbox: MailboxName)
 

--- a/Sources/NIOIMAPCore/Grammar/Quota/QuotaResource.swift
+++ b/Sources/NIOIMAPCore/Grammar/Quota/QuotaResource.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// A resource with it's current usage and maximum size.
-public struct QuotaResource: Hashable {
+public struct QuotaResource: Hashable, Sendable {
     /// The resource that the quota is applied to.
     public var resourceName: String
 

--- a/Sources/NIOIMAPCore/Grammar/Response/ExtendedSearchResponse.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ExtendedSearchResponse.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// Sent from a server in response to an extended search.
-public struct ExtendedSearchResponse: Hashable {
+public struct ExtendedSearchResponse: Hashable, Sendable {
     /// Identifies the search that resulted in this response.
     public var correlator: SearchCorrelator?
 
@@ -40,7 +40,7 @@ extension ExtendedSearchResponse {
     /// The kind of search response.
     ///
     /// Describes if the `UnknownMessageIdentifier` in the `returnData`’s `SearchReturnData` are `UID` or `SequenceNumber`.
-    public enum Kind: Hashable {
+    public enum Kind: Hashable, Sendable {
         case sequenceNumber
         case uid
     }

--- a/Sources/NIOIMAPCore/Grammar/Response/Response.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/Response.swift
@@ -15,13 +15,13 @@
 import struct NIO.ByteBuffer
 import struct NIO.ByteBufferAllocator
 
-public enum ResponseOrContinuationRequest: Hashable {
+public enum ResponseOrContinuationRequest: Hashable, Sendable {
     case continuationRequest(ContinuationRequest)
     case response(Response)
 }
 
 /// Wraps the various response types that may be sent by a server.
-public enum Response: Hashable {
+public enum Response: Hashable, Sendable {
     /// Servers may send one or more untagged response for every tagged response.
     /// Untagged responses are sent before their corresponding tagged response.
     case untagged(ResponsePayload)
@@ -82,7 +82,7 @@ extension Response: CustomDebugStringConvertible {
 /// After recieving `start` (or `startUID`) you may recieve n `simpleAttribute`, `streamingBegin`, and `streamingBytes` events.
 /// Every `streamingBegin` has exaclty one corresponding `streamingEnd`
 /// `streamingBegin` has a `type` that specifies the type of data to be streamed
-public enum FetchResponse: Hashable {
+public enum FetchResponse: Hashable, Sendable {
     /// A fetch response is beginning for the message with the given sequence number.
     case start(SequenceNumber)
 
@@ -108,7 +108,7 @@ public enum FetchResponse: Hashable {
 }
 
 /// The current type of data that is being streamed.
-public enum StreamingKind: Hashable {
+public enum StreamingKind: Hashable, Sendable {
     /// BINARY RFC 3516, streams BINARY when using a `literal`
     case binary(section: SectionSpecifier.Part, offset: Int?)
 

--- a/Sources/NIOIMAPCore/Grammar/Response/ResponsePayload.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/ResponsePayload.swift
@@ -17,7 +17,7 @@ import struct OrderedCollections.OrderedDictionary
 
 /// Data returned as part of an untagged response. Typically one of these cases will be returned
 /// for each message or mailbox that is of interest.
-public enum ResponsePayload: Hashable {
+public enum ResponsePayload: Hashable, Sendable {
     /// Indicates if the command, or subcommand, executed successfully.
     case conditionalState(UntaggedStatus)
 

--- a/Sources/NIOIMAPCore/Grammar/Response/TaggedResponse.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/TaggedResponse.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 /// A tagged response that is sent by a server to signal that
 /// a command has finished processing.
-public struct TaggedResponse: Hashable {
+public struct TaggedResponse: Hashable, Sendable {
     /// The tag of the command that led to this response.
     public var tag: String
 

--- a/Sources/NIOIMAPCore/Grammar/Response/TaggedResponseState.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/TaggedResponseState.swift
@@ -18,7 +18,7 @@ extension TaggedResponse {
     /// Tagged status responses
     ///
     /// The tagged versions in RFC 3501 section 7.1
-    public enum State: Hashable {
+    public enum State: Hashable, Sendable {
         /// The command executed successfully.
         case ok(ResponseText)
 

--- a/Sources/NIOIMAPCore/Grammar/Response/UntaggedResponseState.swift
+++ b/Sources/NIOIMAPCore/Grammar/Response/UntaggedResponseState.swift
@@ -17,7 +17,7 @@ import struct NIO.ByteBuffer
 /// Untagged status responses
 ///
 /// The untagged versions in RFC 3501 section 7.1
-public enum UntaggedStatus: Hashable {
+public enum UntaggedStatus: Hashable, Sendable {
     /// Indicates a success.
     case ok(ResponseText)
 

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchCorrelator.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchCorrelator.swift
@@ -16,7 +16,7 @@ import struct NIO.ByteBuffer
 
 /// Multiple searches may be run concurrently, and so a `SearchCorrelator` can be used
 /// to identify the search to which a response belongs.
-public struct SearchCorrelator: Hashable {
+public struct SearchCorrelator: Hashable, Sendable {
     /// The tag of the command that this search result is a response to.
     public var tag: String
 

--- a/Sources/NIOIMAPCore/Grammar/Search/SearchReturnData.swift
+++ b/Sources/NIOIMAPCore/Grammar/Search/SearchReturnData.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// Contains information returned from a complete search command, not on a per-message basis.
-public enum SearchReturnData: Hashable {
+public enum SearchReturnData: Hashable, Sendable {
     /// Return the lowest message number/UID that satisfies the SEARCH criteria.
     case min(UnknownMessageIdentifier)
 

--- a/Sources/NIOIMAPCore/Grammar/URLFetchData.swift
+++ b/Sources/NIOIMAPCore/Grammar/URLFetchData.swift
@@ -15,7 +15,7 @@
 import struct NIO.ByteBuffer
 
 /// Wraps data and a URL that the data is associated with. Returned as part of a `.urlFetch` command.
-public struct URLFetchData: Hashable {
+public struct URLFetchData: Hashable, Sendable {
     // TODO: This is defined in the spec as being an `astring`, however is really a full URL wrapped in quotes
     // we should consider extracting the data of the quotes and correctly parsing the URL
     /// The IMAP URL that's being fetched.

--- a/Sources/NIOIMAPCore/PreviewText.swift
+++ b/Sources/NIOIMAPCore/PreviewText.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct PreviewText: Hashable {
+public struct PreviewText: Hashable, Sendable {
     fileprivate let text: String
 
     public init(_ text: String) {


### PR DESCRIPTION
Mark more types as `Sendable`.

### Motivation:

I missed a bunch of types in #767.