### PR TITLE
Reject invalid AuthenticationMechanism

### DIFF
--- a/Examples/PerformanceTester/Sources/NIOIMAPPerformanceTester/main.swift
+++ b/Examples/PerformanceTester/Sources/NIOIMAPPerformanceTester/main.swift
@@ -66,12 +66,12 @@ let commands: [(String, Command)] = [
             []
         )
     ),
-    ("parse_auth_plain_nil", .authenticate(mechanism: .init("PLAIN"), initialResponse: nil)),
-    ("parse_auth_plain_empty", .authenticate(mechanism: .init("PLAIN"), initialResponse: .empty)),
+    ("parse_auth_plain_nil", .authenticate(mechanism: .plain, initialResponse: nil)),
+    ("parse_auth_plain_empty", .authenticate(mechanism: .plain, initialResponse: .empty)),
     (
         "parse_auth_plain_initial data",
         .authenticate(
-            mechanism: .init("PLAIN"),
+            mechanism: .plain,
             initialResponse: .init(ByteBuffer(string: "dGhpcyBpcyB0ZXN0IGJhc2U2NA=="))
         )
     ),

--- a/Sources/NIOIMAPCore/Grammar/AuthenticationMechanism.swift
+++ b/Sources/NIOIMAPCore/Grammar/AuthenticationMechanism.swift
@@ -31,10 +31,44 @@
 /// The server advertises `AUTH=PLAIN` and `AUTH=GSSAPI` capabilities. The client chooses `PLAIN` mechanism,
 /// and sends base64-encoded credentials in response to the server challenge.
 ///
+/// ## Names
+///
+/// A mechanism name is 1 to 20 characters long, and contains only ASCII letters, digits, `-` and
+/// `_`, as required by
+/// [RFC 4422 section 3.1](https://datatracker.ietf.org/doc/html/rfc4422#section-3.1). ``init(_:)``
+/// rejects anything else, which guarantees that a mechanism can always be encoded as a single
+/// IMAP atom.
+///
 /// - SeeAlso: [RFC 3501 Section 6.2.2](https://datatracker.ietf.org/doc/html/rfc3501#section-6.2.2)
+/// - SeeAlso: [RFC 4422 Section 3.1](https://datatracker.ietf.org/doc/html/rfc4422#section-3.1)
 /// - SeeAlso: [RFC 4616 PLAIN Authentication](https://datatracker.ietf.org/doc/html/rfc4616)
 /// - SeeAlso: [RFC 4752 GSSAPI Authentication](https://datatracker.ietf.org/doc/html/rfc4752)
 public struct AuthenticationMechanism: Hashable, Sendable {
+    fileprivate let rawValue: String
+
+    /// Creates a new authentication mechanism from a string, if the string is a valid mechanism name.
+    ///
+    /// The provided value is uppercased for consistency with IMAP protocol conventions, and is then
+    /// checked against the rules that
+    /// [RFC 4422 section 3.1](https://datatracker.ietf.org/doc/html/rfc4422#section-3.1) sets for
+    /// mechanism names: 1 to 20 characters of ASCII letter, digit, `-` or `_`. Lowercase input is
+    /// accepted, because it is uppercased before being checked.
+    ///
+    /// - parameter value: The mechanism name (for example, PLAIN or GSSAPI).
+    /// - returns: A new mechanism, or `nil` if `value` is not a valid mechanism name.
+    public init?(_ value: String) {
+        let name = value.uppercased()
+        guard Self.isValidName(name) else { return nil }
+        self.rawValue = name
+    }
+
+    fileprivate init(unchecked: String) {
+        assert(Self.isValidName(unchecked))
+        self.rawValue = unchecked
+    }
+}
+
+extension AuthenticationMechanism {
     /// `TOKEN` mechanism - generates authentication tokens via algorithm.
     public static let token = Self(unchecked: "TOKEN")
 
@@ -52,21 +86,30 @@ public struct AuthenticationMechanism: Hashable, Sendable {
 
     /// `GSSAPI` mechanism - uses Generic Security Service API (RFC 4752).
     public static let gssAPI = Self(unchecked: "GSSAPI")
+}
 
-    /// The mechanism name.
-    public let rawValue: String
+extension AuthenticationMechanism {
+    /// The greatest number of characters a mechanism name may contain.
+    private static let maximumNameLength = 20
 
-    /// Creates a new authentication mechanism from a string.
+    /// Whether the given name satisfies
+    /// [RFC 4422 section 3.1](https://datatracker.ietf.org/doc/html/rfc4422#section-3.1).
     ///
-    /// The provided value is uppercased for consistency with IMAP protocol conventions.
-    ///
-    /// - parameter value: The mechanism name (for example, PLAIN or GSSAPI).
-    public init(_ value: String) {
-        self.rawValue = value.uppercased()
+    /// The name is expected to be uppercased already.
+    private static func isValidName(_ name: String) -> Bool {
+        (1...maximumNameLength).contains(name.utf8.count)
+            && name.utf8.allSatisfy {
+                $0.isAlphaNum || ($0 == UInt8(ascii: "-")) || ($0 == UInt8(ascii: "_"))
+            }
     }
+}
 
-    fileprivate init(unchecked: String) {
-        self.rawValue = unchecked
+extension String {
+    /// Creates a `String` from an ``AuthenticationMechanism``.
+    ///
+    /// - parameter other: The authentication mechanism to convert.
+    public init(_ other: AuthenticationMechanism) {
+        self = other.rawValue
     }
 }
 

--- a/Sources/NIOIMAPCore/Grammar/Capability.swift
+++ b/Sources/NIOIMAPCore/Grammar/Capability.swift
@@ -551,7 +551,7 @@ extension Capability {
     ///
     /// - SeeAlso: [RFC 4959](https://datatracker.ietf.org/doc/html/rfc4959)
     public static func authenticate(_ type: AuthenticationMechanism) -> Self {
-        Self("AUTH=\(type.rawValue)")
+        Self("AUTH=\(String(type))")
     }
 
     /// Creates a `CONTEXT=<kind>` capability for the specified search or sort context.

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser+Commands.swift
@@ -151,7 +151,7 @@ extension GrammarParser {
     func parseCommandSuffix_authenticate(buffer: inout ParseBuffer, tracker: StackTracker) throws -> Command {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> Command in
             try PL.parseSpaces(buffer: &buffer, tracker: tracker)
-            let mechanism = AuthenticationMechanism(try self.parseAtom(buffer: &buffer, tracker: tracker))
+            let mechanism = try self.parseAuthenticationMechanism(buffer: &buffer, tracker: tracker)
             let initialResponse = try PL.parseOptional(
                 buffer: &buffer,
                 tracker: tracker,

--- a/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
+++ b/Sources/NIOIMAPCore/Parser/Grammar/GrammarParser.swift
@@ -180,6 +180,24 @@ extension GrammarParser {
         )
     }
 
+    /// RFC 3501 defines
+    /// ```
+    /// auth-type = atom
+    /// ```
+    /// but [RFC 4422 section 3.1](https://datatracker.ietf.org/doc/html/rfc4422#section-3.1)
+    /// restricts what a mechanism name may contain. ``AuthenticationMechanism/init(_:)`` enforces
+    /// that, and a name it rejects is a parse error.
+    func parseAuthenticationMechanism(
+        buffer: inout ParseBuffer,
+        tracker: StackTracker
+    ) throws -> AuthenticationMechanism {
+        let atom = try self.parseAtom(buffer: &buffer, tracker: tracker)
+        guard let mechanism = AuthenticationMechanism(atom) else {
+            throw ParserError(hint: "Invalid authentication mechanism name: \(atom)")
+        }
+        return mechanism
+    }
+
     func parseAuthenticatedURL(buffer: inout ParseBuffer, tracker: StackTracker) throws -> NetworkMessagePath {
         try PL.composite(buffer: &buffer, tracker: tracker) { buffer, tracker -> NetworkMessagePath in
             try PL.parseFixedString("imap://", buffer: &buffer, tracker: tracker)

--- a/Tests/NIOIMAPCoreTests/Grammar/AuthenticationMechanism+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/AuthenticationMechanism+Tests.swift
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+@_spi(NIOIMAPInternal) @testable import NIOIMAPCore
+import Testing
+
+@Suite("AuthenticationMechanism")
+struct AuthenticationMechanismTests {
+    @Test("uppercased normalization")
+    func uppercasedNormalization() {
+        #expect(AuthenticationMechanism("plain") == .plain)
+        #expect(AuthenticationMechanism("plain").map { String($0) } == "PLAIN")
+        #expect(AuthenticationMechanism("Scram-Sha-256").map { String($0) } == "SCRAM-SHA-256")
+    }
+
+    /// Mechanism names are not restricted to letters: digits, `-` and `_` are allowed, too.
+    @Test(
+        "valid names",
+        arguments: [
+            "PLAIN",
+            "GSSAPI",
+            "EXTERNAL",
+            "XOAUTH2",
+            "SCRAM-SHA-256",
+            "SCRAM-SHA-256-PLUS",
+            "CRAM-MD5",
+            "DIGEST-MD5",
+            "X_SOMETHING",
+            "A",
+            "OAUTH10A-FOR-A-LONG-",  // The maximum of 20 characters.
+        ]
+    )
+    func validNames(_ name: String) {
+        #expect(AuthenticationMechanism(name).map { String($0) } == name)
+    }
+
+    @Test(
+        "invalid names are rejected",
+        arguments: [
+            "",
+            "PL.AIN",
+            "PLAIN:",
+            "PLAIN AND MORE",
+            "SCRAM+SHA+256",
+            "MECHANISM/NAME",
+            "GRÜEZI",
+            "🤦",
+            "PLAIN\u{00}",
+            "OAUTH10A-FOR-A-LONGER",  // 21 characters, one over the maximum.
+        ]
+    )
+    func invalidNames(_ name: String) {
+        #expect(AuthenticationMechanism(name) == nil)
+    }
+
+    @Test(
+        "encode",
+        arguments: [
+            EncodeFixture.authenticationMechanism(.gssAPI, "GSSAPI"),
+            EncodeFixture.authenticationMechanism(.plain, "PLAIN"),
+            EncodeFixture.authenticationMechanism(.init("myAuth")!, "MYAUTH"),
+            EncodeFixture.authenticationMechanism(.init("xoauth2")!, "XOAUTH2"),
+        ]
+    )
+    func encode(_ fixture: EncodeFixture<AuthenticationMechanism>) {
+        fixture.checkEncoding()
+    }
+
+    @Test(
+        "parse",
+        arguments: [
+            ParseFixture.authenticationMechanism("PLAIN", expected: .success(.plain)),
+            ParseFixture.authenticationMechanism("GSSAPI", expected: .success(.gssAPI)),
+            ParseFixture.authenticationMechanism("SCRAM-SHA-256", expected: .success(.init("SCRAM-SHA-256")!)),
+            // A lowercase name is out of spec, but is normalized rather than rejected.
+            ParseFixture.authenticationMechanism("plain", expected: .success(.plain)),
+        ]
+    )
+    func parse(_ fixture: ParseFixture<AuthenticationMechanism>) {
+        fixture.checkParsing()
+    }
+
+    /// A name that the specification doesn’t allow is a parse error, so that a command which
+    /// couldn’t be encoded again can never be created by parsing.
+    @Test(
+        "parsing rejects invalid names",
+        arguments: [
+            "PL.AIN",
+            "OAUTH10A-FOR-A-LONGER",
+        ]
+    )
+    func parseInvalidNames(_ name: String) {
+        ParseFixture.authenticationMechanism(name, expected: .failureIgnoringBufferModifications)
+            .checkParsing()
+    }
+}
+
+// MARK: -
+
+extension EncodeFixture<AuthenticationMechanism> {
+    fileprivate static func authenticationMechanism(
+        _ input: AuthenticationMechanism,
+        _ expectedString: String
+    ) -> Self {
+        EncodeFixture(
+            input: input,
+            bufferKind: .defaultServer,
+            expectedString: expectedString,
+            encoder: { $0.writeAuthenticationMechanism($1) }
+        )
+    }
+}
+
+extension ParseFixture<AuthenticationMechanism> {
+    fileprivate static func authenticationMechanism(
+        _ input: String,
+        _ terminator: String = " ",
+        expected: Expected
+    ) -> Self {
+        ParseFixture(
+            input: input,
+            terminator: terminator,
+            expected: expected,
+            parser: GrammarParser().parseAuthenticationMechanism
+        )
+    }
+}

--- a/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/CommandType/CommandType+Tests.swift
@@ -440,7 +440,7 @@ struct CommandTypeTests {
         ),
         ParseFixture.command(
             "AUTHENTICATE GSSAPI",
-            expected: .success(.authenticate(mechanism: AuthenticationMechanism("GSSAPI"), initialResponse: nil))
+            expected: .success(.authenticate(mechanism: .gssAPI, initialResponse: nil))
         ),
         ParseFixture.command("CREATE test", expected: .success(.create(.init("test"), []))),
         ParseFixture.command("GETQUOTA root", expected: .success(.getQuota(.init("root")))),
@@ -1672,35 +1672,6 @@ extension CommandEncodeFixture<Command> {
             options: options,
             expectedStrings: expectedStrings,
             encoder: { $0.writeCommand($1) }
-        )
-    }
-}
-
-@Suite("AuthenticationMechanism")
-struct AuthenticationMechanismTests {
-    @Test(
-        "encode",
-        arguments: [
-            EncodeFixture.authenticationMechanism(.gssAPI, "GSSAPI"),
-            EncodeFixture.authenticationMechanism(.plain, "PLAIN"),
-            EncodeFixture.authenticationMechanism(.init("myAuth"), "MYAUTH"),
-        ]
-    )
-    func encode(_ fixture: EncodeFixture<AuthenticationMechanism>) {
-        fixture.checkEncoding()
-    }
-}
-
-extension EncodeFixture<AuthenticationMechanism> {
-    fileprivate static func authenticationMechanism(
-        _ input: AuthenticationMechanism,
-        _ expectedString: String
-    ) -> Self {
-        EncodeFixture(
-            input: input,
-            bufferKind: .defaultServer,
-            expectedString: expectedString,
-            encoder: { $0.writeAuthenticationMechanism($1) }
         )
     }
 }

--- a/Tests/NIOIMAPCoreTests/Grammar/Enable/EnableData+Tests.swift
+++ b/Tests/NIOIMAPCoreTests/Grammar/Enable/EnableData+Tests.swift
@@ -32,7 +32,7 @@ struct EnableDataTests {
             "ENABLED ENABLE CONDSTORE"
         ),
         EncodeFixture.enableData(
-            [.enable, .condStore, .authenticate(.init("some"))],
+            [.enable, .condStore, .authenticate(.init("some")!)],
             "ENABLED ENABLE CONDSTORE AUTH=SOME"
         ),
     ])

--- a/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
+++ b/Tests/NIOIMAPCoreTests/Parser/RoundtripTests.swift
@@ -44,7 +44,7 @@ private enum RoundtripTests {
             RoundtripFixture(name: "LOGIN command", command: .login(username: "user", password: "password")),
             RoundtripFixture(
                 name: "AUTHENTICATE command",
-                command: .authenticate(mechanism: .init("some"), initialResponse: nil)
+                command: .authenticate(mechanism: .init("some")!, initialResponse: nil)
             ),
             RoundtripFixture(name: "CREATE command with INBOX", command: .create(.inbox, [])),
             RoundtripFixture(name: "CREATE command with mailbox name", command: .create(MailboxName("mailbox"), [])),


### PR DESCRIPTION
Reject invalid `AuthenticationMechanism`.

### Motivation:

[RFC 4422 section 3.1](https://datatracker.ietf.org/doc/html/rfc4422#section-3.1) restricts what valid SASL authentication names can be, but the `AuthenticationMechanism` never enforced that.

### Modifications:

Change `init` to be optional, rejecting invalid SASL mechanisms.