### PR TITLE
Add CI for building with Android SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,3 +23,7 @@ jobs:
   cxx-interop:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+
+  android-sdk:
+    name: Android Swift SDK
+    uses: apple/swift-nio/.github/workflows/android_swift_sdk.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,3 +27,7 @@ jobs:
   cxx-interop:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+
+  android-sdk:
+    name: Android Swift SDK
+    uses: apple/swift-nio/.github/workflows/android_swift_sdk.yml@main


### PR DESCRIPTION
### Motivation:

There's an open PR to add support for Android, but we don't currently have any CI for building with the Android SDK.

### Modifications:

Add CI pipelines for building with the Android SDK, using the workflows from the NIO repo.

### Result:

New CI pipelines should be run on PRs and main.

These are expected to be failing and will be non-required, but will unblock the development work.
