### PR TITLE
Workaround for IMAPClientHandler and APPEND

### DIFF
--- a/Sources/NIOIMAP/Coders/ClientStateMachine.swift
+++ b/Sources/NIOIMAP/Coders/ClientStateMachine.swift
@@ -593,9 +593,15 @@ extension ClientStateMachine {
             return nil
         }
 
+        // Workaround: Using non-synchronizing literals is broken for APPEND.
+        var encodingOptions = self.encodingOptions
+        encodingOptions.useSynchronizingLiteral = true
+        encodingOptions.useNonSynchronizingLiteralPlus = false
+        encodingOptions.useNonSynchronizingLiteralMinus = false
+
         var encodeBuffer = CommandEncodeBuffer(
             buffer: ByteBuffer(),
-            options: self.encodingOptions,
+            options: encodingOptions,
             encodedAtLeastOneCatenateElement: appendingStateMachine.hasCatenatedAtLeastOneObject,
             loggingMode: false
         )


### PR DESCRIPTION
Support for [RFC 7888](https://www.rfc-editor.org/rfc/rfc7888) _Non-Synchronizing Literals_ is currently broken in the `IMAPClientHandler` for `APPEND`. This disables those extensions for `APPEND`.

### Motivation:

If the connection uses `CommandEncodingOptions` with RFC 7888 _Non-Synchronizing Literals_ the connection will get stuck during `APPEND` because the internal state of the `IMAPClientHandler` is waiting for continuations when there are none.

The normal (non-RFC 7888) flow is
```text
C: A003 APPEND saved-messages (\Seen) {310}
S: + Ready for literal data
C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
C: ...
```
but with e.g. `LITERAL+` is becomes
```text
C: A003 APPEND saved-messages (\Seen) {310+}
C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
C: ...
```
but the `IMAPClientHandler` would currently still wait for a _ Command Continuation Request_ after the `{310+}`.

Eventually, the state machine of `IMAPClientHandler` needs to be cleaned up with a real fix, but that is way, way more work.

### Modifications:

Disable `LITERAL+` and `LITERAL-` for `APPEND.

### Result:

`APPEND` works with the `IMAPClientHandler.