### PR TITLE
Declare `MessageIdentificationShiftWrapper` to be `Sendable`

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -63,7 +63,7 @@ public struct MessageIdentifierSet<IdentifierType: MessageIdentifier>: Hashable,
 /// This allows us to store `type`.max + 1 inside a UInt32.
 /// This applies for both UIDs and SequenceNumbers.
 @usableFromInline
-struct MessageIdentificationShiftWrapper: Hashable {
+struct MessageIdentificationShiftWrapper: Hashable, Sendable {
     var rawValue: UInt32
 
     init(rawValue: UInt32) {


### PR DESCRIPTION
Add a `Sendable` conformance to `MessageIdentificationShiftWrapper`.

### Motivation:

Even though this isn't a public type, it's declared to be usable from inline, so its sendability matters externally.

