### PR TITLE
Allow receiving untagged responses while appending

### DIFF
--- a/Sources/NIOIMAP/Client/AuthenticationStateMachine.swift
+++ b/Sources/NIOIMAP/Client/AuthenticationStateMachine.swift
@@ -37,8 +37,10 @@ extension ClientStateMachine {
 
         mutating func receiveResponse(_ response: Response) throws {
             switch self.state {
-            case .finished, .waitingForChallengeResponse:
-                throw UnexpectedResponse(activePromise: nil)
+            case .finished:
+                throw UnexpectedResponse(kind: .authenticationFinished)
+            case .waitingForChallengeResponse:
+                throw UnexpectedResponse(kind: .authenticationWaitingForChallengeResponse)
             case .waitingForServer:
                 break
             }
@@ -63,7 +65,7 @@ extension ClientStateMachine {
 
             switch response {
             case .fetch, .fatal, .idleStarted, .authenticationChallenge:
-                throw UnexpectedResponse(activePromise: nil)
+                throw UnexpectedResponse(kind: .authentication)
             case .untagged:
                 // Ignore
                 break
@@ -75,7 +77,7 @@ extension ClientStateMachine {
         mutating func receiveContinuationRequest(_: ContinuationRequest) throws {
             switch self.state {
             case .finished, .waitingForChallengeResponse:
-                throw UnexpectedResponse(activePromise: nil)
+                throw UnexpectedContinuationRequest(kind: .authentication)
             case .waitingForServer:
                 break
             }

--- a/Sources/NIOIMAP/Client/IdleStateMachine.swift
+++ b/Sources/NIOIMAP/Client/IdleStateMachine.swift
@@ -46,7 +46,8 @@ extension ClientStateMachine {
         mutating func receiveResponse(_ response: Response) throws {
             switch self.state {
             case .waitingForConfirmation:
-                throw UnexpectedResponse(activePromise: nil)
+                // TODO: should ignore this
+                throw UnexpectedResponse(kind: .idleWaitingForConfirmation)
             case .idling:
                 try self.receiveResponse_idlingState(response)
             }
@@ -57,7 +58,7 @@ extension ClientStateMachine {
             case .waitingForConfirmation:
                 self.state = .idling
             case .idling:
-                throw UnexpectedContinuationRequest()
+                throw UnexpectedContinuationRequest(kind: .idle)
             }
         }
 
@@ -67,7 +68,7 @@ extension ClientStateMachine {
             case .untagged, .fetch:
                 break
             case .tagged, .fatal, .authenticationChallenge, .idleStarted:
-                throw UnexpectedResponse(activePromise: nil)
+                throw UnexpectedResponse(kind: .idleRunning)
             }
         }
     }

--- a/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
@@ -89,7 +89,8 @@ class EncodeTestClass: XCTestCase {
                 XCTAssertEqual(
                     size,
                     expectedStrings.reduce(0) { $0 + $1.utf8.count },
-                    file: (file), line: line
+                    file: file,
+                    line: line
                 )
                 XCTAssertEqual(self.testBufferStrings, expectedStrings, file: (file), line: line)
             } catch {

--- a/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
@@ -86,7 +86,11 @@ class EncodeTestClass: XCTestCase {
             do {
                 self.testBuffer.mode = .client(options: options)
                 let size = try encoder(test)
-                XCTAssertEqual(size, expectedStrings.reduce(0) { $0 + $1.utf8.count }, file: (file), line: line)
+                XCTAssertEqual(
+                    size,
+                    expectedStrings.reduce(0) { $0 + $1.utf8.count },
+                    file: (file), line: line
+                )
                 XCTAssertEqual(self.testBufferStrings, expectedStrings, file: (file), line: line)
             } catch {
                 XCTFail("\(error)", file: (file), line: line)

--- a/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/EncodeTestClass.swift
@@ -69,7 +69,13 @@ class EncodeTestClass: XCTestCase {
             )
             do {
                 let size = try encoder(test)
-                XCTAssertEqual(size, expectedStrings.reduce(0) { $0 + $1.utf8.count }, "Expected byte count", file: (file), line: line)
+                XCTAssertEqual(
+                    size,
+                    expectedStrings.reduce(0) { $0 + $1.utf8.count },
+                    "Expected byte count",
+                    file: file,
+                    line: line
+                )
                 XCTAssertEqual(self.testBufferStrings, expectedStrings, "Expected strings", file: (file), line: line)
             } catch {
                 XCTFail("\(error)", file: (file), line: line)
@@ -89,6 +95,7 @@ class EncodeTestClass: XCTestCase {
                 XCTAssertEqual(
                     size,
                     expectedStrings.reduce(0) { $0 + $1.utf8.count },
+                    "Expected byte count",
                     file: file,
                     line: line
                 )

--- a/Tests/NIOIMAPTests/Client/AppendStateMachineTests.swift
+++ b/Tests/NIOIMAPTests/Client/AppendStateMachineTests.swift
@@ -20,41 +20,127 @@ class AppendStateMachineTests: XCTestCase {
     var stateMachine: ClientStateMachine.Append!
 
     override func setUp() {
-        self.stateMachine = .init()
+        self.stateMachine = .init(tag: "A1")
     }
 
     func testNormalWorkflow() {
         // append a message
-        XCTAssertTrue(
-            self.stateMachine.sendCommand(
-                .append(.beginMessage(message: .init(options: .init(), data: .init(byteCount: 10))))
-            )
+        self.stateMachine.sendCommand(
+            .append(.beginMessage(message: .init(options: .init(), data: .init(byteCount: 10))))
         )
-        XCTAssertNoThrow(try self.stateMachine.receiveContinuationRequest(.data("req")))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.messageBytes("12345"))))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.messageBytes("67890"))))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.endMessage)))
+        XCTAssert(self.stateMachine.isWaitingForContinuationRequest)
 
-        // catenate a message
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.beginCatenate(options: .init()))))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.catenateURL("url1"))))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.catenateURL("url2"))))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.catenateURL("url3"))))
-        XCTAssertTrue(self.stateMachine.sendCommand(.append(.catenateData(.begin(size: 10)))))
         XCTAssertNoThrow(try self.stateMachine.receiveContinuationRequest(.data("req")))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.catenateData(.bytes("12345")))))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.catenateData(.bytes("67890")))))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.catenateData(.end))))
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.endCatenate)))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
 
-        XCTAssertFalse(self.stateMachine.sendCommand(.append(.finish)))
+        self.stateMachine.sendCommand(.append(.messageBytes("12345")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.messageBytes("67890")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.endMessage))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.finish))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
         XCTAssertNoThrow(
             XCTAssertEqual(
                 try self.stateMachine.receiveResponse(
                     .tagged(.init(tag: "A1", state: .ok(.init(code: nil, text: "OK"))))
                 ),
-                true
+                .doneAppending
             )
         )
+    }
+
+    func testNormalWorkflow_catenate() {
+        // append a message
+        self.stateMachine.sendCommand(
+            .append(.beginMessage(message: .init(options: .init(), data: .init(byteCount: 10))))
+        )
+        XCTAssert(self.stateMachine.isWaitingForContinuationRequest)
+
+        XCTAssertNoThrow(try self.stateMachine.receiveContinuationRequest(.data("req")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        // “Normal”
+        self.stateMachine.sendCommand(.append(.messageBytes("12345")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.messageBytes("67890")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.endMessage))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        // Catenate
+        self.stateMachine.sendCommand(.append(.beginCatenate(options: .init())))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.catenateURL("url1")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.catenateURL("url2")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.catenateURL("url3")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.catenateData(.begin(size: 10))))
+        XCTAssert(self.stateMachine.isWaitingForContinuationRequest)
+
+        XCTAssertNoThrow(try self.stateMachine.receiveContinuationRequest(.data("req")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.catenateData(.bytes("12345"))))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.catenateData(.bytes("67890"))))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.catenateData(.end)))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.endCatenate))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        self.stateMachine.sendCommand(.append(.finish))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
+
+        XCTAssertNoThrow(
+            XCTAssertEqual(
+                try self.stateMachine.receiveResponse(
+                    .tagged(.init(tag: "A1", state: .ok(.init(code: nil, text: "OK"))))
+                ),
+                .doneAppending
+            )
+        )
+    }
+
+    func testReceivingUntaggedWhileWaitingForContinuationRequest() throws {
+        // append a message
+        self.stateMachine.sendCommand(
+            .append(.beginMessage(message: .init(options: .init(), data: .init(byteCount: 10))))
+        )
+        XCTAssert(self.stateMachine.isWaitingForContinuationRequest)
+
+        // At this point, we’re waiting for a Continuation Request from the server.
+        // But we may end up getting an untagged response first.
+        // ```
+        // C: A003 APPEND saved-messages (\Seen) {310}
+        // S: * 3 EXPUNGE
+        // S: + Ready for literal data
+        // C: Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
+        // C: From: Fred Foobar <foobar@Blurdybloop.COM>
+        // ``
+
+        XCTAssertNoThrow(
+            try self.stateMachine.receiveResponse(.untagged(.messageData(.expunge(3)))),
+            "Should be ignored."
+        )
+        XCTAssertNoThrow(try self.stateMachine.receiveContinuationRequest(.data("req")))
+        XCTAssertFalse(self.stateMachine.isWaitingForContinuationRequest)
     }
 }

--- a/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
+++ b/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
@@ -247,7 +247,7 @@ class ClientStateMachineTests: XCTestCase {
         // ```
 
         XCTAssertThrowsError(
-            try self.stateMachine.receiveResponse(.tagged(.init(tag: "A1", state: .ok(.init(text: "Completed"))))),
+            try self.stateMachine.receiveResponse(.tagged(.init(tag: "A1", state: .ok(.init(text: "Completed")))))
         )
     }
 }

--- a/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
+++ b/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
@@ -158,6 +158,98 @@ class ClientStateMachineTests: XCTestCase {
             XCTAssertTrue(e is DuplicateCommandTag)
         }
     }
+
+    func testReceivingUntaggedWhileExpectingLiteralContinuationRequest() {
+        let command = TaggedCommand(tag: "A1", command: .select(MailboxName(ByteBuffer(string: "äÿ")), []))
+
+        var result1: OutgoingChunk?
+        XCTAssertNoThrow(result1 = try self.stateMachine.sendCommand(.tagged(command)))
+        XCTAssertEqual(result1!.bytes, "A1 SELECT {4}\r\n")
+
+        // At this point, we’re waiting for a Continuation Request from the server.
+        // But we may end up getting an untagged response first.
+        // ```
+        // C: A1 SELECT {4}
+        // S: * 3 EXPUNGE
+        // S: + Ready for literal data
+        // C: äÿ
+        // ```
+
+        XCTAssertNoThrow(
+            try self.stateMachine.receiveResponse(.untagged(.messageData(.expunge(3)))),
+            "Should be ignored."
+        )
+        var resultAction: ClientStateMachine.ContinuationRequestAction!
+        XCTAssertNoThrow(
+            resultAction = try self.stateMachine.receiveContinuationRequest(.data("Ready for literal data"))
+        )
+        XCTAssertEqual(
+            resultAction,
+            .sendChunks([
+                .init(bytes: "äÿ\r\n", promise: nil, shouldSucceedPromise: true)
+            ])
+        )
+    }
+
+    func testReceivingTaggedWhileExpectingLiteralContinuationRequest() {
+        var result: OutgoingChunk?
+
+        // Send a command that we can complete later:
+        XCTAssertNoThrow(
+            result = try self.stateMachine.sendCommand(.tagged(.init(tag: "B2", command: .expunge)))
+        )
+        XCTAssertEqual(result!.bytes, "B2 EXPUNGE\r\n")
+
+        // Now send a command that will drop us into “expecting literal Continuation Request”:
+        let command = TaggedCommand(tag: "A1", command: .select(MailboxName(ByteBuffer(string: "äÿ")), []))
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.tagged(command)))
+        XCTAssertEqual(result!.bytes, "A1 SELECT {4}\r\n")
+
+        // At this point, we’re waiting for a Continuation Request from the server.
+        // But we may end up getting a (tagged) command completion first:
+        // ```
+        // C: A1 SELECT {4}
+        // S: B2 OK EXPUNGE completed
+        // S: + Ready for literal data
+        // C: äÿ
+        // ```
+
+        XCTAssertNoThrow(
+            try self.stateMachine.receiveResponse(
+                .tagged(.init(tag: "B2", state: .ok(.init(text: "EXPUNGE completed"))))
+            ),
+            "Should be ignored"
+        )
+        var resultAction: ClientStateMachine.ContinuationRequestAction!
+        XCTAssertNoThrow(
+            resultAction = try self.stateMachine.receiveContinuationRequest(.data("Ready for literal data"))
+        )
+        XCTAssertEqual(
+            resultAction,
+            .sendChunks([
+                .init(bytes: "äÿ\r\n", promise: nil, shouldSucceedPromise: true)
+            ])
+        )
+    }
+
+    func testReceivingTaggedForCurrentCommandWhileExpectingLiteralContinuationRequest() {
+        var result: OutgoingChunk?
+
+        // Send a command that will drop us into “expecting literal Continuation Request”:
+        let command = TaggedCommand(tag: "A1", command: .select(MailboxName(ByteBuffer(string: "äÿ")), []))
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.tagged(command)))
+        XCTAssertEqual(result!.bytes, "A1 SELECT {4}\r\n")
+
+        // If we receive a (tagged) completion for the current command, we need to throw an error:
+        // ```
+        // C: A1 SELECT {4}
+        // S: A1 OK Completed
+        // ```
+
+        XCTAssertThrowsError(
+            try self.stateMachine.receiveResponse(.tagged(.init(tag: "A1", state: .ok(.init(text: "Completed"))))),
+        )
+    }
 }
 
 // MARK: - IDLE
@@ -435,6 +527,8 @@ extension ClientStateMachineTests {
         )
         XCTAssertEqual(result, .init(bytes: " {5}\r\n", promise: nil, shouldSucceedPromise: true))
 
+        // We’ll now enqueue a lot of CommandStreamPart that can’t be sent onto the wire, yet,
+        // because we’re still waiting for the Continuation Request from the server:
         XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.messageBytes("0"))))
         XCTAssertNil(result)
         XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.messageBytes("1"))))
@@ -451,9 +545,11 @@ extension ClientStateMachineTests {
         XCTAssertNil(result)
         self.stateMachine.flush()
 
+        // Now the Continuation Request comes in:
         var resultAction: ClientStateMachine.ContinuationRequestAction!
         XCTAssertNoThrow(resultAction = try self.stateMachine.receiveContinuationRequest(.data("OK")))
 
+        // We should send the pending chunks at this point:
         XCTAssertEqual(
             resultAction,
             .sendChunks([
@@ -466,6 +562,128 @@ extension ClientStateMachineTests {
                 .init(bytes: "\r\n", promise: nil, shouldSucceedPromise: true),
             ])
         )
+
+        // Complete the APPEND command:
+        XCTAssertNoThrow(try self.stateMachine.receiveResponse(.tagged(.init(tag: "A1", state: .ok(.init(text: ""))))))
+
+        guard
+            case .expectingNormalResponse = self.stateMachine.state
+        else {
+            XCTFail("\(self.stateMachine.state)")
+            return
+        }
+    }
+
+    func testAppendReceivingUntaggedWhileWaitingForContinuationRequest() {
+        var result: OutgoingChunk?
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.start(tag: "A1", appendingTo: .inbox))))
+        XCTAssertEqual(result, .init(bytes: "A1 APPEND \"INBOX\"", promise: nil, shouldSucceedPromise: true))
+
+        XCTAssertNoThrow(
+            result = try self.stateMachine.sendCommand(
+                .append(.beginMessage(message: .init(options: .none, data: .init(byteCount: 6))))
+            )
+        )
+        XCTAssertEqual(result, .init(bytes: " {6}\r\n", promise: nil, shouldSucceedPromise: true))
+
+        // At this point, we’re waiting for a Continuation Request from the server.
+        // But we may end up getting an untagged response first.
+        // ```
+        // C: A003 APPEND saved-messages (\Seen) {5}
+        // S: * 3 EXPUNGE
+        // S: + Ready for literal data
+        // C: foobar
+        // ```
+
+        XCTAssertNoThrow(
+            try self.stateMachine.receiveResponse(.untagged(.messageData(.expunge(3)))),
+            "Should be ignored."
+        )
+        var resultAction: ClientStateMachine.ContinuationRequestAction!
+        XCTAssertNoThrow(
+            resultAction = try self.stateMachine.receiveContinuationRequest(.data("Ready for literal data"))
+        )
+        XCTAssertEqual(resultAction, .sendChunks([]))
+
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.messageBytes("foobar"))))
+        XCTAssertEqual(result, .init(bytes: "foobar", promise: nil, shouldSucceedPromise: true))
+
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.endMessage)))
+        XCTAssertEqual(result, .init(bytes: "", promise: nil, shouldSucceedPromise: true))
+
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.finish)))
+        XCTAssertEqual(result, .init(bytes: "\r\n", promise: nil, shouldSucceedPromise: true))
+
+        // Complete the APPEND command:
+        XCTAssertNoThrow(try self.stateMachine.receiveResponse(.tagged(.init(tag: "A1", state: .ok(.init(text: ""))))))
+
+        guard
+            case .expectingNormalResponse = self.stateMachine.state
+        else {
+            XCTFail("\(self.stateMachine.state)")
+            return
+        }
+    }
+
+    func testAppendReceivingTtaggedWhileWaitingForContinuationRequest() {
+        var result: OutgoingChunk?
+
+        // Send a command that we can complete later:
+        XCTAssertNoThrow(
+            result = try self.stateMachine.sendCommand(.tagged(.init(tag: "B2", command: .expunge)))
+        )
+        XCTAssertEqual(result!.bytes, "B2 EXPUNGE\r\n")
+
+        // Now send the APPEND:
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.start(tag: "A1", appendingTo: .inbox))))
+        XCTAssertEqual(result, .init(bytes: "A1 APPEND \"INBOX\"", promise: nil, shouldSucceedPromise: true))
+
+        XCTAssertNoThrow(
+            result = try self.stateMachine.sendCommand(
+                .append(.beginMessage(message: .init(options: .none, data: .init(byteCount: 6))))
+            )
+        )
+        XCTAssertEqual(result, .init(bytes: " {6}\r\n", promise: nil, shouldSucceedPromise: true))
+
+        // At this point, we’re waiting for a Continuation Request from the server.
+        // But we may end up getting an untagged response first.
+        // ```
+        // C: A003 APPEND saved-messages (\Seen) {5}
+        // S: B2 OK EXPUNGE completed
+        // S: + Ready for literal data
+        // C: foobar
+        // ```
+
+        XCTAssertNoThrow(
+            try self.stateMachine.receiveResponse(
+                .tagged(.init(tag: "B2", state: .ok(.init(text: "EXPUNGE completed"))))
+            ),
+            "Should be ignored"
+        )
+        var resultAction: ClientStateMachine.ContinuationRequestAction!
+        XCTAssertNoThrow(
+            resultAction = try self.stateMachine.receiveContinuationRequest(.data("Ready for literal data"))
+        )
+        XCTAssertEqual(resultAction, .sendChunks([]))
+
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.messageBytes("foobar"))))
+        XCTAssertEqual(result, .init(bytes: "foobar", promise: nil, shouldSucceedPromise: true))
+
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.endMessage)))
+        XCTAssertEqual(result, .init(bytes: "", promise: nil, shouldSucceedPromise: true))
+
+        XCTAssertNoThrow(result = try self.stateMachine.sendCommand(.append(.finish)))
+        XCTAssertEqual(result, .init(bytes: "\r\n", promise: nil, shouldSucceedPromise: true))
+
+        // Complete the APPEND command:
+        XCTAssertNoThrow(try self.stateMachine.receiveResponse(.tagged(.init(tag: "A1", state: .ok(.init(text: ""))))))
+
+        guard
+            case .expectingNormalResponse = self.stateMachine.state
+        else {
+            XCTFail("\(self.stateMachine.state)")
+            return
+        }
     }
 
     func testSendingAnAuthenticationChallengeWhenUnexpectedThrows() {


### PR DESCRIPTION
Allow receiving untagged responses while running `APPEND` command.

### Motivation:

[Section 7.5 “ Server Responses - Command Continuation Request” of RFC 3501](https://www.rfc-editor.org/rfc/rfc3501#section-7.5) show this example of how literals and _ command continuation requests_ work:
```text
C: A001 LOGIN {11}
S: + Ready for additional command text
C: FRED FOOBAR {7}
S: + Ready for additional command text
C: fat man
S: A001 OK LOGIN completed
```

The problem is that when the client sends a command such as
```text
C: A50 SELECT {11}
```
the server may already have enqueued untagged responses. And while the client _has_ to wait for the server’s _ Continuation Request_, it must also allow untagged (and tagged) responses from the server.

For example:
```text
C: A50 SELECT {6}
S: * EXPUNGE 5
S: + Ready for additional command text
C: foobar
```

The `ClientStateMachine` needs to correctly allow for these.

Since the `ClientStateMachine` handles `APPEND` through the `ClientStateMachine.Append` sub-state, this needs to handle such responses from the server, too.

### Modifications:

Allow untagged and tagged responses while we wait for a Continuation Request.

Added and updated tests.

As the `ClientStateMachine` code (already) notes: The `ClientStateMachine` should really be split up into 2 parts: one that manages command logic, and another one that handles the continuation logic. This PR does not attempt to do that.

### Result:

`ClientStateMachine` can process untagged / tagged responses while waiting for a Continuation Request.
