### PR TITLE
Fix CR LF handling in FramingParser

### DIFF
--- a/Sources/NIOIMAP/Client/FramingParser.swift
+++ b/Sources/NIOIMAP/Client/FramingParser.swift
@@ -225,21 +225,31 @@ public struct FramingParser: Hashable, Sendable {
         while self.frameLength < self.buffer.readableBytes {
             switch self.state {
             case .normalTraversal(let lineFeedStrategy):
-                let status = self.readByte_state_normalTraversal(lineFeedStrategy: lineFeedStrategy)
-                switch status {
-                case .parsedCompleteFrame:
-                    return .complete(self.readFrame())
-                case .continueParsing:
-                    continue
+                do {
+                    let status = try self.readByte_state_normalTraversal(lineFeedStrategy: lineFeedStrategy)
+                    switch status {
+                    case .parsedCompleteFrame:
+                        return .complete(self.readFrame())
+                    case .continueParsing:
+                        continue
+                    }
+                } catch {
+                    self.state = .normalTraversal(.includeInFrame)
+                    return .invalid(self.readFrame())
                 }
 
             case .insideQuoted(let s):
-                let status = readByte_state_insideQuoted(quotedState: s)
-                switch status {
-                case .parsedCompleteFrame:
-                    return .complete(self.readFrame())
-                case .continueParsing:
-                    continue
+                do {
+                    let status = try readByte_state_insideQuoted(quotedState: s)
+                    switch status {
+                    case .parsedCompleteFrame:
+                        return .complete(self.readFrame())
+                    case .continueParsing:
+                        continue
+                    }
+                } catch {
+                    self.state = .normalTraversal(.includeInFrame)
+                    return .invalid(self.readFrame())
                 }
 
             case .foundCR:
@@ -340,11 +350,11 @@ public struct FramingParser: Hashable, Sendable {
 
 extension FramingParser {
     /// Returns `.parsedCompleteFrame` if the frame is complete.
-    private mutating func readByte_state_normalTraversal(lineFeedStrategy: LineFeedByteStrategy) -> FrameStatus {
+    private mutating func readByte_state_normalTraversal(lineFeedStrategy: LineFeedByteStrategy) throws -> FrameStatus {
         let byte = self.readByte()
         switch byte {
         case CR, LF:
-            return processLineBreakByte_state(
+            return try processLineBreakByte_state(
                 byte: byte,
                 lineFeedStrategy: lineFeedStrategy
             )
@@ -358,14 +368,24 @@ extension FramingParser {
             return .continueParsing
 
         default:
-            // We don't need to do anything this byte, as it's just a "normal" part of a
+            // We don't need to do anything with this byte, as it's just a "normal" part of a
             // command. We "consume" it in the call to readByte above, which just makes
             // the current frame one byte longer.
+            //
+            // If we were in the `.ignoreFirst` strategy — set after a bare CR ended the previous
+            // frame so that a *leading* LF would be skipped — then consuming a non-LF byte means
+            // this is the start of a fresh frame. Any LF later in this frame is a genuine
+            // terminator, so revert to `.includeInFrame`. Failing to do so would leave the
+            // strategy stale and desync the state machine: a subsequent LF would reach
+            // `processLineBreakByte_state` with `frameLength > 1`.
+            if case .ignoreFirst = lineFeedStrategy {
+                self.state = .normalTraversal(.includeInFrame)
+            }
             return .continueParsing
         }
     }
 
-    private mutating func readByte_state_insideQuoted(quotedState: QuotedState) -> FrameStatus {
+    private mutating func readByte_state_insideQuoted(quotedState: QuotedState) throws -> FrameStatus {
         let byte = self.readByte()
         switch (byte, quotedState) {
         case (CR, _), (LF, _):
@@ -373,7 +393,7 @@ extension FramingParser {
             // parts (notably `text`) is allowed to have _any_ character
             // (except CR or LF).
             // Thus, fall through to “normal” state:
-            return processLineBreakByte_state(
+            return try processLineBreakByte_state(
                 byte: byte,
                 lineFeedStrategy: .includeInFrame
             )
@@ -398,7 +418,7 @@ extension FramingParser {
     private mutating func processLineBreakByte_state(
         byte: UInt8,
         lineFeedStrategy: LineFeedByteStrategy
-    ) -> FrameStatus {
+    ) throws -> FrameStatus {
         switch byte {
         case CR:
             self.readByte_state_foundCR()
@@ -407,7 +427,15 @@ extension FramingParser {
         case LF:
             switch lineFeedStrategy {
             case .ignoreFirst:
-                precondition(self.frameLength == 1)
+                // Reaching here means a bare CR completed the previous frame and this LF is its
+                // partner — so it must be the only byte consumed in this frame. The `.ignoreFirst`
+                // reset in `readByte_state_normalTraversal` makes `frameLength == 1` an invariant,
+                // but these bytes come straight off the network, so we defensively treat any
+                // violation as a recoverable invalid frame rather than aborting the whole process
+                // with a `precondition`.
+                guard self.frameLength == 1 else {
+                    throw InvalidFrame()
+                }
                 self.stepBackAndIgnoreByte()
                 self.state = .normalTraversal(.includeInFrame)
                 return .continueParsing

--- a/Tests/NIOIMAPTests/FramingIntegrationTests.swift
+++ b/Tests/NIOIMAPTests/FramingIntegrationTests.swift
@@ -79,7 +79,7 @@ import Testing
         for entry in Self.wellFormedCorpus {
             let bytes = Array(entry.input.utf8)
 
-            // Sanity: the un-split stream parses to the expected commands.
+            // Baseline: the un-split stream parses to the expected commands.
             #expect(
                 self.parsedParts(of: bytes, splittingAt: []) == entry.expected,
                 "unsplit: \(entry.input.debugDescription)"

--- a/Tests/NIOIMAPTests/FramingIntegrationTests.swift
+++ b/Tests/NIOIMAPTests/FramingIntegrationTests.swift
@@ -41,6 +41,164 @@ import Testing
         helper.writeInbound("{3}\r\n456\r\n")
         helper.assertInbound(.tagged(.init(tag: "A1", command: .login(username: "123", password: "456"))))
     }
+
+    // Regression test: a bare CR ending one inbound segment, followed by a segment terminated by a
+    // bare LF, used to abort the whole process via a `precondition` in `FramingParser`. Because
+    // `FrameDecoder` can be installed ahead of any authentication handler, this was reachable by
+    // any connecting client, so we drive raw `FramingResult`s rather than parsed commands.
+    @Test("split bare CR does not crash the frame decoder")
+    func splitBareCRDoesNotCrashFrameDecoder() {
+        let channel = EmbeddedChannel(handler: ByteToMessageHandler(FrameDecoder()))
+
+        #expect(throws: Never.self) { try channel.writeInbound(ByteBuffer(string: "A1 NOOP\r")) }
+        #expect(throws: Never.self) { try channel.writeInbound(ByteBuffer(string: "A2 NOOP\n")) }
+
+        var first: FramingResult?
+        var second: FramingResult?
+        #expect(throws: Never.self) { first = try channel.readInbound(as: FramingResult.self) }
+        #expect(throws: Never.self) { second = try channel.readInbound(as: FramingResult.self) }
+        #expect(first == .complete("A1 NOOP\r"))
+        #expect(second == .complete("A2 NOOP\n"))
+
+        #expect(throws: Never.self) { _ = try channel.finish() }
+    }
+
+    // MARK: - Well-formed input parses identically regardless of how it is split
+
+    // The core robustness property: a well-formed IMAP byte stream must parse into the *same*
+    // sequence of `CommandStreamPart`s — and never crash — no matter where the network happens to
+    // split it. We assert this exhaustively at every byte boundary (and, separately, at every pair
+    // of boundaries), which automatically exercises every CR/LF split position including the
+    // bare-CR-at-a-segment-boundary case.
+    //
+    // We compare at the *parsed* layer rather than the raw framing layer on purpose: a `CR | LF`
+    // split legitimately drops the skipped LF and a split literal body is chunked differently, so
+    // the raw frames differ — but the parsed commands must not.
+    @Test("well-formed input parses identically at every single split")
+    func wellFormedInputParsesIdenticallyAtEverySingleSplit() {
+        for entry in Self.wellFormedCorpus {
+            let bytes = Array(entry.input.utf8)
+
+            // Sanity: the un-split stream parses to the expected commands.
+            #expect(self.parsedParts(of: bytes, splittingAt: []) == entry.expected, "unsplit: \(entry.input.debugDescription)")
+
+            // Every two-way split (both segments non-empty) must agree.
+            for splitIndex in 1..<bytes.count {
+                let parts = self.parsedParts(of: bytes, splittingAt: [splitIndex])
+                #expect(parts == entry.expected, "split \(entry.input.debugDescription) at byte \(splitIndex)")
+            }
+        }
+    }
+
+    @Test("well-formed input parses identically at every pair of splits")
+    func wellFormedInputParsesIdenticallyAtEveryPairOfSplits() {
+        // Three-way splits catch desyncs that only appear when a boundary lands inside a frame that
+        // is itself already straddling a boundary. Restricted to a couple of representative streams
+        // (a CRLF command and a literal) to keep the O(n²) sweep cheap.
+        for entry in Self.wellFormedCorpus where entry.exhaustivePairs {
+            let bytes = Array(entry.input.utf8)
+            for first in 1..<bytes.count {
+                for second in (first + 1)..<bytes.count {
+                    let parts = self.parsedParts(of: bytes, splittingAt: [first, second])
+                    #expect(parts == entry.expected, "split \(entry.input.debugDescription) at bytes \(first), \(second)")
+                }
+            }
+        }
+    }
+}
+
+extension FramingIntegrationTests {
+    /// A well-formed IMAP stream, the commands it must parse into, and whether it should also be
+    /// swept with the (more expensive) every-pair-of-splits test.
+    struct CorpusEntry {
+        var input: String
+        var expected: [CommandStreamPart]
+        var exhaustivePairs: Bool = false
+    }
+
+    static let wellFormedCorpus: [CorpusEntry] = [
+        // A single command with a conforming CRLF terminator.
+        CorpusEntry(
+            input: "A1 NOOP\r\n",
+            expected: [.tagged(.init(tag: "A1", command: .noop))],
+            exhaustivePairs: true
+        ),
+        // The same command with a non-conforming bare LF (Unix) terminator.
+        CorpusEntry(
+            input: "A1 NOOP\n",
+            expected: [.tagged(.init(tag: "A1", command: .noop))]
+        ),
+        // Two commands back to back, CRLF-terminated.
+        CorpusEntry(
+            input: "a1 NOOP\r\nb2 NOOP\r\n",
+            expected: [
+                .tagged(.init(tag: "a1", command: .noop)),
+                .tagged(.init(tag: "b2", command: .noop)),
+            ]
+        ),
+        // Two commands back to back, bare-LF terminated.
+        CorpusEntry(
+            input: "a1 NOOP\nb2 NOOP\n",
+            expected: [
+                .tagged(.init(tag: "a1", command: .noop)),
+                .tagged(.init(tag: "b2", command: .noop)),
+            ]
+        ),
+        // Two commands where the first is terminated by a bare CR and the second by a bare LF.
+        // Splitting immediately after that bare CR is the exact bare-CR-desync repro, so this
+        // entry also regression-guards the fix at one of its split points.
+        CorpusEntry(
+            input: "A1 NOOP\rA2 NOOP\n",
+            expected: [
+                .tagged(.init(tag: "A1", command: .noop)),
+                .tagged(.init(tag: "A2", command: .noop)),
+            ],
+            exhaustivePairs: true
+        ),
+        // A command carrying literals — the literal body must reassemble across any boundary.
+        CorpusEntry(
+            input: "A1 LOGIN {3}\r\n123 {3}\r\n456\r\n",
+            expected: [.tagged(.init(tag: "A1", command: .login(username: "123", password: "456")))],
+            exhaustivePairs: true
+        ),
+        // A command carrying quoted strings.
+        CorpusEntry(
+            input: #"A1 LOGIN "user" "pass"\#r\#n"#,
+            expected: [.tagged(.init(tag: "A1", command: .login(username: "user", password: "pass")))]
+        ),
+    ]
+
+    /// Feeds `bytes` to a fresh `FrameDecoder` + `IMAPServerHandler` pipeline, broken into segments
+    /// at the given (sorted, strictly increasing) byte boundaries, and returns every parsed
+    /// `CommandStreamPart`. Any throw — including a process-aborting crash — fails the test.
+    func parsedParts(
+        of bytes: [UInt8],
+        splittingAt boundaries: [Int],
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) -> [CommandStreamPart] {
+        let channel = EmbeddedChannel(handlers: [ByteToMessageHandler(FrameDecoder()), IMAPServerHandler()])
+        var parts: [CommandStreamPart] = []
+
+        var start = 0
+        for end in boundaries + [bytes.count] {
+            let segment = Array(bytes[start..<end])
+            start = end
+            #expect(throws: Never.self, sourceLocation: sourceLocation) {
+                try channel.writeInbound(ByteBuffer(bytes: segment))
+            }
+            while true {
+                var part: CommandStreamPart?
+                #expect(throws: Never.self, sourceLocation: sourceLocation) {
+                    part = try channel.readInbound(as: CommandStreamPart.self)
+                }
+                guard let part else { break }
+                parts.append(part)
+            }
+        }
+
+        _ = try? channel.finish()
+        return parts
+    }
 }
 
 extension FramingIntegrationTests {

--- a/Tests/NIOIMAPTests/FramingIntegrationTests.swift
+++ b/Tests/NIOIMAPTests/FramingIntegrationTests.swift
@@ -80,7 +80,10 @@ import Testing
             let bytes = Array(entry.input.utf8)
 
             // Sanity: the un-split stream parses to the expected commands.
-            #expect(self.parsedParts(of: bytes, splittingAt: []) == entry.expected, "unsplit: \(entry.input.debugDescription)")
+            #expect(
+                self.parsedParts(of: bytes, splittingAt: []) == entry.expected,
+                "unsplit: \(entry.input.debugDescription)"
+            )
 
             // Every two-way split (both segments non-empty) must agree.
             for splitIndex in 1..<bytes.count {
@@ -100,7 +103,10 @@ import Testing
             for first in 1..<bytes.count {
                 for second in (first + 1)..<bytes.count {
                     let parts = self.parsedParts(of: bytes, splittingAt: [first, second])
-                    #expect(parts == entry.expected, "split \(entry.input.debugDescription) at bytes \(first), \(second)")
+                    #expect(
+                        parts == entry.expected,
+                        "split \(entry.input.debugDescription) at bytes \(first), \(second)"
+                    )
                 }
             }
         }

--- a/Tests/NIOIMAPTests/FramingParserTests.swift
+++ b/Tests/NIOIMAPTests/FramingParserTests.swift
@@ -201,6 +201,236 @@ import Testing
         #expect(result == [.complete("A2 NOOP\r")])
     }
 
+    // MARK: - Bare CR at a segment boundary
+
+    // When a bare CR is the *last* byte of a segment, the parser completes the frame but can't yet
+    // tell whether the matching LF will follow in the next segment. It therefore enters the
+    // `.ignoreFirst` line-feed strategy: skip a *leading* LF next, but otherwise treat the byte
+    // stream normally.
+    //
+    // The bug these tests guard against: if the next segment contained a non-LF byte followed by a
+    // *bare* LF (no preceding CR — e.g. a Unix-style terminator), the `.ignoreFirst` strategy was
+    // not reset, so that LF reached `processLineBreakByte_state` with `frameLength > 1` and tripped
+    // a `precondition`, aborting the whole process. The tests below pin down every continuation of
+    // a bare CR.
+    //
+    // (Note: a continuation ending in CRLF does *not* trigger the bug — the CR completes the frame
+    // and `readByte_state_foundCR` consumes the trailing LF — so the crash repros below all use a
+    // bare LF terminator.)
+
+    // The original crash: `CR` (end of segment), then a command terminated by a bare LF. Pre-fix
+    // this aborted the process; it must now frame cleanly.
+    @Test("bare CR then a command terminated by a bare LF")
+    func bareCRThenCommandTerminatedByBareLF() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "A1 NOOP\r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A1 NOOP\r")])
+
+        // The next segment is a fresh command with a Unix-style bare LF terminator. It must frame
+        // normally rather than trip the precondition.
+        buffer = "A2 NOOP\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A2 NOOP\n")])
+    }
+
+    // The minimal repro, drip-fed one byte per segment: `\r`, then `X`, then `\n`.
+    @Test("bare CR then byte then LF drip-fed")
+    func bareCRThenByteThenLFDripFed() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "\r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("\r")])
+
+        // A non-LF byte after the bare CR begins a new frame, so `.ignoreFirst` must be dropped.
+        buffer = "X"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.incomplete(2)])
+
+        // The LF now terminates the "X" frame instead of being mistaken for the CR's partner.
+        buffer = "\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("X\n")])
+    }
+
+    // The legitimate `.ignoreFirst` case: when the LF *is* the first byte of the next segment, it
+    // is the CR's partner and must be silently consumed (not emitted as an empty frame).
+    @Test("bare CR then leading LF is ignored")
+    func bareCRThenLeadingLFIsIgnored() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "A1 NOOP\r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A1 NOOP\r")])
+
+        // Leading LF (the CR's partner) is swallowed, and the following command frames normally.
+        buffer = "\nA2 NOOP\r\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A2 NOOP\r\n")])
+    }
+
+    // A bare CR followed by a non-LF byte and *another* bare CR: the second frame is itself
+    // CR-terminated and the parser must re-enter `.ignoreFirst` for the next segment.
+    @Test("bare CR then a frame also ending in a bare CR")
+    func bareCRThenFrameAlsoEndingInBareCR() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "A1\r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A1\r")])
+
+        buffer = "B2\r"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("B2\r")])
+
+        // Still in `.ignoreFirst`; a lone trailing LF is the second CR's partner and is ignored.
+        buffer = "\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.incomplete(2)])
+    }
+
+    // A bare CR immediately followed by `CR LF` in the next segment: the leading CR opens an empty
+    // line, and because its LF *is* present it is folded into a single empty `\r\n` frame.
+    @Test("bare CR then CRLF empty line")
+    func bareCRThenCRLFEmptyLine() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "A1\r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A1\r")])
+
+        buffer = "\r\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("\r\n")])
+    }
+
+    // After a bare CR, a `{` must still open a literal header (the `.ignoreFirst` strategy applies
+    // only to a leading LF, never to other bytes).
+    @Test("bare CR then literal header")
+    func bareCRThenLiteralHeader() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "A1 LOGIN \r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A1 LOGIN \r")])
+
+        buffer = "{3}\r\nhey\r\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("{3}\r\n"), .insideLiteral("hey", remainingBytes: 0), .complete("\r\n")])
+    }
+
+    // After a bare CR, a `"` must still open a quoted string.
+    @Test("bare CR then quoted string")
+    func bareCRThenQuotedString() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "A1 LOGIN \r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A1 LOGIN \r")])
+
+        buffer = "\"foo\"\r\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("\"foo\"\r\n")])
+    }
+
+    // Several bare CRs each ending their own segment must not desync the state machine: each one
+    // simply completes a frame and re-arms `.ignoreFirst`.
+    @Test("repeated bare CRs across segments")
+    func repeatedBareCRsAcrossSegments() {
+        var parser = self.parser
+        for _ in 0..<3 {
+            var buffer: ByteBuffer = "\r"
+            var result: [FramingResult]?
+            #expect(throws: Never.self) {
+                result = try parser.appendAndFrameBuffer(&buffer)
+            }
+            #expect(result == [.complete("\r")])
+        }
+    }
+
+    // MARK: - Literal-header CRLF split across a segment boundary
+
+    // The literal-body path uses the *same* `.ignoreFirst` strategy when a literal header's CRLF
+    // is split (`…{3}\r` ends a segment). A following non-LF byte must begin the literal body
+    // directly...
+    @Test("literal header CR split then body without LF")
+    func literalHeaderCRSplitThenBodyWithoutLF() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "A1 LOGIN {3}\r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A1 LOGIN {3}\r")])
+
+        buffer = "hey\r\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.insideLiteral("hey", remainingBytes: 0), .complete("\r\n")])
+    }
+
+    // ...while a following LF (the CR's partner) is skipped before the literal body begins.
+    @Test("literal header CR split then leading LF before body")
+    func literalHeaderCRSplitThenLeadingLFBeforeBody() {
+        var parser = self.parser
+
+        var buffer: ByteBuffer = "A1 LOGIN {3}\r"
+        var result: [FramingResult]?
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.complete("A1 LOGIN {3}\r")])
+
+        buffer = "\nhey\r\n"
+        #expect(throws: Never.self) {
+            result = try parser.appendAndFrameBuffer(&buffer)
+        }
+        #expect(result == [.insideLiteral("hey", remainingBytes: 0), .complete("\r\n")])
+    }
+
     @Test("two commands across multiple buffers")
     func twoCommandsAcrossMultipleBuffers() {
         var parser = self.parser


### PR DESCRIPTION
Fix a remotely-triggerable crash in `FramingParser` when a bare `CR` ends one inbound buffer and a bare `LF` terminates the next.

### Motivation:

`FramingParser` frames client commands server-side (`FrameDecoder` → `IMAPServerHandler`). When a buffer ends on a bare `CR`, it completes that frame but enters the `.ignoreFirst` strategy, since the partner `LF` may arrive in the next read.

That strategy was only cleared if the next byte was actually a leading `LF`. If the next buffer instead began with content terminated by a bare `LF` (e.g. `A1 NOOP\r` then `A2 NOOP\n`), the stale strategy meant the trailing `LF` reached `processLineBreakByte_state` with `frameLength > 1` and tripped `precondition(self.frameLength == 1)`, aborting the whole process. As `FrameDecoder` sits ahead of any auth handler, any connecting client could trigger this.

This is the command-side counterpart to the response-side split-CRLF fix in #812: `FramingParser` already handled split CRLF via `.ignoreFirst`; this repairs a latent bug in that machinery.

### Modifications:

In `readByte_state_normalTraversal`, reset `.ignoreFirst` to `.includeInFrame` when a non-`LF` byte is consumed — a fresh frame has begun, so a later `LF` is a genuine terminator. This is the fix.

As defense-in-depth, replace the `precondition` with `throw InvalidFrame()`; the `.normalTraversal`/`.insideQuoted` call sites catch it, reset state, and emit a recoverable `.invalid` frame. With the fix above this path is unreachable in practice. Add tests: targeted `FramingParser` cases for every bare-`CR` continuation, plus integration tests asserting a well-formed stream parses to the same `CommandStreamPart`s — and never crashes — at every single- and pair-of-byte split.

### Result:

A bare `CR` at a buffer boundary followed by bare-`LF`-terminated content now frames cleanly instead of crashing. Well-formed input parses identically regardless of how it's split, and non-conforming bare-`CR` / bare-`LF` terminators are tolerated. No previously-successful parse changes, and there's no API/ABI change — the throwing additions are confined to `private` methods.
