### PR TITLE
Drop pre-Swift 6.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,8 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   cxx-interop:
@@ -42,7 +40,7 @@ jobs:
       matrix:
         example: [CLI, Proxy, Fuzzer, PerformanceTester]
     container:
-      image: swift:6.0
+      image: swift:6.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,8 +18,8 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   cxx-interop:
@@ -42,7 +42,6 @@ jobs:
     with:
       runner_pool: general
       build_scheme: swift-nio-imap
-      swift_6_1_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
       swift_6_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
       swift_6_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
 
@@ -54,7 +53,7 @@ jobs:
       matrix:
         example: [CLI, Proxy, Fuzzer, PerformanceTester]
     container:
-      image: swift:6.0
+      image: swift:6.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Examples/CLI/Package.swift
+++ b/Examples/CLI/Package.swift
@@ -1,5 +1,6 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// 6.2 to match the root package, which this example depends on by path.
 
 import PackageDescription
 

--- a/Examples/Fuzzer/Package.swift
+++ b/Examples/Fuzzer/Package.swift
@@ -1,5 +1,6 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// 6.2 to match the root package, which this example depends on by path.
 
 import PackageDescription
 

--- a/Examples/PerformanceTester/Package.swift
+++ b/Examples/PerformanceTester/Package.swift
@@ -1,5 +1,6 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// 6.2 to match the root package, which this example depends on by path.
 
 import PackageDescription
 

--- a/Examples/Proxy/Package.swift
+++ b/Examples/Proxy/Package.swift
@@ -1,5 +1,6 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// 6.2 to match the root package, which this example depends on by path.
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,16 +1,23 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// 6.2 is the floor so that the package always builds with `nonisolated(nonsending)` available.
 
 import PackageDescription
 
 let package = Package(
     name: "swift-nio-imap",
+    platforms: [
+        .macOS(.v15),
+        .iOS(.v18),
+        .watchOS(.v11),
+        .tvOS(.v18),
+        .visionOS(.v2),
+    ],
     products: [
         .library(name: "NIOIMAP", targets: ["NIOIMAP"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.64.0"),
-        .package(url: "https://github.com/apple/swift-se0270-range-set.git", from: "1.0.1"),
         .package(url: "https://github.com/apple/swift-collections.git", "1.1.0"..<"2.0.0"),
     ],
     targets: [
@@ -40,9 +47,11 @@ let package = Package(
             name: "NIOIMAPCore",
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
-                .product(name: "SE0270_RangeSet", package: "swift-se0270-range-set"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
             ],
+            // The documentation is built out-of-band, not by SwiftPM: excluding the catalog
+            // keeps it out of the build product instead of being copied in as a resource.
+            exclude: ["NIOIMAPCore.docc"],
             swiftSettings: [
                 .enableUpcomingFeature("MemberImportVisibility")
             ]

--- a/Sources/NIOIMAPCore/Base64/Chromium.swift
+++ b/Sources/NIOIMAPCore/Base64/Chromium.swift
@@ -334,12 +334,7 @@ extension Base64 {
     )
         -> String where Buffer.Element == UInt8
     {
-        #if swift(>=5.3)
         let newCapacity = ((bytes.count + 2) / 3) * 4
-        guard #available(OSX 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-            let bytes: [UInt8] = self.encodeBytes(bytes: bytes, options: options)
-            return String(decoding: bytes, as: Unicode.UTF8.self)
-        }
         if let result = bytes.withContiguousStorageIfAvailable({ (input) -> String in
             String(unsafeUninitializedCapacity: newCapacity) { (buffer) -> Int in
                 var length = newCapacity
@@ -351,10 +346,6 @@ extension Base64 {
         }
 
         return self.encodeString(bytes: Array(bytes), options: options)
-        #else
-        let bytes: [UInt8] = self.encodeBytes(bytes: bytes, options: options)
-        return String(decoding: bytes, as: Unicode.UTF8.self)
-        #endif
     }
 
     @inlinable

--- a/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
+++ b/Sources/NIOIMAPCore/Grammar/UID/MessageIdentifierSet.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import struct NIO.ByteBuffer
-@preconcurrency import SE0270_RangeSet
 
 /// A set of message identifiers represented as an array of ranges.
 ///

--- a/Tests/NIOIMAPCoreTests/Grammar/Append/AppendData+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Append/AppendData+Tests.swift
@@ -44,7 +44,7 @@ struct AppendDataTests {
         fixture.checkEncoding()
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("encode in server mode calls preconditionFailure")
     func encodeInServerModeCallsPreconditionFailure() async {
         await #expect(

--- a/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Body/BodyStructure+Tests.swift
@@ -2053,7 +2053,7 @@ private struct BodyStructureTests {
         fixture.checkEncoding()
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("subscript fatal error for invalid part") func subscriptFatalErrorForInvalidPart() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/Flag/Flag+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Flag/Flag+Tests.swift
@@ -61,7 +61,7 @@ struct FlagTests {
         #expect(String(fixture.0) == fixture.1)
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("extension(_:) precondition failure without backslash") func extensionPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/FullDateTime+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/FullDateTime+Tests.swift
@@ -127,7 +127,7 @@ struct FullDateTimeTests {
         fixture.checkParsing()
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("invalid month triggers precondition failure") func invalidMonthPrecondition() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/IUserInfo+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/IUserInfo+Tests.swift
@@ -62,7 +62,7 @@ struct UserAuthenticationMechanismTests {
         fixture.checkParsing()
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("both nil arguments triggers precondition failure") func bothNilPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/Modifier/ModifierSequenceValue+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Modifier/ModifierSequenceValue+Tests.swift
@@ -68,7 +68,7 @@ struct ModificationSequenceValueTests {
         #expect(advanced == end)
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("overflow triggers precondition failure") func overflowPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/Section/SectionSpecTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Section/SectionSpecTests.swift
@@ -306,7 +306,7 @@ private struct SectionSpecifierTests {
         #expect(fixture.0 == fixture.1)
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("MIME header with empty part triggers precondition failure") func mimeHeaderWithEmptyPartPreconditionFailure()
         async
     {

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDSetNonEmptyTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDSetNonEmptyTests.swift
@@ -40,7 +40,7 @@ extension UIDSetNonEmptyTests {
         #expect(uids.set == MessageIdentifierSet<UID>([1...5]))
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("empty array literal triggers precondition failure") func emptyArrayLiteralPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,

--- a/Tests/NIOIMAPCoreTests/Grammar/UID/UIDTests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/UID/UIDTests.swift
@@ -88,7 +88,7 @@ struct UIDTests {
         #expect(unknown.rawValue == 99)
     }
 
-    #if swift(>=6.2) && !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
+    #if !os(iOS) && !os(watchOS) && !os(tvOS) && !os(visionOS)
     @Test("advanced(by:) overflow triggers precondition failure") func advancedByOverflowPreconditionFailure() async {
         await #expect(
             processExitsWith: ExitTest.Condition.failure,


### PR DESCRIPTION
Require Swift 6.2

### Motivation:

We need Swift 6.2 for #841 and other upcoming work.

### Modifications:

- Drop pre-6.2 versions.
- Drop `SE0270_RangeSet` dependency.
- Require minimum version on Apple platforms.
