### PR TITLE
Fix client handler encoding options

### DIFF
--- a/Sources/NIOIMAP/Coders/ClientEncodingOptions.swift
+++ b/Sources/NIOIMAP/Coders/ClientEncodingOptions.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(NIOIMAPInternal) import NIOIMAPCore
+
+struct ClientEncodingOptions {
+    var userOptions: IMAPClientHandler.EncodingOptions
+    var automatic: CommandEncodingOptions
+
+    init(
+        userOptions: IMAPClientHandler.EncodingOptions,
+        automatic: CommandEncodingOptions = CommandEncodingOptions()
+    ) {
+        self.userOptions = userOptions
+        self.automatic = automatic
+    }
+
+    var encodingOptions: CommandEncodingOptions {
+        switch userOptions {
+        case .automatic: return automatic
+        case .fixed(let e): return e
+        }
+    }
+}
+
+extension ClientEncodingOptions {
+    mutating func updateAutomaticOptions(
+        response: Response
+    ) {
+        switch response {
+        case .untagged(.capabilityData(let c)):
+            self.updateAutomaticOptions(capabilities: c)
+        case .tagged(let tagged):
+            switch tagged.state {
+            case .ok(let r), .no(let r), .bad(let r):
+                switch r.code {
+                case .capability(let c)?:
+                    self.updateAutomaticOptions(capabilities: c)
+                default:
+                    break
+                }
+            }
+        default:
+            break
+        }
+    }
+
+    mutating func updateAutomaticOptions(
+        capabilities: [Capability]
+    ) {
+        automatic = CommandEncodingOptions(capabilities: capabilities)
+    }
+}

--- a/Sources/NIOIMAP/Coders/ClientStateMachine.swift
+++ b/Sources/NIOIMAP/Coders/ClientStateMachine.swift
@@ -456,7 +456,11 @@ extension ClientStateMachine {
 
     private func makeEncodeBuffer(_ command: CommandStreamPart? = nil) -> CommandEncodeBuffer {
         let byteBuffer = self.allocator.buffer(capacity: 128)
-        var encodeBuffer = CommandEncodeBuffer(buffer: byteBuffer, options: self.encodingOptions.encodingOptions, loggingMode: false)
+        var encodeBuffer = CommandEncodeBuffer(
+            buffer: byteBuffer,
+            options: self.encodingOptions.encodingOptions,
+            loggingMode: false
+        )
         if let command = command {
             encodeBuffer.writeCommandStream(command)
         }

--- a/Sources/NIOIMAPCore/CommandEncodingOptions.swift
+++ b/Sources/NIOIMAPCore/CommandEncodingOptions.swift
@@ -33,21 +33,12 @@ public struct CommandEncodingOptions: Hashable, Sendable {
 
     public static let rfc3501: Self = .init()
 
-    /// Create RFC 3501 compliant encoding options, i.e. without any IMAP extensions.
-    public init() {
-        self.useQuotedString = true
-        self.useSynchronizingLiteral = true
-        self.useNonSynchronizingLiteralPlus = false
-        self.useNonSynchronizingLiteralMinus = false
-        self.useBinaryLiteral = false
-    }
-
     public init(
-        useQuotedString: Bool,
-        useSynchronizingLiteral: Bool,
-        useNonSynchronizingLiteralPlus: Bool,
-        useNonSynchronizingLiteralMinus: Bool,
-        useBinaryLiteral: Bool
+        useQuotedString: Bool = true,
+        useSynchronizingLiteral: Bool = true,
+        useNonSynchronizingLiteralPlus: Bool = false,
+        useNonSynchronizingLiteralMinus: Bool = false,
+        useBinaryLiteral: Bool = false
     ) {
         self.useQuotedString = useQuotedString
         self.useSynchronizingLiteral = useSynchronizingLiteral

--- a/Sources/Proxy/MailClientToProxyHandler.swift
+++ b/Sources/Proxy/MailClientToProxyHandler.swift
@@ -46,7 +46,7 @@ class MailClientToProxyHandler: ChannelInboundHandler {
                     sslHandler,
                     OutboundPrintHandler(type: "CLIENT (Encoded)"),
                     InboundPrintHandler(type: "SERVER (Original)"),
-                    IMAPClientHandler(encodingChangeCallback: { _, _ in }),
+                    IMAPClientHandler(),
                     ProxyToMailServerHandler(mailAppToProxyChannel: mailClientToProxyChannel),
                 ])
             }
@@ -64,8 +64,8 @@ class MailClientToProxyHandler: ChannelInboundHandler {
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let command = self.unwrapInboundIn(data)
-        self.clientChannel?.writeAndFlush(command, promise: nil)
+        let part = self.unwrapInboundIn(data)
+        self.clientChannel?.writeAndFlush(IMAPClientHandler.OutboundIn.part(part), promise: nil)
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {

--- a/Tests/NIOIMAPTests/Coders/ClientEncodingOptionsTests.swift
+++ b/Tests/NIOIMAPTests/Coders/ClientEncodingOptionsTests.swift
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+@testable import NIOIMAP
+@_spi(NIOIMAPInternal) @testable import NIOIMAPCore
+import XCTest
+
+extension CommandEncodingOptions {
+    static var a: CommandEncodingOptions {
+        CommandEncodingOptions(
+            useQuotedString: true,
+            useSynchronizingLiteral: false,
+            useNonSynchronizingLiteralPlus: true,
+            useNonSynchronizingLiteralMinus: false,
+            useBinaryLiteral: true
+        )
+    }
+
+    static var b: CommandEncodingOptions {
+        CommandEncodingOptions(
+            useQuotedString: false,
+            useSynchronizingLiteral: true,
+            useNonSynchronizingLiteralPlus: false,
+            useNonSynchronizingLiteralMinus: false,
+            useBinaryLiteral: false
+        )
+    }
+}
+
+class ClientEncodingOptionsTests: XCTestCase {
+    func testGettingEffectiveOptions() {
+        XCTAssertEqual(
+            ClientEncodingOptions(
+                userOptions: .automatic,
+                automatic: .a
+            ).encodingOptions,
+            .a
+        )
+        XCTAssertEqual(
+            ClientEncodingOptions(
+                userOptions: .automatic,
+                automatic: .b
+            ).encodingOptions,
+            .b
+        )
+        XCTAssertEqual(
+            ClientEncodingOptions(
+                userOptions: .fixed(.a),
+                automatic: .b
+            ).encodingOptions,
+            .a
+        )
+        XCTAssertEqual(
+            ClientEncodingOptions(
+                userOptions: .fixed(.b),
+                automatic: .a
+            ).encodingOptions,
+            .b
+        )
+    }
+
+    func testUpdateWithResponse() {
+        var sut = ClientEncodingOptions(userOptions: .automatic)
+
+        XCTAssertEqual(sut.encodingOptions, CommandEncodingOptions())
+
+        sut.updateAutomaticOptions(response: .untagged(.capabilityData([.imap4, .literalMinus])))
+        XCTAssertEqual(
+            sut.encodingOptions,
+            CommandEncodingOptions(
+                useNonSynchronizingLiteralMinus: true
+            )
+        )
+
+        sut.updateAutomaticOptions(
+            response: .tagged(
+                TaggedResponse(
+                    tag: "A",
+                    state: .ok(
+                        ResponseText(
+                            code: .capability([.imap4rev1, .literalPlus, .binary]),
+                            text: "Done"
+                        )
+                    )
+                )
+            )
+        )
+        XCTAssertEqual(
+            sut.encodingOptions,
+            CommandEncodingOptions(
+                useNonSynchronizingLiteralPlus: true,
+                useBinaryLiteral: true
+            )
+        )
+    }
+
+    func testUpdatingAutoWhenUsingFixed() {
+        var sut = ClientEncodingOptions(userOptions: .fixed(.a))
+
+        XCTAssertEqual(sut.encodingOptions, .a)
+
+        sut.updateAutomaticOptions(response: .untagged(.capabilityData([.imap4, .literalMinus])))
+        XCTAssertEqual(sut.encodingOptions, .a)
+
+        sut.userOptions = .automatic
+        XCTAssertEqual(
+            sut.encodingOptions,
+            CommandEncodingOptions(
+                useNonSynchronizingLiteralMinus: true
+            )
+        )
+    }
+}

--- a/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
+++ b/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
@@ -21,7 +21,7 @@ class ClientStateMachineTests: XCTestCase {
     var stateMachine: ClientStateMachine!
 
     override func setUp() {
-        self.stateMachine = ClientStateMachine(encodingOptions: .rfc3501)
+        self.stateMachine = ClientStateMachine(encodingOptions: .fixed(.rfc3501))
         self.stateMachine.handlerAdded(ByteBufferAllocator())
     }
 


### PR DESCRIPTION
The encoding options of the `IMAPClientHandler` are not being set properly.

### Motivation:

The `IMAPClientHandler` tries to automatically extract incoming server capabilities to update its encoding options. But it fails to pick up capabilities inside a _tagged_ response.

The encoding options furthermore would only be set once an untagged `ID` response was received from the server, and only if the capabilities had previously been received. There should be no such dependency on `ID`.

Finally, code that uses `IMAPClientHandler` should be able to set specific encoding options as it sees fit.

### Modifications:

**Note:** This changes the `OutboundIn` type of the `IMAPClientHandler`.

Instead of the current `CommandStreamPart `, it’s now a new `enum`:
```swift
extension IMAPClientHandler {
    public enum OutboundIn: Hashable, Sendable {
        case part(CommandStreamPart)
        case setEncodingOptions(EncodingOptions)
    }
}
```

This lets the client send in specific `CommandEncodingOptions` or use the automatic options (based on incoming capabilities):
```swift
extension IMAPClientHandler {
    public enum EncodingOptions: Hashable, Sendable {
        case automatic
        case fixed(CommandEncodingOptions)
    }
}
```

Finally, parsing of capabilities from server responses has been fixed to detect capabilities both in
1. an untagged capabilities response, or
2. a tagged response with a `CAPABILITY` response code

### Result:

Encoding options are properly updated and set.
