### PR TITLE
Add helper for logging CommandStreamPart without PII and special case ID command / response

### DIFF
--- a/Sources/NIOIMAPCore/CommandEncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/CommandEncodeBuffer.swift
@@ -56,8 +56,8 @@ extension CommandEncodeBuffer {
     /// Call the closure with a buffer, return the result as a String.
     ///
     /// Used for implementing ``CustomDebugStringConvertible`` conformance.
-    static func makeDescription(_ closure: (inout CommandEncodeBuffer) -> Void) -> String {
-        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501, loggingMode: false)
+    static func makeDescription(loggingMode: Bool = false, _ closure: (inout CommandEncodeBuffer) -> Void) -> String {
+        var buffer = CommandEncodeBuffer(buffer: ByteBuffer(), options: .rfc3501, loggingMode: loggingMode)
         closure(&buffer)
         var chunk = buffer.buffer.nextChunk()
         var result = String(bestEffortDecodingUTF8Bytes: chunk.bytes.readableBytesView)

--- a/Sources/NIOIMAPCore/EncodeBuffer.swift
+++ b/Sources/NIOIMAPCore/EncodeBuffer.swift
@@ -181,3 +181,14 @@ extension EncodeBuffer {
         self.buffer.clear()
     }
 }
+
+extension EncodeBuffer {
+    mutating func withoutLoggingMode<R>(_ closure: (inout EncodeBuffer) -> R) -> R {
+        let old = self.loggingMode
+        defer {
+            self.loggingMode = old
+        }
+        self.loggingMode = false
+        return closure(&self)
+    }
+}

--- a/Sources/NIOIMAPCore/Grammar/Command/CommandStreamPart.swift
+++ b/Sources/NIOIMAPCore/Grammar/Command/CommandStreamPart.swift
@@ -130,6 +130,15 @@ extension CommandStreamPart: CustomDebugStringConvertible {
             $0.writeCommandStream(self)
         }
     }
+
+    /// Creates a string from the array of `CommandStreamPart` with all _personally identifiable information_ redacted.
+    public static func descriptionWithoutPII(_ parts: some Sequence<CommandStreamPart>) -> String {
+        CommandEncodeBuffer.makeDescription(loggingMode: true) {
+            for p in parts {
+                $0.writeCommandStream(p)
+            }
+        }
+    }
 }
 
 extension CommandEncodeBuffer {

--- a/Sources/NIOIMAPCore/Grammar/ID/ID.swift
+++ b/Sources/NIOIMAPCore/Grammar/ID/ID.swift
@@ -22,15 +22,19 @@ extension EncodeBuffer {
         guard values.count > 0 else {
             return self.writeNil()
         }
-        return self.writeOrderedDictionary(values) { (e, self) in
-            self.writeIMAPString(e.key) +
-                self.writeSpace() +
-                self.writeNString(e.value)
+        return self.withoutLoggingMode { buffer in
+            buffer.writeOrderedDictionary(values) { (e, buffer) in
+                buffer.writeIMAPString(e.key) +
+                    buffer.writeSpace() +
+                    buffer.writeNString(e.value)
+            }
         }
     }
 
     @discardableResult mutating func writeIDResponse(_ response: OrderedDictionary<String, String?>) -> Int {
-        self.writeString("ID ") +
-            self.writeIDParameters(response)
+        self.withoutLoggingMode {
+            $0.writeString("ID ") +
+                $0.writeIDParameters(response)
+        }
     }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/ID/ID+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/ID/ID+Tests.swift
@@ -46,3 +46,21 @@ extension ID_Tests {
         )
     }
 }
+
+extension ID_Tests {
+    func testThatAnIDResponseDoesNotGetRedactedForLogging() {
+        let id = Response.untagged(ResponsePayload.id(["name": "A"]))
+        XCTAssertEqual("\(Response.descriptionWithoutPII([id]))", #"""
+        * ID ("name" "A")\#r
+        
+        """#)
+    }
+
+    func testThatAnIDCommandDoesNotGetRedactedForLogging() {
+        let part = CommandStreamPart.tagged(TaggedCommand(tag: "A1", command: .id(["name": "A"])))
+        XCTAssertEqual("\(CommandStreamPart.descriptionWithoutPII([part]))", #"""
+        A1 ID ("name" "A")\#r
+        
+        """#)
+    }
+}

--- a/Tests/NIOIMAPCoreTests/Grammar/ID/ID+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/ID/ID+Tests.swift
@@ -52,7 +52,7 @@ extension ID_Tests {
         let id = Response.untagged(ResponsePayload.id(["name": "A"]))
         XCTAssertEqual("\(Response.descriptionWithoutPII([id]))", #"""
         * ID ("name" "A")\#r
-        
+
         """#)
     }
 
@@ -60,7 +60,7 @@ extension ID_Tests {
         let part = CommandStreamPart.tagged(TaggedCommand(tag: "A1", command: .id(["name": "A"])))
         XCTAssertEqual("\(CommandStreamPart.descriptionWithoutPII([part]))", #"""
         A1 ID ("name" "A")\#r
-        
+
         """#)
     }
 }


### PR DESCRIPTION
Add helper for logging CommandStreamPart without PII and special case ID command / response

### Motivation:

It is extremely useful to be able to see the key-value pairs of the ID command / response when debugging, but they are currently being redacted (since all strings are by default).

### Modifications:

There’s already support for creating a `String` from a `CommandStreamPart` with all PII (personally identifiable information) redacted.

This adds a helper
```swift
extension CommandStreamPart {
    public static func descriptionWithoutPII(_ parts: some Sequence<CommandStreamPart>) -> String
}
```
to generate these.

And this adds special logic to _not_ redact the key-value pairs of the [RFC 2971 “ID”](https://datatracker.ietf.org/doc/html/rfc2971) command and response.

### Result:

`ID` response / command are not being redacted.