### PR TITLE
FramingParser: Allow un-matched DQUOTE in lines

### DIFF
--- a/Sources/NIOIMAP/Client/FramingParser.swift
+++ b/Sources/NIOIMAP/Client/FramingParser.swift
@@ -380,9 +380,11 @@ extension FramingParser {
         let byte = self.readByte()
         switch (byte, quotedState) {
         case (CR, _), (LF, _):
-            // This is bogus: Can’t have CR or LR inside quoted string.
-            // Complete the frame and let it fail.
-            return .parsedCompleteFrame
+            // Can’t have CR or LF inside quoted strings, but certain
+            // parts (notably `text`) is allowed to have _any_ character
+            // (except CR or LF).
+            // Thus, fall through to “normal” state:
+            return readByte_state_normalTraversal(lineFeedStrategy: .includeInFrame)
 
         case (ESCAPE, .normal):
             self.state = .insideQuoted(.escaped)

--- a/Tests/NIOIMAPTests/FramingParserTests.swift
+++ b/Tests/NIOIMAPTests/FramingParserTests.swift
@@ -38,6 +38,26 @@ extension FramingParserTests {
         XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("A1 NOOP\r\n")])
     }
 
+    func testSingleQuoteInLine() {
+        // RFC 3501 allows un-matched `"` in `text` parts, such as the text of an untagged OK response.
+        //
+        // Test that this:
+        //
+        // S: * OK Hello " foo
+        // S: * NO Hello bar
+        //
+        // gets parsed into the corresponding two frames / lines.
+        do {
+            var buffer: ByteBuffer = "* OK Hello \" foo\r\n"
+            XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("* OK Hello \" foo\r\n")])
+        }
+        // Check that the next line parses:
+        do {
+            var buffer: ByteBuffer = "* NO Hello bar\r\n"
+            XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("* NO Hello bar\r\n")])
+        }
+    }
+
     func testCommandWithQuoted() {
         var buffer: ByteBuffer = "A1 LOGIN \"foo\" \"bar\"\r\n"
         XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("A1 LOGIN \"foo\" \"bar\"\r\n")])


### PR DESCRIPTION
Allow `DQUOTE` / `"` in lines (frames) of `FramingParser`.

### Motivation:

Certain parts (notably `text`) are allowed to have unmatched `"` in them.

### Modifications:

Fix `FramingParser`.

Add test case to make sure that
```
S: * OK Hello " foo
S: * NO Hello bar
```
gets framed correctly into 2 “frames” / lines.

### Result:

Tests pass.