### PR TITLE
Add MessageIdentifierSet.suffix overload

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -463,17 +463,16 @@ extension MessageIdentifierSet {
         var result = MessageIdentifierSet()
         var resultCount = 0
         for range in ranges.reversed() {
-            if resultCount + range.range.count <= maxLength {
-                resultCount += range.range.count
-                result.formUnion(MessageIdentifierSet(range))
-                guard resultCount < maxLength else { break }
-            } else {
+            guard resultCount + range.range.count <= maxLength else {
                 let count = maxLength - resultCount
                 let tailRange = range.range.suffix(count)
                 let tail = MessageIdentifierRange(tailRange.first!...tailRange.last!)
                 result.formUnion(MessageIdentifierSet(tail))
                 break
             }
+            resultCount += range.range.count
+            result.formUnion(MessageIdentifierSet(range))
+            guard resultCount < maxLength else { break }
         }
         return result
     }

--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -453,6 +453,32 @@ extension MessageIdentifierSet: SetAlgebra {
     }
 }
 
+// MARK: - Suffix
+
+extension MessageIdentifierSet {
+    public func suffix(_ maxLength: Int) -> MessageIdentifierSet {
+        precondition(0 <= maxLength)
+        guard 0 < maxLength else { return MessageIdentifierSet() }
+
+        var result = MessageIdentifierSet()
+        var resultCount = 0
+        for range in ranges.reversed() {
+            if resultCount + range.range.count <= maxLength {
+                resultCount += range.range.count
+                result.formUnion(MessageIdentifierSet(range))
+                guard resultCount < maxLength else { break }
+            } else {
+                let count = maxLength - resultCount
+                let tailRange = range.range.suffix(count)
+                let tail = MessageIdentifierRange(tailRange.first!...tailRange.last!)
+                result.formUnion(MessageIdentifierSet(tail))
+                break
+            }
+        }
+        return result
+    }
+}
+
 // MARK: - Conversion
 
 extension MessageIdentifierSet where IdentifierType == SequenceNumber {

--- a/Tests/NIOIMAPCoreTests/Grammar/MessageIdentifierSet+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/MessageIdentifierSet+Tests.swift
@@ -32,4 +32,33 @@ extension MessageIdentifierSet_Tests {
         let output = MessageIdentifierSet<UID>(input)
         XCTAssertEqual(output, [1...5, 10...15, 20...30])
     }
+
+    func testSuffix() {
+        XCTAssertEqual(UIDSet().suffix(0), [])
+        XCTAssertEqual(UIDSet([1]).suffix(0), [])
+        XCTAssertEqual(UIDSet([100, 200]).suffix(0), [])
+
+        XCTAssertEqual(UIDSet([100, 200]).suffix(1), [200])
+        XCTAssertEqual(UIDSet([100, 200]).suffix(2), [100, 200])
+        XCTAssertEqual(UIDSet([100, 200]).suffix(3), [100, 200])
+
+        XCTAssertEqual(UIDSet([200...299]).suffix(0), [])
+        XCTAssertEqual(UIDSet([200...299]).suffix(1), [299])
+        XCTAssertEqual(UIDSet([200...299]).suffix(2), [298...299])
+        XCTAssertEqual(UIDSet([200...299]).suffix(3), [297...299])
+
+        XCTAssertEqual(UIDSet([100, 200...299]).suffix(0), [])
+        XCTAssertEqual(UIDSet([100, 200...299]).suffix(1), [299])
+        XCTAssertEqual(UIDSet([100, 200...299]).suffix(2), [298...299])
+        XCTAssertEqual(UIDSet([100, 200...299]).suffix(3), [297...299])
+
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(0), [])
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(1), [202])
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(2), [201...202])
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(3), [200...202])
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(4), [102, 200...202])
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(5), [101...102, 200...202])
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(6), [100...102, 200...202])
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(7), [100...102, 200...202])
+    }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/MessageIdentifierSet+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/MessageIdentifierSet+Tests.swift
@@ -34,31 +34,31 @@ extension MessageIdentifierSet_Tests {
     }
 
     func testSuffix() {
-        XCTAssertEqual(UIDSet().suffix(0), [])
-        XCTAssertEqual(UIDSet([1]).suffix(0), [])
-        XCTAssertEqual(UIDSet([100, 200]).suffix(0), [])
+        XCTAssertEqual(UIDSet().suffix(0), UIDSet())
+        XCTAssertEqual(UIDSet([1]).suffix(0), UIDSet())
+        XCTAssertEqual(UIDSet([100, 200]).suffix(0), UIDSet())
 
-        XCTAssertEqual(UIDSet([100, 200]).suffix(1), [200])
-        XCTAssertEqual(UIDSet([100, 200]).suffix(2), [100, 200])
-        XCTAssertEqual(UIDSet([100, 200]).suffix(3), [100, 200])
+        XCTAssertEqual(UIDSet([100, 200]).suffix(1), UIDSet([200]))
+        XCTAssertEqual(UIDSet([100, 200]).suffix(2), UIDSet([100, 200]))
+        XCTAssertEqual(UIDSet([100, 200]).suffix(3), UIDSet([100, 200]))
 
-        XCTAssertEqual(UIDSet([200...299]).suffix(0), [])
-        XCTAssertEqual(UIDSet([200...299]).suffix(1), [299])
-        XCTAssertEqual(UIDSet([200...299]).suffix(2), [298...299])
-        XCTAssertEqual(UIDSet([200...299]).suffix(3), [297...299])
+        XCTAssertEqual(UIDSet([200...299]).suffix(0), UIDSet())
+        XCTAssertEqual(UIDSet([200...299]).suffix(1), UIDSet([299]))
+        XCTAssertEqual(UIDSet([200...299]).suffix(2), UIDSet([298...299]))
+        XCTAssertEqual(UIDSet([200...299]).suffix(3), UIDSet([297...299]))
 
-        XCTAssertEqual(UIDSet([100, 200...299]).suffix(0), [])
-        XCTAssertEqual(UIDSet([100, 200...299]).suffix(1), [299])
-        XCTAssertEqual(UIDSet([100, 200...299]).suffix(2), [298...299])
-        XCTAssertEqual(UIDSet([100, 200...299]).suffix(3), [297...299])
+        XCTAssertEqual(UIDSet([100, 200...299]).suffix(0), UIDSet())
+        XCTAssertEqual(UIDSet([100, 200...299]).suffix(1), UIDSet([299]))
+        XCTAssertEqual(UIDSet([100, 200...299]).suffix(2), UIDSet([298...299]))
+        XCTAssertEqual(UIDSet([100, 200...299]).suffix(3), UIDSet([297...299]))
 
-        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(0), [])
-        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(1), [202])
-        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(2), [201...202])
-        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(3), [200...202])
-        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(4), [102, 200...202])
-        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(5), [101...102, 200...202])
-        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(6), [100...102, 200...202])
-        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(7), [100...102, 200...202])
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(0), UIDSet())
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(1), UIDSet([202]))
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(2), UIDSet([201...202]))
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(3), UIDSet([200...202]))
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(4), UIDSet([102, 200...202]))
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(5), UIDSet([101...102, 200...202]))
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(6), UIDSet([100...102, 200...202]))
+        XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(7), UIDSet([100...102, 200...202]))
     }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/MessageIdentifierSet+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/MessageIdentifierSet+Tests.swift
@@ -60,5 +60,9 @@ extension MessageIdentifierSet_Tests {
         XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(5), UIDSet([101...102, 200...202]))
         XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(6), UIDSet([100...102, 200...202]))
         XCTAssertEqual(UIDSet([100...102, 200...202]).suffix(7), UIDSet([100...102, 200...202]))
+
+        XCTAssertEqual(UIDSet.all.suffix(0), UIDSet())
+        XCTAssertEqual(UIDSet.all.suffix(1), UIDSet([4_294_967_295]))
+        XCTAssertEqual(UIDSet.all.suffix(2), UIDSet([4_294_967_294...4_294_967_295]))
     }
 }


### PR DESCRIPTION
Add `MessageIdentifierSet.suffix` overload

### Motivation:

This is a fairly common operation when dealing with UIDs, and since `MessageIdentifierSet` is backed by `RangeSet`, we can do this more efficiently than the default implementation.

### Modifications:

Adds `MessageIdentifierSet.suffix` and tests.

