### PR TITLE
FramingParser can crash when single CR is inside DQUOTE string

### DIFF
--- a/Sources/Proxy/main.swift
+++ b/Sources/Proxy/main.swift
@@ -40,26 +40,29 @@ guard CommandLine.arguments.count == 5 else {
 
 let host = CommandLine.arguments[1]
 guard let port = Int(CommandLine.arguments[2]) else {
-    print("Invalid port, coudln't convert to an integer")
+    print("Invalid port, couldn't convert to an integer")
     exit(1)
 }
 
 let serverHost = CommandLine.arguments[3]
 guard let serverPort = Int(CommandLine.arguments[4]) else {
-    print("Invalid server port, coudln't convert to an integer")
+    print("Invalid server port, couldn't convert to an integer")
     exit(1)
 }
 
 // MARK: - Run
 
 try ServerBootstrap(group: eventLoopGroup).childChannelInitializer { channel -> EventLoopFuture<Void> in
-    channel.pipeline.addHandlers([
+    try! channel.pipeline.syncOperations.addHandlers([
         InboundPrintHandler(type: "CLIENT (Original)"),
         OutboundPrintHandler(type: "SERVER (Decoded)"),
         ByteToMessageHandler(FrameDecoder()),
         IMAPServerHandler(),
         MailClientToProxyHandler(serverHost: serverHost, serverPort: serverPort),
     ])
+    let p = eventLoopGroup.any().makePromise(of: Void.self)
+    p.succeed()
+    return p.futureResult
 }
 .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
 .bind(host: host, port: port).wait()

--- a/Tests/NIOIMAPTests/FramingParserTests.swift
+++ b/Tests/NIOIMAPTests/FramingParserTests.swift
@@ -58,6 +58,26 @@ extension FramingParserTests {
         }
     }
 
+    func testSingleQuoteInLine_CR_lineBreak() {
+        // RFC 3501 allows un-matched `"` in `text` parts, such as the text of an untagged OK response.
+        //
+        // Test that this:
+        //
+        // S: * OK Hello " foo
+        // S: * NO Hello bar
+        //
+        // gets parsed into the corresponding two frames / lines.
+        do {
+            var buffer: ByteBuffer = "* OK Hello \" foo\r"
+            XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("* OK Hello \" foo\r")])
+        }
+        // Check that the next line parses:
+        do {
+            var buffer: ByteBuffer = "* NO Hello bar\r"
+            XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("* NO Hello bar\r")])
+        }
+    }
+
     func testCommandWithQuoted() {
         var buffer: ByteBuffer = "A1 LOGIN \"foo\" \"bar\"\r\n"
         XCTAssertEqual(try self.parser.appendAndFrameBuffer(&buffer), [.complete("A1 LOGIN \"foo\" \"bar\"\r\n")])

--- a/Tests/NIOIMAPTests/IntegrationTests.swift
+++ b/Tests/NIOIMAPTests/IntegrationTests.swift
@@ -62,11 +62,13 @@ final class ParserIntegrationTests: XCTestCase {
             server = try ServerBootstrap(group: group)
                 .serverChannelOption(ChannelOptions.socket(.init(SOL_SOCKET), .init(SO_REUSEADDR)), value: 1)
                 .childChannelInitializer { channel in
-                    channel.pipeline.addHandlers(
-                        ByteToMessageHandler(FrameDecoder()),
-                        IMAPServerHandler(),
-                        CollectEverythingHandler(collectionDonePromise: collectionDonePromise)
-                    )
+                    channel.eventLoop.makeCompletedFuture {
+                        try! channel.pipeline.syncOperations.addHandlers([
+                            ByteToMessageHandler(FrameDecoder()),
+                            IMAPServerHandler(),
+                            CollectEverythingHandler(collectionDonePromise: collectionDonePromise),
+                        ])
+                    }
                 }
                 .bind(to: .init(ipAddress: "127.0.0.1", port: 0))
                 .wait()


### PR DESCRIPTION
FramingParser can crash when single CR is inside DQUOTE string

### Motivation:

#776 introduced a bug that could cause a crash (hitting an `assert()`) if the buffer ends with a `CR` (as opposed to `CRLF`) while we’re inside a `"`-string.

### Modifications:

We would erroneously always consume the byte after the `CR` or `LF` if we hit a `CR` or `LF` while inside a `"`-string — because we’d call `self.readByte()` twice as a result of calling into `readByte_state_normalTraversal()` from `readByte_state_insideQuoted()`.

Added test case that would crash (due to the `assert()`) prior to this fix.

### Result:

No crash. 😄
