### PR TITLE
Extract 64-bit raw value from ServerMessageDate. Better debugDescription.

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Date/InternalDate.swift
+++ b/Sources/NIOIMAPCore/Grammar/Date/InternalDate.swift
@@ -55,6 +55,12 @@ public struct ServerMessageDate: Hashable, Sendable {
         )!
     }
 
+    public init(
+        _ rawValue: UInt64
+    ) {
+        self.rawValue = rawValue
+    }
+
     /// Creates a new `ServerMessageDate` from a given collection of `Components`
     /// - parameter components: The components containing a year, month, day, hour, minute, second, and timezone.
     public init(_ components: Components) {
@@ -74,7 +80,21 @@ public struct ServerMessageDate: Hashable, Sendable {
         store(UInt8(components.month), 12)
         store(UInt8(components.day), 31)
 
-        self.rawValue = rawValue
+        self.init(rawValue)
+    }
+}
+
+extension UInt64 {
+    public init(_ other: ServerMessageDate) {
+        self = other.rawValue
+    }
+}
+
+extension ServerMessageDate: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        EncodeBuffer.makeDescription {
+            $0.writeInternalDate(self)
+        }
     }
 }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/DateTests/InternalDateTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/DateTests/InternalDateTests.swift
@@ -39,6 +39,7 @@ extension InternalDateTests {
         XCTAssertEqual(c.minute, 2)
         XCTAssertEqual(c.second, 3)
         XCTAssertEqual(c.zoneMinutes, 620)
+        XCTAssertEqual(String(reflecting: date), #""25-Jun-1994 01:02:03 +1020""#)
     }
 
     func testInternalDateInit_2() {
@@ -60,6 +61,7 @@ extension InternalDateTests {
         XCTAssertEqual(c.minute, 0)
         XCTAssertEqual(c.second, 0)
         XCTAssertEqual(c.zoneMinutes, -959)
+        XCTAssertEqual(String(reflecting: date), #""1-Jan-1900 00:00:00 -1559""#)
     }
 
     func testInternalDateInit_3() {
@@ -81,5 +83,6 @@ extension InternalDateTests {
         XCTAssertEqual(c.minute, 59)
         XCTAssertEqual(c.second, 59)
         XCTAssertEqual(c.zoneMinutes, 959)
+        XCTAssertEqual(String(reflecting: date), #""31-Dec-2579 23:59:59 +1559""#)
     }
 }


### PR DESCRIPTION
Extract 64-bit raw value from ServerMessageDate. Better debugDescription.

### Motivation:

For tests, it is extremely convenient to be able to create a `ServerMessageDate` from its underlying `UInt64` value. And likewise to get to the underlying `UInt64` value.
