### PR TITLE
Fix IMAPServerHandler not resetting outstanding continuations

### DIFF
--- a/Sources/NIOIMAP/Coders/IMAPServerHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPServerHandler.swift
@@ -83,13 +83,12 @@ public final class IMAPServerHandler: ChannelDuplexHandler {
             context.read()
         }
         let outstanding = self.numberOfOutstandingContinuationRequests
-        if outstanding == 0 {
-            return
-        }
+        guard outstanding != 0 else { return }
 
         for _ in 0..<outstanding {
             context.write(self.wrapOutboundOut(self.continuationRequestBytes), promise: nil)
         }
+        self.numberOfOutstandingContinuationRequests = 0
         context.flush()
     }
 


### PR DESCRIPTION
Fix `IMAPServerHandler` not resetting outstanding continuations.

### Motivation:

`IMAPServerHandler` would repeatedly send [Command Continuation Request](https://datatracker.ietf.org/doc/html/rfc3501#section-7.5) because it never reset `numberOfOutstandingContinuationRequests`.

### Modifications:

Added unit test.

Reset `numberOfOutstandingContinuationRequests` once the _continuation requests_ have been sent.
