### PR TITLE
InvalidCommandForState error may leak PII

### DIFF
--- a/Sources/NIOIMAP/Coders/ClientStateMachine.swift
+++ b/Sources/NIOIMAP/Coders/ClientStateMachine.swift
@@ -93,6 +93,22 @@ public struct InvalidCommandForState: Error, Equatable {
     }
 }
 
+extension InvalidCommandForState: CustomStringConvertible, CustomDebugStringConvertible {
+    /// A textual representation of the error with all _personally identifiable information_ in
+    /// ``command`` redacted.
+    ///
+    /// `command` can carry sensitive data — e.g. an `AUTHENTICATE` continuation response holding
+    /// credentials — so the default (reflective) description is overridden to route ``command``
+    /// through ``CommandStreamPart/descriptionWithoutPII(_:)`` and avoid leaking it into logs.
+    public var description: String {
+        "InvalidCommandForState(\(CommandStreamPart.descriptionWithoutPII([self.command])))"
+    }
+
+    public var debugDescription: String {
+        self.description
+    }
+}
+
 struct OutgoingChunk: Equatable {
     var bytes: ByteBuffer
     var promise: EventLoopPromise<Void>?

--- a/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
+++ b/Tests/NIOIMAPTests/Coders/ClientStateMachineTests.swift
@@ -771,3 +771,27 @@ extension ClientStateMachineTests {
         }
     }
 }
+
+// MARK: - InvalidCommandForState PII redaction
+
+extension ClientStateMachineTests {
+    @Test("InvalidCommandForState redacts continuation-response PII")
+    func invalidCommandForStateRedactsContinuationResponsePII() {
+        // A continuation response can carry credentials (e.g. a SASL exchange), so neither the
+        // raw bytes nor a plain rendering of them may appear in the error's description.
+        let error = InvalidCommandForState(.continuationResponse(ByteBuffer(string: "topsecretcredentials")))
+
+        #expect("\(error)" == "InvalidCommandForState([28 bytes]\r\n)")
+        #expect(String(reflecting: error) == "InvalidCommandForState([28 bytes]\r\n)")
+    }
+
+    @Test("InvalidCommandForState redacts LOGIN credentials")
+    func invalidCommandForStateRedactsLoginCredentials() {
+        // LOGIN carries a username and password; neither may leak via the description.
+        let error = InvalidCommandForState(
+            .tagged(.init(tag: "A1", command: .login(username: "alice", password: "hunter2hunter2")))
+        )
+
+        #expect("\(error)" == "InvalidCommandForState(A1 LOGIN \"∅\" \"∅\"\r\n)")
+    }
+}


### PR DESCRIPTION
Add `CustomStringConvertible` and `CustomDebugStringConvertible` that remove PII.

### Motivation:

Errors often get logged. Should not contain personally identifiable information (PII).

### Modifications:

Add conformance. Add tests.
