### PR TITLE
Allow crosscompile to linux

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Append.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Append.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Body.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Body.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Date.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Date.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Entry.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Entry.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+List.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+List.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Partial.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Partial.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -14,8 +14,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(Windows)
+import ucrt
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/UInt8+ParseTypeMembership.swift
+++ b/Sources/NIOIMAPCore/Parser/UInt8+ParseTypeMembership.swift
@@ -18,9 +18,12 @@ import struct NIO.ByteBuffer
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import func Darwin.isalnum
 import func Darwin.isalpha
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import func Glibc.isalnum
 import func Glibc.isalpha
+#elseif canImport(Musl)
+import func Musl.isalnum
+import func Musl.isalpha
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif


### PR DESCRIPTION
Allow crosscompile to linux

### Motivation:

Crosscompile is the greatest thing since sliced bread.

### Modifications:

As per instructions in: https://www.swift.org/documentation/articles/static-linux-getting-started.html
use:

```
#if os(macOS) || os(iOS)
import Darwin
#elseif canImport(Glibc)
import Glibc
#elseif canImport(Musl)
import Musl
#endif
```

### Result:

Crosscompilation works!