### PR TITLE
Allow configuring IMAP client line buffer size

### DIFF
--- a/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
+++ b/Sources/NIOIMAP/Coders/IMAPClientHandler.swift
@@ -42,14 +42,15 @@ public final class IMAPClientHandler: ChannelDuplexHandler {
 
     public init(
         encodingOptions: EncodingOptions = .automatic,
-        parserOptions: ResponseParser.Options = ResponseParser.Options()
+        parserOptions: ResponseParser.Options = ResponseParser.Options(),
+        maximumBufferSize: Int = IMAPDefaults.lineLengthLimit
     ) {
         self.state = .init(encodingOptions: encodingOptions)
         self.decoder = NIOSingleStepByteToMessageProcessor(
             ResponseDecoder(
                 options: parserOptions
             ),
-            maximumBufferSize: IMAPDefaults.lineLengthLimit
+            maximumBufferSize: maximumBufferSize
         )
     }
 


### PR DESCRIPTION
Expose IMAPClientHandler's NIOSingleStepByteToMessageProcessor maximumBufferSize as an initializer parameter while preserving the existing 1 MiB default. Consumers handling untrusted IMAP servers can choose a bounded line buffer alongside parser literal limits, without changing existing callers.

This is intended for upstreaming the small API seam used by Mailternal to enforce explicit protocol bounds.