### PR TITLE
Only parse continuation responses while an AUTHENTICATE is in progress

### DIFF
--- a/Sources/NIOIMAP/Coders/ClientStateMachine.swift
+++ b/Sources/NIOIMAP/Coders/ClientStateMachine.swift
@@ -584,7 +584,10 @@ extension ClientStateMachine {
 
         switch command {
         case .idleDone, .continuationResponse:
-            preconditionFailure("Invalid command for state: \(command)")
+            // These can only arrive here if a malformed or forwarded command is fed to the state
+            // machine out of context (e.g. a spurious `.continuationResponse` parsed from
+            // untrusted bytes). Throw rather than crash the process.
+            throw InvalidCommandForState(command)
         case .tagged(let tc):
             return self.sendTaggedCommand(tc, promise: promise)
         case .append(let ac):

--- a/Sources/NIOIMAPCore/Parser/CommandParser.swift
+++ b/Sources/NIOIMAPCore/Parser/CommandParser.swift
@@ -89,6 +89,9 @@ public struct CommandParser: Parser, Sendable {
     enum Mode: Hashable, Sendable {
         case lines
         case idle
+        /// An `AUTHENTICATE` command has been parsed and we expect either the client's base64
+        /// challenge response(s) or the next ordinary command once authentication completes.
+        case expectingAuthenticationResponse
         case waitingForMessage
         case streamingBytes(Int)
         case streamingEnd
@@ -102,6 +105,19 @@ public struct CommandParser: Parser, Sendable {
             }
             return true
         }
+    }
+
+    /// The context in which a command line is being parsed, controlling which inputs
+    /// ``parseCommandOrAppend(in:buffer:tracker:)`` accepts in addition to tagged commands
+    /// and `APPEND`.
+    private enum CommandLineContext {
+        /// Ordinary command parsing (corresponds to `Mode.lines`). Only tagged commands and
+        /// `APPEND` are valid; a bare CRLF or an unsolicited base64 line is a parse error.
+        case standard
+        /// An `AUTHENTICATE` exchange is in progress (corresponds to
+        /// `Mode.expectingAuthenticationResponse`), so a base64 challenge response is additionally
+        /// accepted — e.g. for multi-round SASL mechanisms such as `GSSAPI`.
+        case authenticating
     }
 
     let parser: GrammarParser
@@ -232,6 +248,8 @@ public struct CommandParser: Parser, Sendable {
                 return try self.handleIdle(buffer: &buffer, tracker: tracker)
             case .lines:
                 return try self.handleLines(buffer: &buffer, tracker: tracker)
+            case .expectingAuthenticationResponse:
+                return try self.handleAuthentication(buffer: &buffer, tracker: tracker)
             case .waitingForMessage:
                 return try self.handleWaitingForMessage(buffer: &buffer, tracker: tracker)
             case .streamingBytes(let remaining):
@@ -270,11 +288,48 @@ public struct CommandParser: Parser, Sendable {
     }
 
     private mutating func handleLines(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CommandStreamPart {
+        // In `.lines` mode there is no `AUTHENTICATE` in progress, so a bare CRLF / unsolicited
+        // base64 line must be rejected rather than misclassified as a continuation response.
+        try self.parseCommandOrAppend(in: .standard, buffer: &buffer, tracker: tracker)
+    }
+
+    /// Parses while an `AUTHENTICATE` exchange is in progress.
+    ///
+    /// In addition to ordinary commands and `APPEND`, the client may send one or more base64
+    /// challenge responses (multi-round SASL, e.g. `GSSAPI`). The parser leaves this mode only
+    /// once an ordinary command or `APPEND` is parsed, since it never sees the server's tagged
+    /// completion response.
+    private mutating func handleAuthentication(
+        buffer: inout ParseBuffer,
+        tracker: StackTracker
+    ) throws -> CommandStreamPart {
+        try self.parseCommandOrAppend(in: .authenticating, buffer: &buffer, tracker: tracker)
+    }
+
+    /// Shared implementation for `.lines` and `.expectingAuthenticationResponse` modes.
+    ///
+    /// Both contexts accept a tagged command or an `APPEND`; only `.authenticating` additionally
+    /// accepts a base64 continuation response. `parseCommand` is tried first and a tagged command
+    /// requires `tag SP …` while a base64 line contains no space, so there is no ambiguity between
+    /// the two.
+    private mutating func parseCommandOrAppend(
+        in context: CommandLineContext,
+        buffer: inout ParseBuffer,
+        tracker: StackTracker
+    ) throws -> CommandStreamPart {
         func parseCommand(buffer: inout ParseBuffer, tracker: StackTracker) throws -> CommandStreamPart {
             let command = try self.parser.parseTaggedCommand(buffer: &buffer, tracker: tracker)
             try PL.parseNewline(buffer: &buffer, tracker: tracker)
-            if case .idleStart = command.command {
+            switch command.command {
+            case .idleStart:
                 self.mode = .idle
+            case .authenticate:
+                // Expect the client's base64 challenge response(s) until authentication completes.
+                self.mode = .expectingAuthenticationResponse
+            default:
+                // Any other command exits a preceding `AUTHENTICATE` exchange. This is a harmless
+                // no-op when we are already in `.lines`.
+                self.mode = .lines
             }
             return .tagged(command)
         }
@@ -291,16 +346,27 @@ public struct CommandParser: Parser, Sendable {
         ) throws -> CommandStreamPart {
             let authenticationChallengeResponse = try self.parser.parseBase64(buffer: &buffer, tracker: tracker)
             try PL.parseNewline(buffer: &buffer, tracker: tracker)
+            // Stay in `.expectingAuthenticationResponse` to support multi-round SASL exchanges.
             return .continuationResponse(authenticationChallengeResponse)
         }
 
-        return try PL.parseOneOf(
-            parseCommand,
-            parseAppend,
-            parseAuthenticationChallengeResponse,
-            buffer: &buffer,
-            tracker: tracker
-        )
+        switch context {
+        case .standard:
+            return try PL.parseOneOf(
+                parseCommand,
+                parseAppend,
+                buffer: &buffer,
+                tracker: tracker
+            )
+        case .authenticating:
+            return try PL.parseOneOf(
+                parseCommand,
+                parseAppend,
+                parseAuthenticationChallengeResponse,
+                buffer: &buffer,
+                tracker: tracker
+            )
+        }
     }
 
     private mutating func handleWaitingForMessage(

--- a/Tests/NIOIMAPCoreTests/Parser/SynchronizedCommand+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/SynchronizedCommand+Tests.swift
@@ -396,19 +396,108 @@ struct SynchronizedCommandTests {
 
     // MARK: - Continuation response
 
-    @Test("authentication continuation response is parsed from base64 line")
+    @Test("authentication continuation response is parsed from base64 line during AUTHENTICATE")
     func authenticationContinuationResponseIsParsedFromBase64Line() throws {
-        // A base64-encoded line (not a tagged command or APPEND) is parsed as a
-        // continuationResponse via parseAuthenticationChallengeResponse.
+        // A base64 challenge response is only parsed as a continuationResponse while an
+        // AUTHENTICATE exchange is in progress.
         var parser = CommandParser()
         // "AHRlc3R1c2VyAHRlc3RwYXNz" is base64 for "\0testuser\0testpass"
-        var buf = ByteBuffer("AHRlc3R1c2VyAHRlc3RwYXNz\r\n")
-        let result = try parser.parseCommandStream(buffer: &buf)
-        guard case .continuationResponse = result?.commandPart else {
-            Issue.record("Expected continuationResponse, got \(String(describing: result))")
+        var buf = ByteBuffer("1 AUTHENTICATE PLAIN\r\nAHRlc3R1c2VyAHRlc3RwYXNz\r\n")
+
+        // The AUTHENTICATE command puts the parser into "expecting authentication response" mode.
+        let auth = try parser.parseCommandStream(buffer: &buf)
+        guard case .tagged(let tc) = auth?.commandPart, case .authenticate = tc.command else {
+            Issue.record("Expected tagged AUTHENTICATE, got \(String(describing: auth))")
+            return
+        }
+
+        // Now the base64 line is parsed as a continuation response.
+        let response = try parser.parseCommandStream(buffer: &buf)
+        guard case .continuationResponse = response?.commandPart else {
+            Issue.record("Expected continuationResponse, got \(String(describing: response))")
             return
         }
         #expect(buf.readableBytes == 0)
+    }
+
+    @Test(
+        "bare line terminator without a preceding AUTHENTICATE is rejected",
+        arguments: [
+            "\r\n",  // conforming CRLF
+            "\n",  // non-conforming bare LF (Unix)
+        ]
+    )
+    func bareLineTerminatorWithoutAuthenticateIsRejected(_ lineEnding: String) {
+        // Without an AUTHENTICATE in progress, a bare line terminator must be a parse error rather
+        // than being silently misclassified as a continuation response. This must hold both for the
+        // conforming CRLF terminator and for a non-conforming bare LF (Unix) terminator.
+        var parser = CommandParser()
+        var buf = ByteBuffer(string: lineEnding)
+        #expect(throws: (any Error).self) {
+            try parser.parseCommandStream(buffer: &buf)
+        }
+    }
+
+    @Test("unsolicited base64 line without a preceding AUTHENTICATE is rejected")
+    func unsolicitedBase64LineWithoutAuthenticateIsRejected() {
+        // Without an AUTHENTICATE in progress, an unsolicited base64 line must be a parse error.
+        var parser = CommandParser()
+        var buf = ByteBuffer("AHRlc3R1c2VyAHRlc3RwYXNz\r\n")
+        #expect(throws: (any Error).self) {
+            try parser.parseCommandStream(buffer: &buf)
+        }
+    }
+
+    @Test("multi-round AUTHENTICATE keeps parsing continuation responses")
+    func multiRoundAuthenticateKeepsParsingContinuationResponses() throws {
+        // Multi-round SASL (e.g. GSSAPI) sends several base64 responses; the parser stays in
+        // authenticate mode across all of them.
+        var parser = CommandParser()
+        var buf = ByteBuffer("1 AUTHENTICATE GSSAPI\r\ncmVzcG9uc2Ux\r\ncmVzcG9uc2Uy\r\n")
+
+        let auth = try parser.parseCommandStream(buffer: &buf)
+        guard case .tagged(let tc) = auth?.commandPart, case .authenticate = tc.command else {
+            Issue.record("Expected tagged AUTHENTICATE, got \(String(describing: auth))")
+            return
+        }
+
+        for _ in 0..<2 {
+            let response = try parser.parseCommandStream(buffer: &buf)
+            guard case .continuationResponse = response?.commandPart else {
+                Issue.record("Expected continuationResponse, got \(String(describing: response))")
+                return
+            }
+        }
+        #expect(buf.readableBytes == 0)
+    }
+
+    @Test("ordinary command after AUTHENTICATE exits authenticate mode")
+    func ordinaryCommandAfterAuthenticateExitsAuthenticateMode() throws {
+        // After an AUTHENTICATE exchange, an ordinary command resets the parser back to `.lines`,
+        // and a later stray base64 line is again rejected.
+        var parser = CommandParser()
+        var buf = ByteBuffer("1 AUTHENTICATE PLAIN\r\nAHRlc3R1c2Vy\r\n2 NOOP\r\nAHRlc3R1c2Vy\r\n")
+
+        let auth = try parser.parseCommandStream(buffer: &buf)
+        guard case .tagged(let tc) = auth?.commandPart, case .authenticate = tc.command else {
+            Issue.record("Expected tagged AUTHENTICATE, got \(String(describing: auth))")
+            return
+        }
+
+        let response = try parser.parseCommandStream(buffer: &buf)
+        guard case .continuationResponse = response?.commandPart else {
+            Issue.record("Expected continuationResponse, got \(String(describing: response))")
+            return
+        }
+
+        // The NOOP exits authenticate mode and parses as an ordinary command.
+        let noop = try parser.parseCommandStream(buffer: &buf)
+        #expect(noop?.commandPart == .tagged(.init(tag: "2", command: .noop)))
+
+        // The trailing base64 line is now rejected because we are back in `.lines` mode.
+        #expect(throws: (any Error).self) {
+            try parser.parseCommandStream(buffer: &buf)
+        }
     }
 
     // MARK: - Incomplete CRLF in waitingForMessage mode

--- a/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
+++ b/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
@@ -396,6 +396,26 @@ extension ClientStateMachineTests {
             try stateMachine.receiveResponse(.idleStarted)
         }
     }
+
+    @Test("sending a continuation response while expecting a normal response throws instead of crashing")
+    func sendingContinuationResponseWhileExpectingNormalResponseThrows() {
+        // A spurious `.continuationResponse` (e.g. one forwarded after being misparsed from
+        // untrusted bytes) must not crash the process. A fresh state machine is in
+        // `.expectingNormalResponse`, where this command is invalid.
+        var stateMachine = makeStateMachine()
+        #expect(throws: InvalidCommandForState.self) {
+            try stateMachine.sendCommand(.continuationResponse("spurious"))
+        }
+    }
+
+    @Test("sending idleDone while expecting a normal response throws instead of crashing")
+    func sendingIdleDoneWhileExpectingNormalResponseThrows() {
+        // Likewise, an out-of-context `.idleDone` must throw rather than hit a precondition.
+        var stateMachine = makeStateMachine()
+        #expect(throws: InvalidCommandForState.self) {
+            try stateMachine.sendCommand(.idleDone)
+        }
+    }
 }
 
 // MARK: - Append


### PR DESCRIPTION
Only parse continuation responses while an AUTHENTICATE is in progress

### Motivation:

`CommandParser.handleLines` always offered `parseAuthenticationChallengeResponse` (→ `parseBase64` → `.continuationResponse`) as a `parseOneOf` fallback. With no notion of "awaiting an auth challenge response," any bare `CRLF` or base64-shaped line was accepted as a `.continuationResponse` regardless of whether an `AUTHENTICATE` was underway. Besides being a correctness defect, a forwarded spurious `.continuationResponse` (e.g. via a proxy) crashes `ClientStateMachine.sendNextCommand_expectingNormalResponse`, which `preconditionFailure`s — turning untrusted bytes into a DoS.

### Modifications:

Add `Mode.expectingAuthenticationResponse`, entered when an `AUTHENTICATE` is parsed (mirroring `.idleStart → .idle`); any other command resets to `.lines`, which is how the parser leaves auth mode since it never sees the server's tagged completion.

`.lines` no longer offers the base64 fallback, so bare `CRLF` / unsolicited base64 now throws. The continuation alternative is offered only in the new mode, where a parsed response keeps the mode (multi-round SASL). The shared parsers are factored behind `parseCommandOrAppend(in: CommandLineContext)`.

`sendNextCommand_expectingNormalResponse` now `throw`s `InvalidCommandForState` for `.idleDone` / `.continuationResponse` instead of trapping.

Tests for parser rejection (`CRLF` + bare-`LF`, unsolicited base64), the `AUTHENTICATE` flow, multi-round SASL, and mode-exit; plus state-machine tests asserting the throw.

### Result:

A bare CRLF / unsolicited base64 line is rejected as a parse error, a base64 continuation is accepted only mid-`AUTHENTICATE`, and a forwarded out-of-context `.continuationResponse` / `.idleDone` is a recoverable error rather than a crash.