### PR TITLE
Rename → IMAPClientHandler.Message

### DIFF
--- a/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
@@ -24,14 +24,17 @@ public final class IMAPClientHandler: ChannelDuplexHandler {
     /// Converts a `ByteBuffer` into a `Response` by sending data through a parser.
     public typealias InboundOut = Response
 
-    /// Commands are encoding into a ByteBuffer to send to a server.
-    public enum OutboundIn: Hashable, Sendable {
-        case part(CommandStreamPart)
-        case setEncodingOptions(EncodingOptions)
-    }
+    /// Either `CommandStreamPart` or options.
+    public typealias OutboundIn = Message
 
     /// After encoding the bytes may be sent further through the channel to, for example, a TLS handler.
     public typealias OutboundOut = ByteBuffer
+
+    /// We can receive either `CommandStreamPart` or `EncodingOptions`.
+    public enum Message: Hashable, Sendable {
+        case part(CommandStreamPart)
+        case setEncodingOptions(EncodingOptions)
+    }
 
     private let decoder: NIOSingleStepByteToMessageProcessor<ResponseDecoder>
 

--- a/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
+++ b/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
@@ -594,7 +594,7 @@ class IMAPClientHandlerTests: XCTestCase {
         class PostTestHandler: ChannelDuplexHandler {
             typealias InboundIn = Response
             typealias OutboundIn = Response
-            typealias OutboundOut = IMAPClientHandler.OutboundIn
+            typealias OutboundOut = IMAPClientHandler.Message
 
             var callCount = 0
 
@@ -712,7 +712,7 @@ class IMAPClientHandlerTests: XCTestCase {
 
         // writing a command that has a continuation
         let future = self.channel.writeAndFlush(
-            IMAPClientHandler.OutboundIn.part(
+            IMAPClientHandler.Message.part(
                 CommandStreamPart.tagged(
                     .init(tag: "A1", command: .rename(from: .init("\\"), to: .init("\\"), parameters: [:]))
                 )
@@ -858,7 +858,7 @@ extension IMAPClientHandlerTests {
 
     @discardableResult
     private func writeOutbound(
-        _ outboundIn: IMAPClientHandler.OutboundIn,
+        _ outboundIn: IMAPClientHandler.Message,
         wait: Bool = true,
         line: UInt = #line
     ) -> EventLoopFuture<Void> {


### PR DESCRIPTION
_[One line description of your change]_

### Motivation:

Pick as better name — as discussed in #788

### Modifications:

Basically
```diff
- public enum OutboundIn: Hashable, Sendable { … }
+ public typealias OutboundIn = Message
+ public enum Message: Hashable, Sendable { … }
```
