### PR TITLE
Improve (pre-calculated) hash of MailboxName

### DIFF
--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxName+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxName+Tests.swift
@@ -193,10 +193,10 @@ extension MailboxName_Tests {
             return countBits(ma.hashValue ^ mb.hashValue)
         }
 
-        XCTAssertGreaterThanOrEqual(countChangedBits("A", "B"), 18)
-        XCTAssertGreaterThanOrEqual(countChangedBits("A", "AA"), 18)
-        XCTAssertGreaterThanOrEqual(countChangedBits("INBOX", "Drafts"), 18)
-        XCTAssertGreaterThanOrEqual(countChangedBits("Sent", "Drafts"), 18)
-        XCTAssertGreaterThanOrEqual(countChangedBits("Sent", "sent"), 18)
+        XCTAssertGreaterThanOrEqual(countChangedBits("A", "B"), 25)
+        XCTAssertGreaterThanOrEqual(countChangedBits("A", "AA"), 25)
+        XCTAssertGreaterThanOrEqual(countChangedBits("INBOX", "Drafts"), 25)
+        XCTAssertGreaterThanOrEqual(countChangedBits("Sent", "Drafts"), 25)
+        XCTAssertGreaterThanOrEqual(countChangedBits("Sent", "sent"), 25)
     }
 }


### PR DESCRIPTION
Improve (pre-calculated) hash of MailboxName

### Motivation:

We precalculate `MailboxName`’s `hash` as per #696 — but the quality wasn’t good and caused the `testHashValue()` test to fail on some platforms.

### Modifications:

This picks up the 64 bit MurMur3 and uses it to derive a 32 bit value for the hash.

MurMur code is here → https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp

The implementation isn’t particularly optimized. But the entire point of #696 is that this only gets calculated once.

### Result:

Better hash value. Tests are no longer failing.