### PR TITLE
Make tests compile for iOS/tvOS/watchOS/visionOS

### DIFF
--- a/Tests/NIOIMAPCoreTests/Grammar/Append/AppendData+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Append/AppendData+Tests.swift
@@ -44,7 +44,7 @@ struct AppendDataTests {
         fixture.checkEncoding()
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("encode in server mode calls preconditionFailure")
     func encodeInServerModeCallsPreconditionFailure() async {
         await #expect(

--- a/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
@@ -2052,7 +2052,7 @@ private struct BodyStructureTests {
         fixture.checkEncoding()
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("subscript fatal error for invalid part") func subscriptFatalErrorForInvalidPart() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/Flag/Flag+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Flag/Flag+Tests.swift
@@ -61,7 +61,7 @@ struct FlagTests {
         #expect(String(fixture.0) == fixture.1)
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("extension(_:) precondition failure without backslash") func extensionPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/FullDateTime+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/FullDateTime+Tests.swift
@@ -127,7 +127,7 @@ struct FullDateTimeTests {
         fixture.checkParsing()
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("invalid month triggers precondition failure") func invalidMonthPrecondition() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/IUserInfo+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/IUserInfo+Tests.swift
@@ -62,7 +62,7 @@ struct UserAuthenticationMechanismTests {
         fixture.checkParsing()
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("both nil arguments triggers precondition failure") func bothNilPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/Modifier/ModifierSequenceValue+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Modifier/ModifierSequenceValue+Tests.swift
@@ -68,7 +68,7 @@ struct ModificationSequenceValueTests {
         #expect(advanced == end)
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("overflow triggers precondition failure") func overflowPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/Section/SectionSpecTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Section/SectionSpecTests.swift
@@ -306,7 +306,7 @@ private struct SectionSpecifierTests {
         #expect(fixture.0 == fixture.1)
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("MIME header with empty part triggers precondition failure") func mimeHeaderWithEmptyPartPreconditionFailure()
         async
     {

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDSetNonEmptyTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDSetNonEmptyTests.swift
@@ -40,7 +40,7 @@ extension UIDSetNonEmptyTests {
         #expect(uids.set == MessageIdentifierSet<UID>([1...5]))
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("empty array literal triggers precondition failure") func emptyArrayLiteralPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDTests.swift
@@ -88,7 +88,7 @@ struct UIDTests {
         #expect(unknown.rawValue == 99)
     }
 
-    #if swift(>=6.2)
+    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("advanced(by:) overflow triggers precondition failure") func advancedByOverflowPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
+++ b/Tests/NIOIMAPTests/Coders/IMAPClientHandlerTests.swift
@@ -630,7 +630,7 @@ struct IMAPClientHandlerTests {
         }
     }
 
-    @available(macOS 15.0, *)
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
     @Test("protect against reentrancy")
     func protectAgainstReentrancy() {
         var helper = Helper()
@@ -701,7 +701,7 @@ struct IMAPClientHandlerTests {
         )
     }
 
-    @available(macOS 15.0, *)
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
     @Test("write cascades promise failure")
     func writeCascadesPromiseFailure() {
         var helper = Helper()
@@ -733,7 +733,7 @@ struct IMAPClientHandlerTests {
         #expect(a)
     }
 
-    @available(macOS 15.0, *)
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)
     @Test("write cascades continuation promise failure")
     func writeCascadesContinuationPromiseFailure() {
         var helper = Helper()


### PR DESCRIPTION
Some of the APIs needed to be guarded on those platforms.
