### PR TITLE
Be more lenient about spaces in RFC 2971 ID response

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -771,17 +771,27 @@ extension GrammarParser {
         }
 
         func parseIDParamsList_empty(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OrderedDictionary<String, String?> {
-            try PL.parseFixedString("()", buffer: &buffer, tracker: tracker)
+            try PL.parseFixedString("(", buffer: &buffer, tracker: tracker)
+            _ = try PL.parseOptional(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try PL.parseSpaces(buffer: &buffer, tracker: tracker)
+            }
+            try PL.parseFixedString(")", buffer: &buffer, tracker: tracker)
             return [:]
         }
 
         func parseIDParamsList_some(buffer: inout ParseBuffer, tracker: StackTracker) throws -> OrderedDictionary<String, String?> {
             try PL.parseFixedString("(", buffer: &buffer, tracker: tracker)
+            _ = try PL.parseOptional(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try PL.parseSpaces(buffer: &buffer, tracker: tracker)
+            }
             let (key, value) = try parseIDParamsList_element(buffer: &buffer, tracker: tracker)
             var dic: OrderedDictionary<String, String?> = [key: value]
             try PL.parseZeroOrMore(buffer: &buffer, into: &dic, tracker: tracker) { (buffer, tracker) -> (String, String?) in
                 try PL.parseSpaces(buffer: &buffer, tracker: tracker)
                 return try parseIDParamsList_element(buffer: &buffer, tracker: tracker)
+            }
+            _ = try PL.parseOptional(buffer: &buffer, tracker: tracker) { buffer, tracker in
+                try PL.parseSpaces(buffer: &buffer, tracker: tracker)
             }
             try PL.parseFixedString(")", buffer: &buffer, tracker: tracker)
             return dic

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -1414,6 +1414,8 @@ extension ParserUnitTests {
             testFunction: GrammarParser().parseIDParamsList,
             validInputs: [
                 ("NIL", " ", [:], #line),
+                ("()", " ", [:], #line),
+                ("( )", " ", [:], #line),
                 (#"("key1" "value1")"#, "", ["key1": "value1"], #line),
                 (
                     #"("key1" "value1" "key2" "value2" "key3" "value3")"#,
@@ -1425,6 +1427,25 @@ extension ParserUnitTests {
                     #"("key1" "&AKM-" "flag" "&2Dzf9NtA3GfbQNxi20DcZdtA3G7bQNxn20Dcfw-")"#,
                     #""#,
                     ["key1": "£", "flag": "🏴󠁧󠁢󠁥󠁮󠁧󠁿"],
+                    #line
+                ),
+                (
+                    #"("a" "1" "b" "2")"#,
+                    "",
+                    ["a": "1", "b": "2"],
+                    #line
+                ),
+                // Extra spaces
+                (
+                    #"( "a" "1" "b" "2" )"#,
+                    "",
+                    ["a": "1", "b": "2"],
+                    #line
+                ),
+                (
+                    #"("a"  "1"  "b"   "2")"#,
+                    "",
+                    ["a": "1", "b": "2"],
                     #line
                 ),
             ],


### PR DESCRIPTION
Be more lenient about spaces in RFC 2971 ID response

### Motivation:

[Archiveopteryx ](https://archiveopteryx.org) inserts extra spaces before the closing `)`.

### Modifications:

Skip any additional spaces in the ID response.
