### PR TITLE
NIOIMAPCore: import the Android overlay module instead of Bionic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,9 @@ jobs:
   android-sdk:
     name: Android Swift SDK
     uses: apple/swift-nio/.github/workflows/android_swift_sdk.yml@main
+    with:
+      # swift-collections 1.6.0 uses `@inline(always)` under `#if compiler(>=6.3)`, but the
+      # attribute is still gated behind the experimental `InlineAlways` feature in the nightly
+      # `main` toolchain this job builds with. Enable it until the dependency's guard is fixed
+      # upstream (cf. apple/swift-collections #580/#584).
+      additional_command_arguments: "-Xswiftc -enable-experimental-feature -Xswiftc InlineAlways"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,3 +31,9 @@ jobs:
   android-sdk:
     name: Android Swift SDK
     uses: apple/swift-nio/.github/workflows/android_swift_sdk.yml@main
+    with:
+      # swift-collections 1.6.0 uses `@inline(always)` under `#if compiler(>=6.3)`, but the
+      # attribute is still gated behind the experimental `InlineAlways` feature in the nightly
+      # `main` toolchain this job builds with. Enable it until the dependency's guard is fixed
+      # upstream (cf. apple/swift-collections #580/#584).
+      additional_command_arguments: "-Xswiftc -enable-experimental-feature -Xswiftc InlineAlways"

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Append.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Append.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Body.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Body.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Date.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Date.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Entry.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Entry.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Envelope.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Fetch.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+List.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+List.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Mailbox.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Message.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Partial.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Partial.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Response.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Search.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Sequence.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+UID.swift
@@ -20,8 +20,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -26,8 +26,8 @@ import Glibc
 import Musl
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif

--- a/Sources/NIOIMAPCore/Parser/UInt8+ParseTypeMembership.swift
+++ b/Sources/NIOIMAPCore/Parser/UInt8+ParseTypeMembership.swift
@@ -24,9 +24,9 @@ import func Glibc.isalpha
 #elseif canImport(Musl)
 import func Musl.isalnum
 import func Musl.isalpha
-#elseif canImport(Bionic)
-import func Bionic.isalnum
-import func Bionic.isalpha
+#elseif canImport(Android)
+import func Android.isalnum
+import func Android.isalpha
 #else
 let badOS = { fatalError("unsupported OS") }()
 #endif


### PR DESCRIPTION
### Motivation

[#826](https://github.com/apple/swift-nio-imap/pull/826) added a `canImport(Bionic)` / `import Bionic` arm to NIOIMAPCore's per-file libc-import guards so the module builds for Android. This follow-up switches that arm to the `Android` umbrella module.

On the Swift Android SDK, `Android` re-exports `Bionic` and layers the Swift overlay on top, so it's the more complete/idiomatic libc surface to import. `Bionic` is effectively a subset.

### Modifications

In the 17 NIOIMAPCore files that gained a Bionic arm, replace `canImport(Bionic)`/`import Bionic` (and the `import func Bionic.isalnum`/`isalpha` in `UInt8+ParseTypeMembership.swift`) with the `Android` equivalents.

### Result

No functional change — both modules resolve the libc symbols used here (`isalnum`/`isalpha`); NIOIMAPCore still builds for Android. Verified the whole module cross-compiles for Android with `import Android` (`swift build --target NIOIMAPCore` via skiptools/swift-android-action).

(Note: `swift-nio` itself currently uses `canImport(Bionic)`; happy to close this if you'd rather keep `nio-imap` consistent with that — but flagging that `Android` is the fuller overlay.)