### PR TITLE
Allow `()` in place of `NIL` for empty addr-list fields. Fixes #821

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
@@ -76,9 +76,19 @@ extension GrammarParser {
             try self.parseNil(buffer: &buffer, tracker: tracker)
             return []
         }
+        func parseOptionalEnvelopeEmailAddresses_emptyList(
+            buffer: inout ParseBuffer,
+            tracker: StackTracker
+        ) throws -> [EmailAddress] {
+            // Some servers emit `()` instead of `NIL` for empty addr-list fields.
+            // This is non-conformant per RFC 3501 but seen in practice.
+            try PL.parseFixedString("()", buffer: &buffer, tracker: tracker)
+            return []
+        }
         let addresses = try PL.parseOneOf(
             parseEnvelopeEmailAddresses,
             parseOptionalEnvelopeEmailAddresses_nil,
+            parseOptionalEnvelopeEmailAddresses_emptyList,
             buffer: &buffer,
             tracker: tracker
         )

--- a/Tests/NIOIMAPCoreTests/Grammar/EnvelopeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/EnvelopeTests.swift
@@ -149,7 +149,7 @@ struct EnvelopeTests {
                         messageID: "messageid"
                     )
                 )
-            )
+            ),
         ]
     )
     func parseEnvelope(_ fixture: ParseFixture<Envelope>) {

--- a/Tests/NIOIMAPCoreTests/Grammar/EnvelopeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/EnvelopeTests.swift
@@ -88,7 +88,11 @@ struct EnvelopeTests {
                     Envelope(
                         date: "Wed, 11 Oct 2023 03:11:07 +0000",
                         subject: "some subject",
-                        from: [.singleAddress(.init(personName: "Tn", sourceRoot: nil, mailbox: "info", host: "e.example.com"))],
+                        from: [
+                            .singleAddress(
+                                .init(personName: "Tn", sourceRoot: nil, mailbox: "info", host: "e.example.com")
+                            )
+                        ],
                         sender: [],
                         reply: [],
                         to: [],

--- a/Tests/NIOIMAPCoreTests/Grammar/EnvelopeTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/EnvelopeTests.swift
@@ -81,6 +81,24 @@ struct EnvelopeTests {
     @Test(
         "parse envelope",
         arguments: [
+            // Envelope where env-to is `()` instead of `NIL`.
+            ParseFixture.envelope(
+                #"("Wed, 11 Oct 2023 03:11:07 +0000" "some subject" (("Tn" NIL "info" "e.example.com")) NIL NIL () NIL NIL "<426119111385110898173554@bar.example.com>" "<foo@example.com>")"#,
+                expected: .success(
+                    Envelope(
+                        date: "Wed, 11 Oct 2023 03:11:07 +0000",
+                        subject: "some subject",
+                        from: [.singleAddress(.init(personName: "Tn", sourceRoot: nil, mailbox: "info", host: "e.example.com"))],
+                        sender: [],
+                        reply: [],
+                        to: [],
+                        cc: [],
+                        bcc: [],
+                        inReplyTo: "<426119111385110898173554@bar.example.com>",
+                        messageID: "<foo@example.com>"
+                    )
+                )
+            ),
             ParseFixture.envelope(
                 #"("date" "subject" (("name1" "adl1" "mailbox1" "host1")) (("name2" "adl2" "mailbox2" "host2")) (("name3" "adl3" "mailbox3" "host3")) (("name4" "adl4" "mailbox4" "host4") ("name5" "adl5" "mailbox5" "host5")) (("name6" "adl6" "mailbox6" "host6")("name7" "adl7" "mailbox7" "host7")) (("name8" "adl8" "mailbox8" "host8")) "someone" "messageid")"#,
                 expected: .success(
@@ -163,6 +181,7 @@ struct EnvelopeTests {
                 expected: .success([.singleAddress(.init(personName: "a", sourceRoot: "b", mailbox: "c", host: "d"))])
             ),
             ParseFixture.optionalEnvelopeEmailAddresses("NIL", " ", expected: .success([])),
+            ParseFixture.optionalEnvelopeEmailAddresses("()", " ", expected: .success([])),
         ]
     )
     func parseOptionalEnvelopeEmailAddresses(_ fixture: ParseFixture<[EmailAddressListElement]>) {


### PR DESCRIPTION
Accept `()` as an empty `addr-list` in envelope parsing

### Motivation:

RFC 3501 defines `addr-list` as `"(" 1*address ")" / nil`, so the only valid representations of an empty address list are a non-empty parenthesised list or `NIL`. Some servers emit `()` instead of `NIL` for envelope fields on messages with no recipients in that field. The parser rejected `()` with a `ParserError`, which left the bytes unconsumed and corrupted parsing of all subsequent responses on the same channel.

### Modifications:

`parseOptionalEnvelopeEmailAddresses` now accepts `()` as a third alternative alongside a non-empty list and `NIL`, treating it as equivalent to `NIL`. Two test cases are added: one for `parseOptionalEnvelopeEmailAddresses` directly, and one full envelope parse with `()` in the `env-to` field.

### Result:

Envelope responses containing `()` for any of the six address fields are parsed successfully and produce an empty address list, matching the behaviour of `NIL`.
