### PR TITLE
Use quoted strings even when they contain REVERSE SOLIDUS or QUOTATION MARK

### DIFF
--- a/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
@@ -69,8 +69,8 @@ class EncodeTestClass: XCTestCase {
             )
             do {
                 let size = try encoder(test)
-                XCTAssertEqual(size, expectedStrings.reduce(0) { $0 + $1.utf8.count }, file: (file), line: line)
-                XCTAssertEqual(self.testBufferStrings, expectedStrings, file: (file), line: line)
+                XCTAssertEqual(size, expectedStrings.reduce(0) { $0 + $1.utf8.count }, "Expected byte count", file: (file), line: line)
+                XCTAssertEqual(self.testBufferStrings, expectedStrings, "Expected strings", file: (file), line: line)
             } catch {
                 XCTFail("\(error)", file: (file), line: line)
             }


### PR DESCRIPTION
Use quoted strings even when they contain `REVERSE SOLIDUS` or `QUOTATION MARK`

### Motivation:

This is most more (space) efficient, but also easier to read. And when the server doesn’t support `LITERAL+` we’ll avoid extra round-trips.

Also: some Microsoft servers don’t like using `LITERAL+` with the `LOGIN` command when the username has a `\` (aka. `REVERSE SOLIDUS`).

### Modifications:

- [x] Updated string encoding logic.
- [x] Updated tests.

### Result:

A string such as `a\b` will now get encoded as `"a\\b"` (i.e. use _quoted_ encoding) instead of using a literal format such as `{3+}␍␊a\b`.