### PR TITLE
Mailbox attribute requirements from RFC 9051

### DIFF
--- a/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxInfo.swift
+++ b/Sources/NIOIMAPCore/Grammar/Mailbox/MailboxInfo.swift
@@ -17,7 +17,11 @@ import struct OrderedCollections.OrderedDictionary
 
 /// A collection of mailbox attributes defined in the supported IMAP4 RFCs.
 public struct MailboxInfo: Hashable, Sendable {
-    /// An array of mailbox attributes.
+    /// An array of mailbox attributes returned by the server.
+    ///
+    /// Note: Servers may omit attributes that can be inferred from other returned attributes.
+    /// Use ``hasEffectiveAttribute(_:)`` to check for an attribute while accounting for
+    /// inference rules per RFC 9051 §6.3.9.4.
     public var attributes: [Attribute]
 
     /// The mailbox path.
@@ -88,6 +92,23 @@ extension MailboxInfo {
         public func hash(into hasher: inout Hasher) {
             self.backing.lowercased().hash(into: &hasher)
         }
+
+        /// Returns whether this attribute implies another attribute per RFC 9051 §6.3.9.4.
+        ///
+        /// The following inference rules are defined:
+        ///
+        /// | Returned Attribute | Implied Attribute |
+        /// |--------------------|-------------------|
+        /// | `\NoInferiors`     | `\HasNoChildren`  |
+        /// | `\NonExistent`     | `\NoSelect`       |
+        public func implies(_ other: Self) -> Bool {
+            switch (self, other) {
+            case (.noInferiors, .hasNoChildren), (.nonExistent, .noSelect):
+                true
+            default:
+                false
+            }
+        }
     }
 }
 
@@ -95,6 +116,36 @@ extension String {
     /// The raw value of the attribute, e.g. `\\trash`. Always lowercase.
     public init(_ other: MailboxInfo.Attribute) {
         self = other.backing
+    }
+}
+
+extension Sequence where Element == MailboxInfo.Attribute {
+    /// Returns whether this sequence contains a given attribute either directly or by implication,
+    /// per RFC 9051 §6.3.9.4.
+    ///
+    /// The following inference rules are defined:
+    ///
+    /// | Returned Attribute | Implied Attribute |
+    /// |--------------------|-------------------|
+    /// | `\NoInferiors`     | `\HasNoChildren`  |
+    /// | `\NonExistent`     | `\NoSelect`       |
+    public func containsEffective(_ attribute: MailboxInfo.Attribute) -> Bool {
+        contains { $0 == attribute || $0.implies(attribute) }
+    }
+}
+
+extension MailboxInfo {
+    /// Returns whether this mailbox's attributes include a given attribute either directly
+    /// or by implication, per RFC 9051 §6.3.9.4.
+    ///
+    /// The following inference rules are defined:
+    ///
+    /// | Returned Attribute | Implied Attribute |
+    /// |--------------------|-------------------|
+    /// | `\NoInferiors`     | `\HasNoChildren`  |
+    /// | `\NonExistent`     | `\NoSelect`       |
+    public func hasEffectiveAttribute(_ attribute: Attribute) -> Bool {
+        attributes.containsEffective(attribute)
     }
 }
 

--- a/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxInfo+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Mailbox/MailboxInfo+Tests.swift
@@ -29,6 +29,51 @@ struct MailboxInfoTests {
         )
     }
 
+    @Test(
+        "attribute implies",
+        arguments: [
+            ImpliesFixture(
+                name: "NoInferiors implies HasNoChildren",
+                attribute: .noInferiors,
+                other: .hasNoChildren,
+                expectation: true
+            ),
+            ImpliesFixture(
+                name: "NonExistent implies NoSelect",
+                attribute: .nonExistent,
+                other: .noSelect,
+                expectation: true
+            ),
+            ImpliesFixture(
+                name: "HasNoChildren does NOT imply NoInferiors",
+                attribute: .hasNoChildren,
+                other: .noInferiors,
+                expectation: false
+            ),
+            ImpliesFixture(
+                name: "NoSelect does NOT imply NonExistent",
+                attribute: .noSelect,
+                other: .nonExistent,
+                expectation: false
+            ),
+            ImpliesFixture(
+                name: "Marked does NOT imply HasNoChildren",
+                attribute: .marked,
+                other: .hasNoChildren,
+                expectation: false
+            ),
+            ImpliesFixture(
+                name: "NoInferiors (uppercase) implies HasNoChildren",
+                attribute: MailboxInfo.Attribute(#"\NOINFERIORS"#),
+                other: .hasNoChildren,
+                expectation: true
+            ),
+        ]
+    )
+    func attributeImplies(_ fixture: ImpliesFixture) {
+        #expect(fixture.attribute.implies(fixture.other) == fixture.expectation)
+    }
+
     @Test(arguments: [
         EncodeFixture.mailboxInfo(
             MailboxInfo(attributes: [], path: try! .init(name: .inbox), extensions: [:]),
@@ -152,6 +197,103 @@ struct MailboxInfoTests {
     )
     func parseFlags(_ fixture: ParseFixture<[MailboxInfo.Attribute]>) {
         fixture.checkParsing()
+    }
+
+    @Test(
+        "sequence containsEffective",
+        arguments: [
+            ContainsEffectiveFixture(
+                name: "empty array",
+                attributes: [],
+                query: .hasNoChildren,
+                expectation: false
+            ),
+            ContainsEffectiveFixture(
+                name: "direct match",
+                attributes: [.hasNoChildren],
+                query: .hasNoChildren,
+                expectation: true
+            ),
+            ContainsEffectiveFixture(
+                name: "NoInferiors contains HasNoChildren",
+                attributes: [.noInferiors],
+                query: .hasNoChildren,
+                expectation: true
+            ),
+            ContainsEffectiveFixture(
+                name: "NonExistent contains NoSelect",
+                attributes: [.nonExistent],
+                query: .noSelect,
+                expectation: true
+            ),
+            ContainsEffectiveFixture(
+                name: "HasNoChildren does NOT contain NoInferiors",
+                attributes: [.hasNoChildren],
+                query: .noInferiors,
+                expectation: false
+            ),
+            ContainsEffectiveFixture(
+                name: "NoSelect does NOT contain NonExistent",
+                attributes: [.noSelect],
+                query: .nonExistent,
+                expectation: false
+            ),
+            ContainsEffectiveFixture(
+                name: "multiple attributes with one triggering implication",
+                attributes: [.marked, .nonExistent],
+                query: .noSelect,
+                expectation: true
+            ),
+            ContainsEffectiveFixture(
+                name: "case-insensitive implication check",
+                attributes: [MailboxInfo.Attribute(#"\NOINFERIORS"#)],
+                query: .hasNoChildren,
+                expectation: true
+            ),
+        ]
+    )
+    func sequenceContainsEffective(_ fixture: ContainsEffectiveFixture) {
+        #expect(fixture.attributes.containsEffective(fixture.query) == fixture.expectation)
+    }
+
+    @Test("mailbox hasEffectiveAttribute")
+    func mailboxHasEffectiveAttribute() {
+        let mailbox1 = MailboxInfo(
+            attributes: [.noInferiors],
+            path: try! .init(name: .inbox),
+            extensions: [:]
+        )
+        #expect(mailbox1.hasEffectiveAttribute(.hasNoChildren), "NoInferiors should imply HasNoChildren")
+        #expect(!mailbox1.hasEffectiveAttribute(.marked), "should not have unrelated attribute")
+
+        let mailbox2 = MailboxInfo(
+            attributes: [.noSelect],
+            path: try! .init(name: .inbox),
+            extensions: [:]
+        )
+        #expect(!mailbox2.hasEffectiveAttribute(.nonExistent), "NoSelect does NOT imply NonExistent")
+    }
+}
+
+// MARK: - Fixtures
+
+extension MailboxInfoTests {
+    struct ImpliesFixture: Sendable, CustomTestStringConvertible {
+        var name: String
+        var attribute: MailboxInfo.Attribute
+        var other: MailboxInfo.Attribute
+        var expectation: Bool
+
+        var testDescription: String { name }
+    }
+
+    struct ContainsEffectiveFixture: Sendable, CustomTestStringConvertible {
+        var name: String
+        var attributes: [MailboxInfo.Attribute]
+        var query: MailboxInfo.Attribute
+        var expectation: Bool
+
+        var testDescription: String { name }
     }
 }
 


### PR DESCRIPTION
Fixes #731

### Motivation:

[RFC 9051 section 6.3.9.4](https://www.rfc-editor.org/rfc/rfc9051#section-6.3.9.4) says
> All clients MUST treat a LIST attribute with a stronger meaning as implying any attribute that can be inferred from it. (See [Section 7.3.1](https://www.rfc-editor.org/rfc/rfc9051#list-resp) for the list of currently defined attributes.) For example, the client must treat the presence of the \NoInferiors attribute as if the \HasNoChildren attribute was also sent by the server.

This PR adds helpers for this — rather than enforcing (while encoding or parsing).

### Modifications:

Adds
* `MailboxInfo.Attribute.implies(_:) -> Bool`
* `MailboxInfo.hasEffectiveAttribute(_:) -> Bool `
* `Sequence<MailboxInfo.Attribute>.containsEffective(_:) -> Bool`

Added tests.