### PR TITLE
Fix parsing of NIL for RFC 7889 APPENDLIMIT

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
@@ -274,7 +274,7 @@ extension GrammarParser {
             case size(Int)
             case recent(Int)
             case highestModifierSequence(ModificationSequenceValue)
-            case appendLimit(Int)
+            case appendLimit(Int?)
         }
 
         func parseStatusAttributeValue_messages(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxValue
@@ -325,7 +325,29 @@ extension GrammarParser {
             tracker: StackTracker
         ) throws -> MailboxValue {
             try PL.parseFixedString("APPENDLIMIT ", buffer: &buffer, tracker: tracker)
-            return .appendLimit(try self.parseNumber(buffer: &buffer, tracker: tracker))
+
+            func parseStatusAttributeValue_appendLimit_nil(
+                buffer: inout ParseBuffer,
+                tracker: StackTracker
+            ) throws -> MailboxValue {
+                try self.parseNil(buffer: &buffer, tracker: tracker)
+                return .appendLimit(nil)
+            }
+            func parseStatusAttributeValue_appendLimit_number(
+                buffer: inout ParseBuffer,
+                tracker: StackTracker
+            ) throws -> MailboxValue {
+                return .appendLimit(try self.parseNumber(buffer: &buffer, tracker: tracker))
+            }
+
+            return try PL.parseOneOf(
+                [
+                    parseStatusAttributeValue_appendLimit_nil,
+                    parseStatusAttributeValue_appendLimit_number,
+                ],
+                buffer: &buffer,
+                tracker: tracker
+            )
         }
 
         func parseStatusAttributeValue(buffer: inout ParseBuffer, tracker: StackTracker) throws -> MailboxValue {

--- a/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/IMAPParserTests.swift
@@ -2753,6 +2753,7 @@ extension ParserUnitTests {
                     ), #line
                 ),
                 ("APPENDLIMIT 257890", ")", .init(appendLimit: 257_890), #line),
+                ("APPENDLIMIT NIL", ")", .init(appendLimit: nil), #line),
                 ("SIZE 81630", ")", .init(size: 81_630), #line),
                 (
                     "UIDNEXT 95604  HIGHESTMODSEQ 35227 APPENDLIMIT 81818  UIDVALIDITY 33682", ")",


### PR DESCRIPTION
Fix parsing of `NIL` for RFC 7889 `APPENDLIMIT`

### Motivation:

#769 implemented RFC 7889, but we fail to parse `APPENDLIMIT NIL` which the server can send if there is no mailbox-specific limit for a particular mailbox, e.g.:
```
C: A1 STATUS INBOX (APPENDLIMIT)
S: * STATUS INBOX (APPENDLIMIT NIL)
S: A1 OK STATUS completed
```

### Modifications:

Added test case and fix parsing.
