### PR TITLE
Add Android to NIOIMAPCore's libc imports

### DIFF
--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Append.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Append.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Body.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Body.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Date.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Date.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Entry.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Entry.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+List.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+List.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Partial.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Partial.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
@@ -20,6 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -26,6 +26,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Bionic)
+import Bionic
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/UInt8+ParseTypeMembership.swift
+++ b/Sources/NIOIMAPCore/Parser/UInt8+ParseTypeMembership.swift
@@ -24,6 +24,9 @@ import func Glibc.isalpha
 #elseif canImport(Musl)
 import func Musl.isalnum
 import func Musl.isalpha
+#elseif canImport(Bionic)
+import func Bionic.isalnum
+import func Bionic.isalpha
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif


### PR DESCRIPTION
### Motivation

`NIOIMAPCore` does not compile for Android. Its parser guards the per-file libc import with `Darwin` / `Glibc` / `Musl` / `Windows` and otherwise falls into:

```swift
#else
let badOS = { fatalError("unsupported OS") }()
#endif
```

On the Swift Android SDK none of those arms match, so every guarded source takes the `#else` branch. Because `badOS` is declared at file scope in ~17 sources, the module then fails to build with `error: invalid redeclaration of 'badOS'`.

### Modifications

Add an `#elseif canImport(Android)` arm importing `Android` to the per-file libc-import guards in `NIOIMAPCore`. For `UInt8+ParseTypeMembership.swift`, which imports specific ctype functions, add `import func Android.isalnum` / `import func Android.isalpha`.

(`Android` is the umbrella module — it re-exports Bionic — so a single arm is sufficient.)

### Result

`NIOIMAPCore` compiles for Android; no change on any other platform.

Verified with an isolated cross-build of the `NIOIMAPCore` target via [skiptools/swift-android-action](https://github.com/skiptools/swift-android-action) (Swift 6.3.2): [green run](https://github.com/odrobnik/swift-nio-imap/actions/runs/26757810077). `swift-format` and `swift package dump-package` both pass.

Note: I couldn't find an Android job in this repo's CI, so this isn't exercised by the existing matrix. Separately, `UInt8+ParseTypeMembership.swift` is also missing a `Windows` arm (so it would `badOS` on Windows too) — left out of scope here, happy to add `import func ucrt.isalnum` / `.isalpha` if wanted.