### PR TITLE
Fix receiving untagged responses during APPEND

### DIFF
--- a/Sources/NIOIMAP/Client/AppendStateMachine.swift
+++ b/Sources/NIOIMAP/Client/AppendStateMachine.swift
@@ -65,9 +65,17 @@ extension ClientStateMachine {
             }
         }
 
-        // We don't expect any responses when appending other than the
-        // final tagged response.
+        // We don't expect any responses while appending other than
+        // 1. Untagged responses
+        // 2. The final tagged response.
         mutating func receiveResponse(_ response: Response) throws -> Bool {
+            switch response {
+            case .untagged:
+                return false
+            default:
+                break
+            }
+
             switch self.state {
             case .started, .waitingForAppendContinuationRequest, .sendingMessageBytes, .catenating,
                 .waitingForCatenateContinuationRequest, .sendingCatenateBytes, .finished:

--- a/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
+++ b/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
@@ -777,7 +777,7 @@ class IMAPClientHandlerTests: XCTestCase {
         XCTAssertNoThrow(try p7.wait())
     }
 
-    func testPromiseIsntLeakedOnUnexpectedResponse() {
+    func testPromiseIsNotLeakedOnUnexpectedResponse() {
         // We need to get into a state where we are
         // expecting a continuation, but actually
         // receive a response.


### PR DESCRIPTION
Fix receiving untagged responses during `APPEND`

### Motivation:

When uploading a message with `APPEND`, the server will send an untagged `* EXISTS` response — and is also allowed to send other so-called _unsolicited data_ as untagged responses. But the `ClientStateMachine` would fail if it received untagged messages while in the _append_ state.

### Modifications:

Allow (i.e. ignore) any untagged responses while in the _append_ state.

Also fixed some typos in test names.

### Result:

Can `APPEND` messages.
