### PR TITLE
Pass response parser options into IMAPClientHandler.init

### DIFF
--- a/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
@@ -38,11 +38,14 @@ public final class IMAPClientHandler: ChannelDuplexHandler {
     private var state: ClientStateMachine
 
     public init(
-        encodingOptions: EncodingOptions = .automatic
+        encodingOptions: EncodingOptions = .automatic,
+        parserOptions: ResponseParser.Options = ResponseParser.Options()
     ) {
         self.state = .init(encodingOptions: encodingOptions)
         self.decoder = NIOSingleStepByteToMessageProcessor(
-            ResponseDecoder(),
+            ResponseDecoder(
+                options: parserOptions
+            ),
             maximumBufferSize: IMAPDefaults.lineLengthLimit
         )
     }

--- a/Sources/NIOIMAP/Coders/ResponseDecoder.swift
+++ b/Sources/NIOIMAP/Coders/ResponseDecoder.swift
@@ -20,8 +20,12 @@ struct ResponseDecoder: NIOSingleStepByteToMessageDecoder {
 
     var parser: ResponseParser
 
-    init() {
-        self.parser = ResponseParser()
+    init(
+        options: ResponseParser.Options = ResponseParser.Options()
+    ) {
+        self.parser = ResponseParser(
+            options: options
+        )
     }
 
     mutating func decode(buffer: inout ByteBuffer) throws -> InboundOut? {

--- a/Tests/NIOIMAPCoreTests/Parser/ResponseParser+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/ResponseParser+Tests.swift
@@ -1181,7 +1181,12 @@ extension ResponseParser_Tests {
     }
 
     func testAttributeLimit_failOnStreaming() {
-        var parser = ResponseParser(bufferLimit: 1000, messageAttributeLimit: 3)
+        var parser = ResponseParser(
+            options: ResponseParser.Options(
+                bufferLimit: 1000,
+                messageAttributeLimit: 3
+            )
+        )
         var buffer: ByteBuffer = "* 999 FETCH (FLAGS (\\Seen) UID 1 RFC822.SIZE 123 RFC822.TEXT {3}\r\n "
 
         // limit is 3, so let's parse the first 3
@@ -1203,7 +1208,12 @@ extension ResponseParser_Tests {
     }
 
     func testAttributeLimit_failOnSimple() {
-        var parser = ResponseParser(bufferLimit: 1000, messageAttributeLimit: 3)
+        var parser = ResponseParser(
+            options: ResponseParser.Options(
+                bufferLimit: 1000,
+                messageAttributeLimit: 3
+            )
+        )
         var buffer: ByteBuffer = "* 999 FETCH (FLAGS (\\Seen) UID 1 RFC822.SIZE 123 UID 2 "
 
         // limit is 3, so let's parse the first 3
@@ -1225,7 +1235,12 @@ extension ResponseParser_Tests {
     }
 
     func testRejectLargeBodies() {
-        var parser = ResponseParser(bufferLimit: 1000, bodySizeLimit: 10)
+        var parser = ResponseParser(
+            options: ResponseParser.Options(
+                bufferLimit: 1000,
+                bodySizeLimit: 10
+            )
+        )
         var buffer: ByteBuffer = "* 999 FETCH (RFC822.TEXT {3}\r\n123 RFC822.HEADER {11}\r\n "
         XCTAssertEqual(try parser.parseResponseStream(buffer: &buffer), .response(.fetch(.start(999))))
         XCTAssertEqual(
@@ -1241,7 +1256,12 @@ extension ResponseParser_Tests {
     }
 
     func testParseNoStringCache() {
-        var parser = ResponseParser(bufferLimit: 1000, bodySizeLimit: 10)
+        var parser = ResponseParser(
+            options: ResponseParser.Options(
+                bufferLimit: 1000,
+                bodySizeLimit: 10
+            )
+        )
         var buffer: ByteBuffer = "* 999 FETCH (FLAGS (\\Seen))\r\n"
         XCTAssertEqual(try parser.parseResponseStream(buffer: &buffer), .response(.fetch(.start(999))))
         XCTAssertEqual(
@@ -1254,12 +1274,16 @@ extension ResponseParser_Tests {
     // which will replace it with "nees", and therefore our
     // parse result should contain the flag "nees".
     func testParseWithStringCache() {
-        func testCache(string: String) -> String {
-            XCTAssertEqual(string.lowercased(), "seen")
-            return "nees"
-        }
-
-        var parser = ResponseParser(bufferLimit: 1000, bodySizeLimit: 10, parsedStringCache: testCache)
+        var parser = ResponseParser(
+            options: ResponseParser.Options(
+                bufferLimit: 1000,
+                bodySizeLimit: 10,
+                parsedStringCache: { string in
+                    XCTAssertEqual(string.lowercased(), "seen")
+                    return "nees"
+                }
+            )
+        )
         var buffer: ByteBuffer = "* 999 FETCH (FLAGS (\\Seen))\r\n"
         XCTAssertEqual(try parser.parseResponseStream(buffer: &buffer), .response(.fetch(.start(999))))
         XCTAssertEqual(
@@ -1271,7 +1295,13 @@ extension ResponseParser_Tests {
     // Even with a `literalSizeLimit` of 1 parsing a RFC822.TEXT should _not_ fail
     // if the `bodySizeLimit` is large enough.
     func testSeparateLiteralSizeLimit() {
-        var parser = ResponseParser(bufferLimit: 1000, bodySizeLimit: 10, literalSizeLimit: 1)
+        var parser = ResponseParser(
+            options: ResponseParser.Options(
+                bufferLimit: 1000,
+                bodySizeLimit: 10,
+                literalSizeLimit: 1
+            )
+        )
         var buffer: ByteBuffer = "* 999 FETCH (RFC822.TEXT {3}\r\n123 RFC822.HEADER {11}\r\n "
         XCTAssertEqual(try parser.parseResponseStream(buffer: &buffer), .response(.fetch(.start(999))))
         XCTAssertEqual(


### PR DESCRIPTION
Pass response parser options into `IMAPClientHandler.init`

### Motivation:

When using the `IMAPClientHandler`, there previously was no way to configure the `ResponseParser` it uses. This lead to #763

### Modifications:

Add `parserOptions: ResponseParser.Options` to `IMAPClientHandler.init`:
```swift
    public init(
        encodingOptions: EncodingOptions = .automatic,
        parserOptions: ResponseParser.Options = ResponseParser.Options()
    )
```

### Result:

Can now configure the `ResponseParser`. Fixes #763.