### PR TITLE
Replace C ctype calls with pure-Swift ASCII checks to fix the Windows build

### DIFF
--- a/Sources/NIOIMAPCore/Parser/UInt8+ParseTypeMembership.swift
+++ b/Sources/NIOIMAPCore/Parser/UInt8+ParseTypeMembership.swift
@@ -14,23 +14,6 @@
 
 import struct NIO.ByteBuffer
 
-// TODO: Remove these
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-import func Darwin.isalnum
-import func Darwin.isalpha
-#elseif canImport(Glibc)
-import func Glibc.isalnum
-import func Glibc.isalpha
-#elseif canImport(Musl)
-import func Musl.isalnum
-import func Musl.isalpha
-#elseif canImport(Android)
-import func Android.isalnum
-import func Android.isalpha
-#else
-let badOS = { fatalError("unsupported OS") }()
-#endif
-
 extension UInt8 {
     var isCR: Bool {
         self == UInt8(ascii: "\r")
@@ -118,7 +101,7 @@ extension UInt8 {
         case UInt8(ascii: "+"), UInt8(ascii: "/"):
             return true
         default:
-            return isalnum(Int32(self)) != 0
+            return self.isAlphaNum
         }
     }
 
@@ -127,7 +110,7 @@ extension UInt8 {
     }
 
     var isAlphaNum: Bool {
-        isalnum(Int32(self)) != 0
+        self.isAlpha || self.isNum
     }
 
     var isNum: Bool {


### PR DESCRIPTION
### Motivation

`UInt8+ParseTypeMembership.swift` is the last file in NIOIMAPCore whose platform import ladder has no Windows branch, so the module does not compile on Windows (`cannot find 'isalnum' in scope`; the ladder's `#else` also declares a `badOS` global). The ladder exists only to import `isalnum`/`isalpha` and already carries a `// TODO: Remove these`.

With this fixed, NIOIMAPCore builds cleanly on Windows — which, together with the in-flight Windows support for swift-nio-ssl (apple/swift-nio-ssl#567), unblocks downstream packages such as SwiftMail there.

### Modifications

Implement `isAlphaNum` in terms of the file's existing pure-Swift `isAlpha` and `isNum`, use it from `isBase64Char`, and drop the import ladder — fulfilling the TODO.

Besides fixing Windows, this removes a locale dependency from the parser: C's `isalnum` answers per the process locale, while the IMAP grammar is defined over ASCII. In the default C locale the behavior is identical.

(Two analogous call sites remain in `GrammarParser.swift` / `GrammarParser+Date.swift`; those files already import `ucrt` on Windows so they compile, but converting them the same way would make the parser fully locale-independent — happy to do that here or as a follow-up if wanted.)

### Result

NIOIMAPCore compiles on Windows (verified on windows-latest, Swift 6.3.1, as part of an end-to-end SwiftMail build: https://github.com/Cocoanetics/SwiftMail/actions/runs/29660684476 — its test suite also runs green on Windows with this branch). No behavior change on other platforms; the base64/status-attribute/date parser tests pass on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
